### PR TITLE
feat: batch-probe + batch-extract async pipeline for embedded subtitles

### DIFF
--- a/backend/ass_utils.py
+++ b/backend/ass_utils.py
@@ -509,6 +509,17 @@ def _run_engine(file_path, engine):
     return run_ffprobe(file_path, use_cache=False)
 
 
+def get_subtitle_stream_output_path(media_path: str, stream_info: dict) -> str:
+    """Build sidecar output path: {basename}.{lang}.{format} next to media file.
+
+    Uses 'und' (undetermined) if language tag is missing.
+    """
+    lang = (stream_info.get("language") or "und").lower()
+    fmt = stream_info.get("format", "ass")
+    base = os.path.splitext(media_path)[0]
+    return f"{base}.{lang}.{fmt}"
+
+
 def extract_subtitle_stream(mkv_path, stream_info, output_path):
     """Extract a subtitle stream (ASS or SRT) from an MKV file.
 

--- a/backend/db/repositories/wanted.py
+++ b/backend/db/repositories/wanted.py
@@ -291,6 +291,16 @@ class WantedRepository(BaseRepository):
         self._commit()
         return True
 
+    def update_existing_sub(self, item_id: int, value: str) -> bool:
+        """Update the existing_sub field for a wanted item."""
+        item = self.session.get(WantedItem, item_id)
+        if not item:
+            return False
+        item.existing_sub = value
+        item.updated_at = self._now()
+        self._commit()
+        return True
+
     def get_wanted_summary(self) -> dict:
         """Get aggregated wanted counts by type, status, and existing_sub."""
         total_stmt = select(func.count()).select_from(WantedItem)

--- a/backend/db/wanted.py
+++ b/backend/db/wanted.py
@@ -101,6 +101,11 @@ def set_wanted_retry_after(item_id: int, retry_after: str) -> bool:
     return _get_repo().set_retry_after(item_id, retry_after)
 
 
+def update_existing_sub(item_id: int, value: str) -> bool:
+    """Update the existing_sub field for a wanted item."""
+    return _get_repo().update_existing_sub(item_id, value)
+
+
 def delete_wanted_items(file_paths: list):
     """Delete wanted items by file paths (batch)."""
     for fp in file_paths or []:

--- a/backend/events/catalog.py
+++ b/backend/events/catalog.py
@@ -26,7 +26,7 @@ wanted_scan_complete = sublarr_signals.signal("wanted_scan_complete")
 wanted_item_processed = sublarr_signals.signal("wanted_item_processed")
 upgrade_complete = sublarr_signals.signal("upgrade_complete")
 batch_complete = sublarr_signals.signal("batch_complete")
-batch_extract_complete = sublarr_signals.signal("batch_extract_complete")
+batch_extract_completed = sublarr_signals.signal("batch_extract_completed")
 webhook_received = sublarr_signals.signal("webhook_received")
 config_updated = sublarr_signals.signal("config_updated")
 whisper_complete = sublarr_signals.signal("whisper_complete")
@@ -156,8 +156,8 @@ EVENT_CATALOG: dict[str, dict] = {
             "duration_ms",
         ],
     },
-    "batch_extract_complete": {
-        "signal": batch_extract_complete,
+    "batch_extract_completed": {
+        "signal": batch_extract_completed,
         "label": "Batch Extract Complete",
         "description": "A batch embedded-subtitle extraction operation completed.",
         "payload_keys": [

--- a/backend/events/catalog.py
+++ b/backend/events/catalog.py
@@ -174,6 +174,7 @@ EVENT_CATALOG: dict[str, dict] = {
         "payload_keys": [
             "total",
             "found",
+            "extracted",
             "skipped",
             "failed",
             "duration_ms",

--- a/backend/events/catalog.py
+++ b/backend/events/catalog.py
@@ -27,6 +27,7 @@ wanted_item_processed = sublarr_signals.signal("wanted_item_processed")
 upgrade_complete = sublarr_signals.signal("upgrade_complete")
 batch_complete = sublarr_signals.signal("batch_complete")
 batch_extract_completed = sublarr_signals.signal("batch_extract_completed")
+batch_probe_completed = sublarr_signals.signal("batch_probe_completed")
 webhook_received = sublarr_signals.signal("webhook_received")
 config_updated = sublarr_signals.signal("config_updated")
 whisper_complete = sublarr_signals.signal("whisper_complete")
@@ -164,6 +165,18 @@ EVENT_CATALOG: dict[str, dict] = {
             "total",
             "succeeded",
             "failed",
+        ],
+    },
+    "batch_probe_completed": {
+        "signal": batch_probe_completed,
+        "label": "Batch Probe Complete",
+        "description": "A batch metadata pre-scan (ffprobe) for embedded subtitle detection completed.",
+        "payload_keys": [
+            "total",
+            "found",
+            "skipped",
+            "failed",
+            "duration_ms",
         ],
     },
     "webhook_received": {

--- a/backend/routes/wanted.py
+++ b/backend/routes/wanted.py
@@ -31,6 +31,7 @@ _batch_extract_state = {
     "processed": 0,
     "succeeded": 0,
     "failed": 0,
+    "skipped": 0,
     "current_item": None,
 }
 _batch_extract_lock = threading.Lock()
@@ -854,6 +855,7 @@ def _run_batch_extract(item_ids, auto_translate, app):
                 "processed": 0,
                 "succeeded": 0,
                 "failed": 0,
+                "skipped": 0,
                 "current_item": None,
             }
         )
@@ -884,7 +886,7 @@ def _run_batch_extract(item_ids, auto_translate, app):
         with _batch_extract_lock:
             _batch_extract_state["running"] = False
             snapshot = dict(_batch_extract_state)
-        emit_event("batch_extract_complete", snapshot)
+        emit_event("batch_extract_completed", snapshot)
 
 
 @bp.route("/wanted/batch-extract", methods=["POST"])

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -177,6 +177,7 @@ export interface BatchExtractStatus {
   processed: number
   succeeded: number
   failed: number
+  skipped: number
   current_item: string | null
 }
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -208,6 +208,7 @@ export interface BatchProbeStatus {
   running: boolean
   total: number
   processed: number
+  extracted: number
   found: number
   skipped: number
   failed: number

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -204,6 +204,28 @@ export async function searchAllWanted(): Promise<{ status: string }> {
   return data
 }
 
+export interface BatchProbeStatus {
+  running: boolean
+  total: number
+  processed: number
+  found: number
+  skipped: number
+  failed: number
+  current_item: string | null
+}
+
+export async function getBatchProbeStatus(): Promise<BatchProbeStatus> {
+  const { data } = await api.get('/wanted/batch-probe/status')
+  return data
+}
+
+export async function startBatchProbe(seriesId?: number): Promise<{ status: string; total_items: number }> {
+  const body: Record<string, unknown> = {}
+  if (seriesId != null) body.series_id = seriesId
+  const { data } = await api.post('/wanted/batch-probe', body)
+  return data
+}
+
 // ─── Providers ───────────────────────────────────────────────────────────────
 
 export async function getProviders(): Promise<{ providers: ProviderInfo[] }> {

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -6,7 +6,7 @@ import {
   getWantedItems, getWantedSummary, refreshWanted,
   updateWantedItemStatus,
   searchWantedItem, processWantedItem, extractEmbeddedSub,
-  startWantedBatchSearch, getWantedBatchStatus, getBatchExtractStatus,
+  startWantedBatchSearch, getWantedBatchStatus, getBatchExtractStatus, getBatchProbeStatus, startBatchProbe,
   getProviders, testProvider, getProviderStats, clearProviderCache,
   searchAllWanted, getRetranslateStatus, retranslateSingle, retranslateBatch,
   getLanguageProfiles, createLanguageProfile, updateLanguageProfile,
@@ -240,6 +240,24 @@ export function useWantedBatchExtractStatus() {
     queryKey: ['wanted-batch-extract-status'],
     queryFn: getBatchExtractStatus,
     refetchInterval: (query) => (query.state.data?.running ? 3000 : false),
+  })
+}
+
+export function useWantedBatchProbeStatus() {
+  return useQuery({
+    queryKey: ['wanted-batch-probe-status'],
+    queryFn: getBatchProbeStatus,
+    refetchInterval: (query) => (query.state.data?.running ? 2000 : false),
+  })
+}
+
+export function useStartBatchProbe() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (seriesId?: number) => startBatchProbe(seriesId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['wanted-batch-probe-status'] })
+    },
   })
 }
 

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -23,6 +23,8 @@ interface UseWebSocketOptions {
   onConfigUpdated?: (data: unknown) => void
   onSyncBatchProgress?: (data: SyncBatchProgress) => void
   onSyncBatchComplete?: (data: SyncBatchComplete) => void
+  onBatchProbeProgress?: (data: unknown) => void
+  onBatchProbeCompleted?: (data: unknown) => void
 }
 
 export function useWebSocket(options: UseWebSocketOptions = {}) {
@@ -68,6 +70,8 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
       ['config_updated', 'onConfigUpdated'],
       ['sync_batch_progress', 'onSyncBatchProgress'],
       ['sync_batch_complete', 'onSyncBatchComplete'],
+      ['batch_probe_progress', 'onBatchProbeProgress'],
+      ['batch_probe_completed', 'onBatchProbeCompleted'],
     ]
 
     // Store named handler references so only this hook's listeners are removed on cleanup

--- a/frontend/src/pages/Wanted.tsx
+++ b/frontend/src/pages/Wanted.tsx
@@ -447,7 +447,8 @@ export function WantedPage() {
             />
           </div>
           <div className="flex gap-4 mt-2 text-xs" style={{ color: 'var(--text-secondary)' }}>
-            <span>{t('wanted.found', 'Found')}: {probeStatus.found}</span>
+            <span>Ziel: {probeStatus.found}</span>
+            <span>Quelle: {probeStatus.extracted}</span>
             <span>{t('wanted.skipped', 'Skipped')}: {probeStatus.skipped}</span>
             <span>{t('wanted.failed', 'Failed')}: {probeStatus.failed}</span>
           </div>

--- a/frontend/src/pages/Wanted.tsx
+++ b/frontend/src/pages/Wanted.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 import {
   useWantedItems, useWantedSummary, useRefreshWanted, useUpdateWantedStatus,
   useSearchWantedItem, useProcessWantedItem, useStartWantedBatch, useWantedBatchStatus,
-  useWantedBatchExtractStatus,
+  useWantedBatchExtractStatus, useWantedBatchProbeStatus, useStartBatchProbe,
   useRetranslateSingle, useAddToBlacklist, useExtractEmbeddedSub,
 } from '@/hooks/useApi'
 import { StatusBadge, SubtitleTypeBadge } from '@/components/shared/StatusBadge'
@@ -258,15 +258,24 @@ export function WantedPage() {
   const addBlacklist = useAddToBlacklist()
   const { data: batchStatus } = useWantedBatchStatus()
   const { data: extractStatus, refetch: refetchExtractStatus } = useWantedBatchExtractStatus()
+  const { data: probeStatus } = useWantedBatchProbeStatus()
+  const startProbe = useStartBatchProbe()
   const queryClient = useQueryClient()
 
-  // Live updates for batch-extract progress via WebSocket
+  // Live updates via WebSocket
   useWebSocket({
     onBatchExtractProgress: () => {
       refetchExtractStatus()
     },
     onBatchExtractCompleted: () => {
       queryClient.invalidateQueries({ queryKey: ['wanted-batch-extract-status'] })
+      queryClient.invalidateQueries({ queryKey: ['wanted'] })
+    },
+    onBatchProbeProgress: () => {
+      queryClient.invalidateQueries({ queryKey: ['wanted-batch-probe-status'] })
+    },
+    onBatchProbeCompleted: () => {
+      queryClient.invalidateQueries({ queryKey: ['wanted-batch-probe-status'] })
       queryClient.invalidateQueries({ queryKey: ['wanted'] })
     },
   })
@@ -279,6 +288,14 @@ export function WantedPage() {
     }
     prevExtractRunning.current = extractStatus?.running
   }, [extractStatus?.running, queryClient])
+
+  const prevProbeRunning = useRef<boolean | undefined>(undefined)
+  useEffect(() => {
+    if (prevProbeRunning.current === true && probeStatus?.running === false) {
+      queryClient.invalidateQueries({ queryKey: ['wanted'] })
+    }
+    prevProbeRunning.current = probeStatus?.running
+  }, [probeStatus?.running, queryClient])
 
   const totalWanted = summary?.by_status?.wanted ?? 0
   const totalEpisodes = summary?.by_type?.episode ?? 0
@@ -402,6 +419,41 @@ export function WantedPage() {
 
   return (
     <div className="space-y-5">
+      {/* Batch Probe Progress Banner */}
+      {probeStatus?.running && (
+        <div
+          className="rounded-lg p-4"
+          style={{ backgroundColor: 'var(--accent-bg)', border: '1px solid var(--accent-dim)' }}
+        >
+          <div className="flex items-center justify-between mb-2">
+            <div className="flex items-center gap-2 text-sm font-medium" style={{ color: 'var(--accent)' }}>
+              <Loader2 size={14} className="animate-spin" />
+              <ScanSearch size={14} />
+              {probeStatus.current_item
+                ? `Scanning: ${probeStatus.current_item}`
+                : t('wanted.starting', 'Starting...')}
+            </div>
+            <span className="text-xs tabular-nums" style={{ fontFamily: 'var(--font-mono)', color: 'var(--accent)' }}>
+              {probeStatus.processed}/{probeStatus.total}
+            </span>
+          </div>
+          <div className="w-full rounded-full h-2" style={{ backgroundColor: 'var(--border)' }}>
+            <div
+              className="h-2 rounded-full transition-all duration-300"
+              style={{
+                width: probeStatus.total > 0 ? `${(probeStatus.processed / probeStatus.total) * 100}%` : '0%',
+                backgroundColor: 'var(--accent)',
+              }}
+            />
+          </div>
+          <div className="flex gap-4 mt-2 text-xs" style={{ color: 'var(--text-secondary)' }}>
+            <span>{t('wanted.found', 'Found')}: {probeStatus.found}</span>
+            <span>{t('wanted.skipped', 'Skipped')}: {probeStatus.skipped}</span>
+            <span>{t('wanted.failed', 'Failed')}: {probeStatus.failed}</span>
+          </div>
+        </div>
+      )}
+
       {/* Batch Extract Progress Banner */}
       {extractStatus?.running && (
         <div
@@ -477,6 +529,20 @@ export function WantedPage() {
           </p>
         </div>
         <div className="flex items-center gap-2">
+          <button
+            onClick={() => startProbe.mutate(undefined)}
+            disabled={startProbe.isPending || probeStatus?.running || batchStatus?.running}
+            className="flex items-center gap-2 px-4 py-2 rounded-md text-sm font-medium hover:opacity-90"
+            title="Scan for embedded subtitles in all unresolved items"
+            style={{
+              backgroundColor: 'var(--bg-surface)',
+              color: 'var(--text-primary)',
+              border: '1px solid var(--border)',
+            }}
+          >
+            <ScanSearch size={14} />
+            {probeStatus?.running ? 'Scanning...' : 'Scan Embedded'}
+          </button>
           <button
             onClick={handleBatchSearch}
             disabled={startBatch.isPending || batchStatus?.running}


### PR DESCRIPTION
## Summary

- **Batch metadata pre-scan** (`POST /wanted/batch-probe`): ffprobes all unresolved wanted items in parallel, detects and extracts embedded subtitle streams
- **Language-agnostic extraction**: statt nur Zielsprach-Streams zu detektieren, werden jetzt **alle** text-basierten Subtitle-Streams als Sidecar-Dateien extrahiert (`episode.eng.ass`, `episode.por.ass`, etc.)
- **Neue Zähler-Semantik**: `found` (Zielsprach-Sub direkt extrahiert), `extracted` (Quell-Subs auf Disk, braucht Übersetzung), `skipped` (keine extrahierbaren Tracks)
- **Batch-extract async** (`POST /wanted/batch-extract`): extrahiert embedded Subs für gezielte Item-IDs oder eine ganze Serie
- **Frontend**: Live-Progress-Banner mit WebSocket-Updates, Zähler im UI, Scan-Button im Wanted-Header

## Commits

| Commit | Inhalt |
|--------|--------|
| `ae6ab07` | fix: batch-extract event name mismatch + skipped field + polling fallback |
| `8436e04` | feat: batch metadata pre-scan for embedded subtitle detection |
| `6d36db6` | fix: batch-probe endpoint — data key, cache workers, 409 race condition |
| `3d63c7c` | feat: batch-probe extracts all embedded subtitle tracks (language-agnostic) |

## Motivation

Anime-MKVs haben fast immer englische ASS-Fansub-Subs eingebettet — keine deutschen. Die alte Logik erkannte nur Zielsprach-Streams und schickte alles in die Provider-Suche (die dann scheitert). Jetzt werden EN/PT/ES/etc. Subs extrahiert und liegen als Sidecar bereit für Batch-Translate.

**Live-Testergebnis** (19 Oshi no Ko-Episodes):
- `found: 6` — Zielsprach-Sub direkt extrahiert
- `extracted: 13` — Quell-Subs (eng/enm/por/spa) auf Disk, ready für Translation
- `skipped: 0`, `failed: 0`

## Geänderte Dateien

- `backend/ass_utils.py` — `get_subtitle_stream_output_path()` neu
- `backend/routes/wanted.py` — batch-probe + batch-extract Endpunkte + Background-Threads
- `backend/events/catalog.py` — `batch_probe_completed` + `batch_extract_completed` Events
- `backend/db/repositories/wanted.py` + `backend/db/wanted.py` — `update_existing_sub()`
- `frontend/src/api/client.ts` — `BatchProbeStatus` (inkl. `extracted`), `BatchExtractStatus`, API-Funktionen
- `frontend/src/hooks/useApi.ts` + `useWebSocket.ts` — Hooks für Probe/Extract-Status
- `frontend/src/pages/Wanted.tsx` — Progress-Banner, Scan-Button, Counter-Anzeige

## Test plan

- [ ] `POST /wanted/batch-probe` → 202, WebSocket-Events `batch_probe_progress` kommen an
- [ ] Status-Endpoint zeigt `extracted`, `found`, `skipped`, `failed` korrekt
- [ ] Sidecar-Dateien (`*.eng.ass`, `*.por.ass`) liegen neben den MKV-Dateien
- [ ] `POST /wanted/batch-probe` während laufendem Probe → 409
- [ ] Frontend-Banner erscheint während Probe läuft, verschwindet danach
- [ ] Wanted-Liste refresht automatisch nach Abschluss der Probe

🤖 Generated with [Claude Code](https://claude.com/claude-code)