### PR TITLE
chore: optimize CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,40 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  workflow_call:
+
+# Cancel in-progress runs for the same branch/PR — saves CI minutes
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
+  # ─── Detect which parts of the codebase changed ──────────────────────────
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            backend:
+              - 'backend/**'
+              - 'requirements*.txt'
+              - '.github/workflows/ci.yml'
+            frontend:
+              - 'frontend/**'
+              - '.github/workflows/ci.yml'
+
+  # ─── Backend ─────────────────────────────────────────────────────────────
   backend:
     name: Backend (Python 3.11)
+    needs: changes
+    if: needs.changes.outputs.backend == 'true' || github.event_name == 'workflow_call'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -35,7 +65,7 @@ jobs:
       - name: Type check (mypy)
         working-directory: ./backend
         run: mypy . --config-file mypy.ini
-        continue-on-error: true
+        continue-on-error: true  # informational — not yet enforced
 
       - name: Tests (pytest)
         working-directory: ./backend
@@ -49,8 +79,11 @@ jobs:
             --ignore=tests/test_wanted_search_reliability.py \
             -k "not (test_sonarr_download_webhook or test_parse_llm_response_too_many_merge or test_record_backend_success)"
 
+  # ─── Frontend ─────────────────────────────────────────────────────────────
   frontend:
     name: Frontend (Node 20)
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true' || github.event_name == 'workflow_call'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -77,8 +110,11 @@ jobs:
         working-directory: ./frontend
         run: npm run test -- --run
 
+  # ─── Security ─────────────────────────────────────────────────────────────
   security:
     name: Security Scan
+    needs: changes
+    if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true' || github.event_name == 'workflow_call'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,21 +3,14 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+
+# Cancel outdated reviews when new commits are pushed to the same PR
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -38,7 +31,12 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
+          prompt: |
+            /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
 
+            Project context:
+            - Flask backend (Python 3.11) + React 19 / TypeScript frontend
+            - SQLite with WAL mode, thread-safe _db_lock pattern
+            - Security-sensitive: file access must use is_safe_path() from backend/security_utils.py
+            - Conventional commits enforced (feat/fix/security/chore/docs)
+            - No direct commits to master — always via PR

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,11 +19,12 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      actions: read
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -35,16 +36,5 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-
-          # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
-
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
-
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
-


### PR DESCRIPTION
## Summary

- **paths-filter**: Backend-Job läuft nur wenn Backend-Dateien geändert wurden, Frontend-Job nur bei Frontend-Änderungen → spart ~3 Min pro Push wenn nur eine Seite geändert
- **concurrency cancel-in-progress**: Alte CI-Runs werden abgebrochen wenn neue Commits gepusht werden — kein Stapeln doppelter Runs
- **Claude Review**: Alte Reviews werden bei neuen Commits im gleichen PR abgebrochen statt parallel zu laufen; Projekt-Kontext im Prompt (Flask/React, security_utils, Konventionen)
- **claude.yml**: Write-Permissions für `contents`, `pull-requests`, `issues` hinzugefügt damit `@claude` tatsächlich Kommentare posten und Commits erstellen kann

## Test plan
- [ ] Push der nur Backend-Dateien ändert → nur `Backend`-Job läuft, `Frontend`-Job wird übersprungen (skipped = grün)
- [ ] Push der nur Frontend-Dateien ändert → nur `Frontend`-Job läuft
- [ ] Zwei schnelle Pushes hintereinander → erster Run wird abgebrochen
- [ ] PR öffnen → `claude-review` startet; weiteren Commit pushen → alter Review-Run wird cancelt, neuer startet