### PR TITLE
feat: provider UI redesign + 4 new providers + language expansion

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -50,6 +50,7 @@ class Settings(BaseSettings):
     # Subtitle Providers
     provider_priorities: str = "animetosho,jimaku,opensubtitles,subdl"
     providers_enabled: str = ""  # Empty = all registered providers enabled
+    providers_hidden: str = ""  # Comma-separated provider names hidden from the UI grid (truly removed)
     provider_search_timeout: int = 30  # Global timeout fallback (seconds)
     provider_cache_ttl_minutes: int = 5  # Cache TTL for provider search results
     provider_auto_prioritize: bool = True  # Auto-prioritize providers based on success rate

--- a/backend/config.py
+++ b/backend/config.py
@@ -50,7 +50,9 @@ class Settings(BaseSettings):
     # Subtitle Providers
     provider_priorities: str = "animetosho,jimaku,opensubtitles,subdl"
     providers_enabled: str = ""  # Empty = all registered providers enabled
-    providers_hidden: str = ""  # Comma-separated provider names hidden from the UI grid (truly removed)
+    providers_hidden: str = (
+        ""  # Comma-separated provider names hidden from the UI grid (truly removed)
+    )
 
     # Addic7ed (TV subtitles — optional credentials increase download limit)
     addic7ed_username: str = ""

--- a/backend/config.py
+++ b/backend/config.py
@@ -51,6 +51,14 @@ class Settings(BaseSettings):
     provider_priorities: str = "animetosho,jimaku,opensubtitles,subdl"
     providers_enabled: str = ""  # Empty = all registered providers enabled
     providers_hidden: str = ""  # Comma-separated provider names hidden from the UI grid (truly removed)
+
+    # Addic7ed (TV subtitles — optional credentials increase download limit)
+    addic7ed_username: str = ""
+    addic7ed_password: str = ""
+
+    # Turkcealtyazi (Turkish subtitles — account required)
+    turkcealtyazi_username: str = ""
+    turkcealtyazi_password: str = ""
     provider_search_timeout: int = 30  # Global timeout fallback (seconds)
     provider_cache_ttl_minutes: int = 5  # Cache TTL for provider search results
     provider_auto_prioritize: bool = True  # Auto-prioritize providers based on success rate
@@ -386,34 +394,146 @@ def map_path(path: str) -> str:
     return path
 
 
-# Language tag mapping (ISO 639-1 -> all variants)
+# Language tag mapping (ISO 639-1 -> all known file/metadata variants)
 _LANGUAGE_TAGS = {
+    # Western Europe
     "de": {"de", "deu", "ger", "german"},
     "en": {"en", "eng", "english"},
     "fr": {"fr", "fra", "fre", "french"},
     "es": {"es", "spa", "spanish"},
     "it": {"it", "ita", "italian"},
     "pt": {"pt", "por", "portuguese"},
-    "ru": {"ru", "rus", "russian"},
-    "ja": {"ja", "jpn", "japanese"},
-    "zh": {"zh", "zho", "chi", "chinese"},
-    "ko": {"ko", "kor", "korean"},
-    "ar": {"ar", "ara", "arabic"},
     "nl": {"nl", "nld", "dut", "dutch"},
-    "pl": {"pl", "pol", "polish"},
     "sv": {"sv", "swe", "swedish"},
     "da": {"da", "dan", "danish"},
     "no": {"no", "nor", "norwegian"},
     "fi": {"fi", "fin", "finnish"},
+    "is": {"is", "isl", "ice", "icelandic"},
+    "eu": {"eu", "eus", "baq", "basque"},
+    "ca": {"ca", "cat", "catalan"},
+    "gl": {"gl", "glg", "galician"},
+    # Eastern Europe
+    "pl": {"pl", "pol", "polish"},
     "cs": {"cs", "ces", "cze", "czech"},
+    "sk": {"sk", "slk", "slo", "slovak"},
     "hu": {"hu", "hun", "hungarian"},
+    "ro": {"ro", "ron", "rum", "romanian"},
+    "bg": {"bg", "bul", "bulgarian"},
+    "hr": {"hr", "hrv", "croatian"},
+    "sr": {"sr", "srp", "serbian"},
+    "sl": {"sl", "slv", "slovenian"},
+    "bs": {"bs", "bos", "bosnian"},
+    "mk": {"mk", "mkd", "macedonian"},
+    "sq": {"sq", "alb", "sqi", "albanian"},
+    "lt": {"lt", "lit", "lithuanian"},
+    "lv": {"lv", "lav", "latvian"},
+    "et": {"et", "est", "estonian"},
+    "uk": {"uk", "ukr", "ukrainian"},
+    "ru": {"ru", "rus", "russian"},
+    # Caucasus / Central Asia
+    "hy": {"hy", "hye", "arm", "armenian"},
+    "ka": {"ka", "kat", "geo", "georgian"},
+    "az": {"az", "aze", "azerbaijani"},
+    "kk": {"kk", "kaz", "kazakh"},
+    "uz": {"uz", "uzb", "uzbek"},
+    # Middle East
+    "ar": {"ar", "ara", "arabic"},
+    "he": {"he", "heb", "hebrew"},
+    "fa": {"fa", "per", "fas", "persian"},
     "tr": {"tr", "tur", "turkish"},
+    # South / Southeast Asia
+    "hi": {"hi", "hin", "hindi"},
+    "bn": {"bn", "ben", "bengali"},
+    "ur": {"ur", "urd", "urdu"},
+    "ta": {"ta", "tam", "tamil"},
+    "te": {"te", "tel", "telugu"},
+    "ml": {"ml", "mal", "malayalam"},
+    "kn": {"kn", "kan", "kannada"},
+    "si": {"si", "sin", "sinhala"},
     "th": {"th", "tha", "thai"},
     "vi": {"vi", "vie", "vietnamese"},
     "id": {"id", "ind", "indonesian"},
     "ms": {"ms", "msa", "may", "malay"},
-    "hi": {"hi", "hin", "hindi"},
+    "tl": {"tl", "fil", "tagalog", "filipino"},
+    # East Asia
+    "ja": {"ja", "jpn", "japanese"},
+    "ko": {"ko", "kor", "korean"},
+    "zh": {"zh", "zho", "chi", "chinese"},
+    "zh-hans": {"zh-hans", "zhs", "chs", "chi-sim", "chinese simplified"},
+    "zh-hant": {"zh-hant", "zht", "cht", "chi-tra", "chinese traditional"},
+    "mn": {"mn", "mon", "mongolian"},
+    # Other
+    "el": {"el", "ell", "gre", "greek"},
+    "af": {"af", "afr", "afrikaans"},
+    "sw": {"sw", "swa", "swahili"},
 }
+
+# Ordered list of supported languages for the UI language picker
+SUPPORTED_LANGUAGES: list[dict] = [
+    {"code": "af", "name": "Afrikaans"},
+    {"code": "sq", "name": "Albanian"},
+    {"code": "ar", "name": "Arabic"},
+    {"code": "hy", "name": "Armenian"},
+    {"code": "az", "name": "Azerbaijani"},
+    {"code": "eu", "name": "Basque"},
+    {"code": "bn", "name": "Bengali"},
+    {"code": "bs", "name": "Bosnian"},
+    {"code": "bg", "name": "Bulgarian"},
+    {"code": "ca", "name": "Catalan"},
+    {"code": "zh", "name": "Chinese"},
+    {"code": "zh-hans", "name": "Chinese (Simplified)"},
+    {"code": "zh-hant", "name": "Chinese (Traditional)"},
+    {"code": "hr", "name": "Croatian"},
+    {"code": "cs", "name": "Czech"},
+    {"code": "da", "name": "Danish"},
+    {"code": "nl", "name": "Dutch"},
+    {"code": "en", "name": "English"},
+    {"code": "et", "name": "Estonian"},
+    {"code": "tl", "name": "Filipino"},
+    {"code": "fi", "name": "Finnish"},
+    {"code": "fr", "name": "French"},
+    {"code": "gl", "name": "Galician"},
+    {"code": "ka", "name": "Georgian"},
+    {"code": "de", "name": "German"},
+    {"code": "el", "name": "Greek"},
+    {"code": "he", "name": "Hebrew"},
+    {"code": "hi", "name": "Hindi"},
+    {"code": "hu", "name": "Hungarian"},
+    {"code": "is", "name": "Icelandic"},
+    {"code": "id", "name": "Indonesian"},
+    {"code": "it", "name": "Italian"},
+    {"code": "ja", "name": "Japanese"},
+    {"code": "kn", "name": "Kannada"},
+    {"code": "kk", "name": "Kazakh"},
+    {"code": "ko", "name": "Korean"},
+    {"code": "lv", "name": "Latvian"},
+    {"code": "lt", "name": "Lithuanian"},
+    {"code": "mk", "name": "Macedonian"},
+    {"code": "ms", "name": "Malay"},
+    {"code": "ml", "name": "Malayalam"},
+    {"code": "mn", "name": "Mongolian"},
+    {"code": "no", "name": "Norwegian"},
+    {"code": "fa", "name": "Persian"},
+    {"code": "pl", "name": "Polish"},
+    {"code": "pt", "name": "Portuguese"},
+    {"code": "ro", "name": "Romanian"},
+    {"code": "ru", "name": "Russian"},
+    {"code": "sr", "name": "Serbian"},
+    {"code": "si", "name": "Sinhala"},
+    {"code": "sk", "name": "Slovak"},
+    {"code": "sl", "name": "Slovenian"},
+    {"code": "es", "name": "Spanish"},
+    {"code": "sw", "name": "Swahili"},
+    {"code": "sv", "name": "Swedish"},
+    {"code": "ta", "name": "Tamil"},
+    {"code": "te", "name": "Telugu"},
+    {"code": "th", "name": "Thai"},
+    {"code": "tr", "name": "Turkish"},
+    {"code": "uk", "name": "Ukrainian"},
+    {"code": "ur", "name": "Urdu"},
+    {"code": "uz", "name": "Uzbek"},
+    {"code": "vi", "name": "Vietnamese"},
+]
 
 
 def _get_language_tags(lang_code: str) -> set[str]:

--- a/backend/providers/__init__.py
+++ b/backend/providers/__init__.py
@@ -229,6 +229,22 @@ class ProviderManager:
             from providers import legendasdivx  # noqa: F401
         except ImportError as e:
             logger.debug("LegendasDivx provider not available: %s", e)
+        try:
+            from providers import subscene  # noqa: F401
+        except ImportError as e:
+            logger.debug("Subscene provider not available: %s", e)
+        try:
+            from providers import addic7ed  # noqa: F401
+        except ImportError as e:
+            logger.debug("Addic7ed provider not available: %s", e)
+        try:
+            from providers import tvsubtitles  # noqa: F401
+        except ImportError as e:
+            logger.debug("TVSubtitles provider not available: %s", e)
+        try:
+            from providers import turkcealtyazi  # noqa: F401
+        except ImportError as e:
+            logger.debug("Turkcealtyazi provider not available: %s", e)
 
         # Load plugin providers (from plugins directory)
         self._load_plugins()

--- a/backend/providers/__init__.py
+++ b/backend/providers/__init__.py
@@ -1333,7 +1333,9 @@ class ProviderManager:
                 provider = _PROVIDER_CLASSES[name](**config)
                 provider.initialize()
                 if hasattr(provider, "session") and provider.session is None:
-                    logger.warning("Provider %s: session is None (likely missing credentials)", name)
+                    logger.warning(
+                        "Provider %s: session is None (likely missing credentials)", name
+                    )
                 else:
                     self._providers[name] = provider
                     self._circuit_breakers[name] = CircuitBreaker(

--- a/backend/providers/__init__.py
+++ b/backend/providers/__init__.py
@@ -107,6 +107,21 @@ def invalidate_manager():
     _manager = None
 
 
+def update_manager_providers(new_enabled_str: str) -> None:
+    """Selectively update enabled providers without reinitializing the whole manager.
+
+    Call this instead of invalidate_manager() when only providers_enabled changed.
+    If the manager hasn't been initialized yet, this is a no-op (it will pick up
+    the correct config on first access).
+    """
+    global _manager
+    if _manager is None:
+        return
+    with _provider_manager_lock:
+        if _manager is not None:
+            _manager.update_providers(new_enabled_str)
+
+
 class ProviderManager:
     """Manages multiple subtitle providers with priority ordering and scoring."""
 
@@ -1194,10 +1209,15 @@ class ProviderManager:
 
             provider = self._providers.get(name)
             if provider:
-                try:
-                    healthy, msg = provider.health_check()
-                except Exception as e:
-                    healthy, msg = False, str(e)
+                # Derive health from cached DB stats — no live HTTP requests.
+                # Matches Bazarr's reactive approach: healthy until proven otherwise.
+                consecutive_failures = perf_stats.get("consecutive_failures", 0) or 0
+                if auto_disabled:
+                    healthy, msg = False, "Auto-disabled"
+                elif consecutive_failures >= 3:
+                    healthy, msg = False, f"{consecutive_failures} consecutive failures"
+                else:
+                    healthy, msg = True, "OK"
                 statuses.append(
                     {
                         "name": name,
@@ -1258,3 +1278,53 @@ class ProviderManager:
             except Exception as e:
                 logger.warning("Error terminating provider %s: %s", name, e)
         self._providers.clear()
+
+    def update_providers(self, new_enabled_str: str) -> None:
+        """Selectively add/remove providers without reinitializing unaffected ones.
+
+        Use instead of invalidate_manager() when only providers_enabled changes.
+        Providers that remain enabled keep their existing instances — no health
+        checks re-run, no unnecessary network traffic.
+        """
+        from config import get_settings as _get_settings
+
+        self.settings = _get_settings()
+
+        if new_enabled_str:
+            new_enabled_set = {p.strip() for p in new_enabled_str.split(",") if p.strip()}
+        else:
+            new_enabled_set = set(_PROVIDER_CLASSES.keys())
+
+        current_names = set(self._providers.keys())
+
+        # Remove providers no longer in the enabled set
+        for name in current_names - new_enabled_set:
+            provider = self._providers.pop(name, None)
+            self._circuit_breakers.pop(name, None)
+            if provider:
+                try:
+                    provider.terminate()
+                except Exception:
+                    pass
+            logger.info("Provider %s disabled (removed from pool)", name)
+
+        # Add providers newly added to the enabled set
+        for name in new_enabled_set - current_names:
+            if name not in _PROVIDER_CLASSES:
+                continue
+            try:
+                config = self._get_provider_config(name)
+                provider = _PROVIDER_CLASSES[name](**config)
+                provider.initialize()
+                if hasattr(provider, "session") and provider.session is None:
+                    logger.warning("Provider %s: session is None (likely missing credentials)", name)
+                else:
+                    self._providers[name] = provider
+                    self._circuit_breakers[name] = CircuitBreaker(
+                        name=name,
+                        failure_threshold=self.settings.circuit_breaker_failure_threshold,
+                        cooldown_seconds=self.settings.circuit_breaker_cooldown_seconds,
+                    )
+                    logger.info("Provider %s enabled (added to pool)", name)
+            except Exception as e:
+                logger.error("Failed to initialize provider %s: %s", name, e)

--- a/backend/providers/__init__.py
+++ b/backend/providers/__init__.py
@@ -1201,7 +1201,7 @@ class ProviderManager:
                 statuses.append(
                     {
                         "name": name,
-                        "enabled": True,
+                        "enabled": name in enabled_set,
                         "initialized": True,
                         "healthy": healthy,
                         "message": msg,

--- a/backend/providers/addic7ed.py
+++ b/backend/providers/addic7ed.py
@@ -96,8 +96,13 @@ class Addic7edProvider(SubtitleProvider):
     name = "addic7ed"
     languages = set(_LANG_NAMES.keys())
     config_fields = [
-        {"key": "addic7ed_username", "label": "Username", "type": "text", "required": False,
-         "description": "Optionaler Addic7ed-Account (erhöht das Tageslimit)"},
+        {
+            "key": "addic7ed_username",
+            "label": "Username",
+            "type": "text",
+            "required": False,
+            "description": "Optionaler Addic7ed-Account (erhöht das Tageslimit)",
+        },
         {"key": "addic7ed_password", "label": "Password", "type": "password", "required": False},
     ]
     rate_limit = (10, 60)
@@ -118,10 +123,12 @@ class Addic7edProvider(SubtitleProvider):
             timeout=self.timeout,
             user_agent=_BROWSER_UA,
         )
-        self.session.headers.update({
-            "Accept-Language": "en-US,en;q=0.9",
-            "Referer": _BASE_URL,
-        })
+        self.session.headers.update(
+            {
+                "Accept-Language": "en-US,en;q=0.9",
+                "Referer": _BASE_URL,
+            }
+        )
 
         if self.username and self.password:
             self._login()
@@ -204,18 +211,26 @@ class Addic7edProvider(SubtitleProvider):
                     continue
                 lang_cell = cells[0].get_text(strip=True)
                 release_cell = cells[1].get_text(strip=True) if len(cells) > 1 else ""
-                dl_link = row.find("a", href=lambda h: h and "/updated/" in h or "/original/" in h if h else False)
+                dl_link = row.find(
+                    "a", href=lambda h: h and "/updated/" in h or "/original/" in h if h else False
+                )
                 if not dl_link:
-                    dl_link = row.find("a", string=lambda t: t and "download" in t.lower() if t else False)
+                    dl_link = row.find(
+                        "a", string=lambda t: t and "download" in t.lower() if t else False
+                    )
                 if not dl_link:
                     continue
                 href = dl_link.get("href", "")
-                download_url = href if href.startswith("http") else f"{_BASE_URL}/{href.lstrip('/')}"
-                entries.append({
-                    "language": lang_cell,
-                    "release": release_cell,
-                    "url": download_url,
-                })
+                download_url = (
+                    href if href.startswith("http") else f"{_BASE_URL}/{href.lstrip('/')}"
+                )
+                entries.append(
+                    {
+                        "language": lang_cell,
+                        "release": release_cell,
+                        "url": download_url,
+                    }
+                )
             return entries
         except Exception as e:
             logger.debug("Addic7ed: episode subtitle fetch error: %s", e)
@@ -234,7 +249,12 @@ class Addic7edProvider(SubtitleProvider):
         if not search_title:
             return []
 
-        logger.debug("Addic7ed: searching '%s' S%02dE%02d", search_title, query.season or 0, query.episode or 0)
+        logger.debug(
+            "Addic7ed: searching '%s' S%02dE%02d",
+            search_title,
+            query.season or 0,
+            query.episode or 0,
+        )
 
         shows = self._search_shows(search_title)
         if not shows:
@@ -242,9 +262,7 @@ class Addic7edProvider(SubtitleProvider):
             return []
 
         # Pick best match
-        best_show = next(
-            (s for s in shows if search_title.lower() in s["name"].lower()), shows[0]
-        )
+        best_show = next((s for s in shows if search_title.lower() in s["name"].lower()), shows[0])
 
         all_entries = self._get_episode_subtitles(
             best_show["url"], query.season or 1, query.episode or 1
@@ -265,7 +283,9 @@ class Addic7edProvider(SubtitleProvider):
                         subtitle_id=subtitle_id,
                         language=lang_code,
                         format=SubtitleFormat.SRT,
-                        filename=f"{entry['release']}.srt" if entry["release"] else f"{subtitle_id}.srt",
+                        filename=f"{entry['release']}.srt"
+                        if entry["release"]
+                        else f"{subtitle_id}.srt",
                         download_url=entry["url"],
                         release_info=entry["release"],
                         matches={"series", "season", "episode"},

--- a/backend/providers/addic7ed.py
+++ b/backend/providers/addic7ed.py
@@ -1,0 +1,306 @@
+"""Addic7ed subtitle provider.
+
+Addic7ed is a community-driven subtitle site specialising in TV series with
+episode-exact subtitle matching. Optional credentials increase the download limit.
+
+NOTE: The existing `gestdown` provider already proxies Addic7ed content through
+a stable REST API (api.gestdown.info). This provider adds direct scraping for
+shows or episodes not covered by the Gestdown proxy.
+
+Base URL: https://www.addic7ed.com
+Auth:     Optional (username/password — free account)
+Rate:     10 req / 60 s (site blocks aggressive scrapers)
+License:  GPL-3.0
+"""
+
+import io
+import logging
+import zipfile
+
+try:
+    from bs4 import BeautifulSoup
+
+    _HAS_BS4 = True
+except ImportError:
+    _HAS_BS4 = False
+
+from providers import register_provider
+from providers.base import (
+    SubtitleFormat,
+    SubtitleProvider,
+    SubtitleResult,
+    VideoQuery,
+)
+from providers.http_session import create_session
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL = "https://www.addic7ed.com"
+_LOGIN_URL = f"{_BASE_URL}/dologin.php"
+_SEARCH_URL = f"{_BASE_URL}/search.php"
+_BROWSER_UA = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+)
+
+# Addic7ed language names as they appear on the site
+_LANG_NAMES = {
+    "ar": "Arabic",
+    "bg": "Bulgarian",
+    "ca": "Catalan",
+    "zh": "Chinese (Simplified)",
+    "zh-hans": "Chinese (Simplified)",
+    "zh-hant": "Chinese (Traditional)",
+    "hr": "Croatian",
+    "cs": "Czech",
+    "da": "Danish",
+    "nl": "Dutch",
+    "en": "English",
+    "fi": "Finnish",
+    "fr": "French",
+    "de": "German",
+    "el": "Greek",
+    "he": "Hebrew",
+    "hu": "Hungarian",
+    "id": "Indonesian",
+    "it": "Italian",
+    "ja": "Japanese",
+    "ko": "Korean",
+    "ms": "Malay",
+    "no": "Norwegian",
+    "pl": "Polish",
+    "pt": "Portuguese",
+    "ro": "Romanian",
+    "ru": "Russian",
+    "sr": "Serbian",
+    "sk": "Slovak",
+    "sl": "Slovenian",
+    "es": "Spanish",
+    "sv": "Swedish",
+    "th": "Thai",
+    "tr": "Turkish",
+    "uk": "Ukrainian",
+    "vi": "Vietnamese",
+}
+
+
+@register_provider
+class Addic7edProvider(SubtitleProvider):
+    """Addic7ed subtitle provider.
+
+    Scrapes addic7ed.com directly for TV series subtitles.
+    Optional login credentials increase the per-day download limit.
+    Requires beautifulsoup4.
+    """
+
+    name = "addic7ed"
+    languages = set(_LANG_NAMES.keys())
+    config_fields = [
+        {"key": "addic7ed_username", "label": "Username", "type": "text", "required": False,
+         "description": "Optionaler Addic7ed-Account (erhöht das Tageslimit)"},
+        {"key": "addic7ed_password", "label": "Password", "type": "password", "required": False},
+    ]
+    rate_limit = (10, 60)
+    timeout = 20
+    max_retries = 2
+
+    def __init__(self, username: str = "", password: str = "", **kwargs):
+        super().__init__(**kwargs)
+        self.username = username
+        self.password = password
+        self.session = None
+        self._logged_in = False
+
+    def initialize(self):
+        self.session = create_session(
+            max_retries=2,
+            backoff_factor=1.5,
+            timeout=self.timeout,
+            user_agent=_BROWSER_UA,
+        )
+        self.session.headers.update({
+            "Accept-Language": "en-US,en;q=0.9",
+            "Referer": _BASE_URL,
+        })
+
+        if self.username and self.password:
+            self._login()
+
+    def terminate(self):
+        if self.session:
+            self.session.close()
+            self.session = None
+        self._logged_in = False
+
+    def health_check(self) -> tuple[bool, str]:
+        if not self.session:
+            return False, "Not initialized"
+        if not _HAS_BS4:
+            return False, "beautifulsoup4 not installed"
+        try:
+            resp = self.session.get(_BASE_URL, timeout=10)
+            return (True, "OK") if resp.status_code == 200 else (False, f"HTTP {resp.status_code}")
+        except Exception as e:
+            return False, str(e)
+
+    def _login(self):
+        try:
+            resp = self.session.post(
+                _LOGIN_URL,
+                data={"username": self.username, "password": self.password, "Submit": "Log in"},
+                timeout=self.timeout,
+            )
+            if resp.status_code == 200 and "logout" in resp.text.lower():
+                self._logged_in = True
+                logger.debug("Addic7ed: logged in as %s", self.username)
+            else:
+                logger.warning("Addic7ed: login failed for %s", self.username)
+        except Exception as e:
+            logger.warning("Addic7ed: login error: %s", e)
+
+    def _search_shows(self, title: str) -> list[dict]:
+        """Search for shows by title, return list of {url, name} dicts."""
+        try:
+            resp = self.session.get(
+                _SEARCH_URL,
+                params={"search": title, "Submit": "Search"},
+                timeout=self.timeout,
+            )
+            if resp.status_code != 200:
+                return []
+            soup = BeautifulSoup(resp.text, "html.parser")
+            results = []
+            # Search results: <div class="tabel95"> with show links
+            for a in soup.select("div.tabel95 a[href*='/show/'], table a[href*='/show/']"):
+                href = a.get("href", "")
+                name = a.get_text(strip=True)
+                if href and name:
+                    url = href if href.startswith("http") else f"{_BASE_URL}/{href.lstrip('/')}"
+                    results.append({"url": url, "name": name})
+            return results
+        except Exception as e:
+            logger.debug("Addic7ed: show search error: %s", e)
+            return []
+
+    def _get_episode_subtitles(self, show_url: str, season: int, episode: int) -> list[dict]:
+        """Get subtitles for a specific episode from the show page."""
+        try:
+            # Addic7ed episode URL pattern: /serie/SHOW_NAME/SEASON/EPISODE/0
+            # Or via season page for the show
+            show_name = show_url.rstrip("/").split("/")[-1]
+            ep_url = f"{_BASE_URL}/serie/{show_name}/{season}/{episode}/0"
+            resp = self.session.get(ep_url, timeout=self.timeout)
+            if resp.status_code != 200:
+                # Try via show URL directly
+                resp = self.session.get(show_url, timeout=self.timeout)
+                if resp.status_code != 200:
+                    return []
+            soup = BeautifulSoup(resp.text, "html.parser")
+            entries = []
+            # Subtitle rows: <tr class="epeven"> or <tr class="epodd">
+            for row in soup.select("tr.epeven, tr.epodd"):
+                cells = row.find_all("td")
+                if len(cells) < 5:
+                    continue
+                lang_cell = cells[0].get_text(strip=True)
+                release_cell = cells[1].get_text(strip=True) if len(cells) > 1 else ""
+                dl_link = row.find("a", href=lambda h: h and "/updated/" in h or "/original/" in h if h else False)
+                if not dl_link:
+                    dl_link = row.find("a", string=lambda t: t and "download" in t.lower() if t else False)
+                if not dl_link:
+                    continue
+                href = dl_link.get("href", "")
+                download_url = href if href.startswith("http") else f"{_BASE_URL}/{href.lstrip('/')}"
+                entries.append({
+                    "language": lang_cell,
+                    "release": release_cell,
+                    "url": download_url,
+                })
+            return entries
+        except Exception as e:
+            logger.debug("Addic7ed: episode subtitle fetch error: %s", e)
+            return []
+
+    def search(self, query: VideoQuery) -> list[SubtitleResult]:
+        if not self.session:
+            return []
+        if not _HAS_BS4:
+            logger.warning("Addic7ed: beautifulsoup4 not installed")
+            return []
+        if query.is_movie or not query.is_episode:
+            return []
+
+        search_title = query.series_title or query.title
+        if not search_title:
+            return []
+
+        logger.debug("Addic7ed: searching '%s' S%02dE%02d", search_title, query.season or 0, query.episode or 0)
+
+        shows = self._search_shows(search_title)
+        if not shows:
+            logger.debug("Addic7ed: no shows found for '%s'", search_title)
+            return []
+
+        # Pick best match
+        best_show = next(
+            (s for s in shows if search_title.lower() in s["name"].lower()), shows[0]
+        )
+
+        all_entries = self._get_episode_subtitles(
+            best_show["url"], query.season or 1, query.episode or 1
+        )
+
+        results = []
+        search_langs = query.languages or ["en"]
+
+        for lang_code in search_langs:
+            lang_name_target = _LANG_NAMES.get(lang_code, "").lower()
+            for entry in all_entries:
+                if lang_name_target and lang_name_target not in entry["language"].lower():
+                    continue
+                subtitle_id = entry["url"].rstrip("/").split("/")[-1]
+                results.append(
+                    SubtitleResult(
+                        provider_name=self.name,
+                        subtitle_id=subtitle_id,
+                        language=lang_code,
+                        format=SubtitleFormat.SRT,
+                        filename=f"{entry['release']}.srt" if entry["release"] else f"{subtitle_id}.srt",
+                        download_url=entry["url"],
+                        release_info=entry["release"],
+                        matches={"series", "season", "episode"},
+                        provider_data={"show_name": best_show["name"]},
+                    )
+                )
+
+        logger.info("Addic7ed: found %d results", len(results))
+        return results
+
+    def download(self, result: SubtitleResult) -> bytes:
+        if not self.session:
+            raise RuntimeError("Addic7ed not initialized")
+
+        resp = self.session.get(
+            result.download_url,
+            headers={"Referer": _BASE_URL},
+            timeout=self.timeout,
+        )
+        if resp.status_code != 200:
+            raise RuntimeError(f"Addic7ed download failed: HTTP {resp.status_code}")
+
+        content = resp.content
+
+        if content[:2] == b"PK":
+            try:
+                with zipfile.ZipFile(io.BytesIO(content)) as zf:
+                    for name in zf.namelist():
+                        if name.lower().endswith((".srt", ".ass", ".ssa", ".vtt")):
+                            content = zf.read(name)
+                            result.filename = name
+                            break
+            except Exception as e:
+                logger.warning("Addic7ed: ZIP extraction failed: %s", e)
+
+        result.content = content
+        logger.info("Addic7ed: downloaded %s (%d bytes)", result.filename, len(content))
+        return content

--- a/backend/providers/subscene.py
+++ b/backend/providers/subscene.py
@@ -1,0 +1,317 @@
+"""Subscene subtitle provider.
+
+Subscene is a large community subtitle database supporting 60+ languages.
+No authentication required for searching and downloading.
+
+Base URL: https://subscene.com
+Auth:     None required
+Rate:     10 req / 60 s (conservative — site blocks aggressive scrapers)
+License:  GPL-3.0
+"""
+
+import io
+import logging
+import zipfile
+
+try:
+    from bs4 import BeautifulSoup
+
+    _HAS_BS4 = True
+except ImportError:
+    _HAS_BS4 = False
+
+from providers import register_provider
+from providers.base import (
+    SubtitleFormat,
+    SubtitleProvider,
+    SubtitleResult,
+    VideoQuery,
+)
+from providers.http_session import create_session
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL = "https://subscene.com"
+_SEARCH_URL = f"{_BASE_URL}/subtitles/searchbytitle"
+_BROWSER_UA = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+)
+
+# Subscene language filter names as used in the URL and page HTML
+# Map ISO 639-1 → Subscene language filter keyword
+_LANG_NAMES = {
+    "ar": "arabic",
+    "da": "danish",
+    "nl": "dutch",
+    "en": "english",
+    "fa": "farsi_persian",
+    "fi": "finnish",
+    "fr": "french",
+    "de": "german",
+    "el": "greek",
+    "he": "hebrew",
+    "hi": "hindi",
+    "hu": "hungarian",
+    "id": "indonesian",
+    "it": "italian",
+    "ja": "japanese",
+    "ko": "korean",
+    "ms": "malay",
+    "no": "norwegian",
+    "pl": "polish",
+    "pt": "portuguese",
+    "ro": "romanian",
+    "ru": "russian",
+    "es": "spanish",
+    "sv": "swedish",
+    "th": "thai",
+    "tr": "turkish",
+    "uk": "ukrainian",
+    "vi": "vietnamese",
+    "zh": "chinese_simplified",
+    "zh-hans": "chinese_simplified",
+    "zh-hant": "chinese_traditional",
+    "hr": "croatian",
+    "cs": "czech",
+    "sk": "slovak",
+    "bg": "bulgarian",
+    "sr": "serbian",
+    "sl": "slovenian",
+    "bs": "bosnian",
+    "mk": "macedonian",
+    "sq": "albanian",
+    "lt": "lithuanian",
+    "lv": "latvian",
+    "et": "estonian",
+    "hy": "armenian",
+    "ka": "georgian",
+    "is": "icelandic",
+    "bn": "bengali",
+    "ur": "urdu",
+    "ta": "tamil",
+    "te": "telugu",
+    "ml": "malayalam",
+    "af": "afrikaans",
+    "ca": "catalan",
+    "eu": "basque",
+    "gl": "galician",
+}
+
+
+@register_provider
+class SubsceneProvider(SubtitleProvider):
+    """Subscene subtitle provider.
+
+    Large community-driven database supporting 60+ languages.
+    Uses HTML scraping with BeautifulSoup4. Gracefully returns an empty
+    list if beautifulsoup4 is not installed.
+    """
+
+    name = "subscene"
+    languages = set(_LANG_NAMES.keys())
+    config_fields = []
+    rate_limit = (10, 60)
+    timeout = 20
+    max_retries = 2
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.session = None
+
+    def initialize(self):
+        self.session = create_session(
+            max_retries=2,
+            backoff_factor=1.5,
+            timeout=self.timeout,
+            user_agent=_BROWSER_UA,
+        )
+        self.session.headers.update({"Accept-Language": "en-US,en;q=0.9"})
+
+    def terminate(self):
+        if self.session:
+            self.session.close()
+            self.session = None
+
+    def health_check(self) -> tuple[bool, str]:
+        if not self.session:
+            return False, "Not initialized"
+        if not _HAS_BS4:
+            return False, "beautifulsoup4 not installed"
+        try:
+            resp = self.session.get(_BASE_URL, timeout=10)
+            return (True, "OK") if resp.status_code == 200 else (False, f"HTTP {resp.status_code}")
+        except Exception as e:
+            return False, str(e)
+
+    def _search_titles(self, title: str) -> list[dict]:
+        """POST to Subscene search and return list of {url, title} dicts."""
+        try:
+            resp = self.session.post(
+                _SEARCH_URL,
+                data={"query": title},
+                headers={"Referer": _BASE_URL},
+                timeout=self.timeout,
+            )
+            if resp.status_code != 200:
+                logger.debug("Subscene: search returned HTTP %d", resp.status_code)
+                return []
+            soup = BeautifulSoup(resp.text, "html.parser")
+            results = []
+            # Results are in <div class="title"><a href="/subtitles/...">
+            for a in soup.select("div.title a[href^='/subtitles/']"):
+                href = a.get("href", "")
+                text = a.get_text(strip=True)
+                if href and text:
+                    results.append({"url": f"{_BASE_URL}{href}", "title": text})
+            return results
+        except Exception as e:
+            logger.debug("Subscene: search error: %s", e)
+            return []
+
+    def _get_subtitles_for_lang(self, page_url: str, lang_name: str) -> list[dict]:
+        """Fetch the subtitle listing page and extract entries for a language."""
+        try:
+            resp = self.session.get(
+                page_url,
+                params={"l": lang_name},
+                headers={"Referer": _BASE_URL},
+                timeout=self.timeout,
+            )
+            if resp.status_code != 200:
+                return []
+            soup = BeautifulSoup(resp.text, "html.parser")
+            entries = []
+            # Subtitle rows: <div class="a1"><a href="/subtitles/.../{id}">
+            for row in soup.select("td.a1"):
+                a = row.find("a")
+                if not a:
+                    continue
+                href = a.get("href", "")
+                spans = a.find_all("span")
+                lang_span = spans[0].get_text(strip=True) if spans else ""
+                name_span = spans[1].get_text(strip=True) if len(spans) > 1 else ""
+                if not href:
+                    continue
+                entries.append({
+                    "url": f"{_BASE_URL}{href}",
+                    "lang": lang_span,
+                    "name": name_span,
+                })
+            return entries
+        except Exception as e:
+            logger.debug("Subscene: listing error for %s: %s", page_url, e)
+            return []
+
+    def _get_download_url(self, subtitle_page_url: str) -> str | None:
+        """Follow the subtitle detail page to find the actual download link."""
+        try:
+            resp = self.session.get(
+                subtitle_page_url,
+                headers={"Referer": _BASE_URL},
+                timeout=self.timeout,
+            )
+            if resp.status_code != 200:
+                return None
+            soup = BeautifulSoup(resp.text, "html.parser")
+            # Download link: <a id="downloadButton" href="/subtitle/download/...">
+            a = soup.find("a", id="downloadButton") or soup.select_one("a[href*='/subtitle/download']")
+            if a:
+                href = a.get("href", "")
+                return f"{_BASE_URL}{href}" if href.startswith("/") else href
+        except Exception as e:
+            logger.debug("Subscene: detail page error: %s", e)
+        return None
+
+    def search(self, query: VideoQuery) -> list[SubtitleResult]:
+        if not self.session:
+            return []
+        if not _HAS_BS4:
+            logger.warning("Subscene: beautifulsoup4 not installed")
+            return []
+
+        search_title = query.series_title or query.title
+        if not search_title:
+            return []
+
+        logger.debug("Subscene: searching '%s' (languages: %s)", search_title, query.languages)
+
+        title_results = self._search_titles(search_title)
+        if not title_results:
+            logger.debug("Subscene: no title matches for '%s'", search_title)
+            return []
+
+        # Pick the best-matching title (first result, case-insensitive prefix match preferred)
+        best_url = None
+        for tr in title_results:
+            if search_title.lower() in tr["title"].lower():
+                best_url = tr["url"]
+                break
+        if not best_url:
+            best_url = title_results[0]["url"]
+
+        results = []
+        search_langs = query.languages or ["en"]
+
+        for lang_code in search_langs:
+            lang_name = _LANG_NAMES.get(lang_code)
+            if not lang_name:
+                continue
+            entries = self._get_subtitles_for_lang(best_url, lang_name)
+            for entry in entries[:10]:  # cap per language to limit requests
+                subtitle_id = entry["url"].rstrip("/").split("/")[-1]
+                results.append(
+                    SubtitleResult(
+                        provider_name=self.name,
+                        subtitle_id=subtitle_id,
+                        language=lang_code,
+                        format=SubtitleFormat.SRT,
+                        filename=entry["name"] + ".srt",
+                        download_url=entry["url"],  # detail page; resolved in download()
+                        release_info=entry["name"],
+                        matches={"series"} if query.series_title else set(),
+                        provider_data={"detail_url": entry["url"]},
+                    )
+                )
+
+        logger.info("Subscene: found %d results", len(results))
+        return results
+
+    def download(self, result: SubtitleResult) -> bytes:
+        if not self.session:
+            raise RuntimeError("Subscene not initialized")
+
+        detail_url = (result.provider_data or {}).get("detail_url") or result.download_url
+        dl_url = self._get_download_url(detail_url)
+        if not dl_url:
+            raise RuntimeError(f"Subscene: no download URL on {detail_url}")
+
+        resp = self.session.get(dl_url, headers={"Referer": detail_url}, timeout=self.timeout)
+        if resp.status_code != 200:
+            raise RuntimeError(f"Subscene download failed: HTTP {resp.status_code}")
+
+        content = resp.content
+
+        # Extract from ZIP if needed
+        if content[:2] == b"PK":
+            try:
+                with zipfile.ZipFile(io.BytesIO(content)) as zf:
+                    names = zf.namelist()
+                    # Pick first subtitle file
+                    for name in names:
+                        if name.lower().endswith((".srt", ".ass", ".ssa", ".vtt", ".sub")):
+                            content = zf.read(name)
+                            result.filename = name
+                            ext = name.rsplit(".", 1)[-1].lower()
+                            result.format = {
+                                "ass": SubtitleFormat.ASS,
+                                "ssa": SubtitleFormat.SSA,
+                                "vtt": SubtitleFormat.VTT,
+                            }.get(ext, SubtitleFormat.SRT)
+                            break
+            except Exception as e:
+                logger.warning("Subscene: ZIP extraction failed: %s", e)
+
+        result.content = content
+        logger.info("Subscene: downloaded %s (%d bytes)", result.filename, len(content))
+        return content

--- a/backend/providers/subscene.py
+++ b/backend/providers/subscene.py
@@ -193,11 +193,13 @@ class SubsceneProvider(SubtitleProvider):
                 name_span = spans[1].get_text(strip=True) if len(spans) > 1 else ""
                 if not href:
                     continue
-                entries.append({
-                    "url": f"{_BASE_URL}{href}",
-                    "lang": lang_span,
-                    "name": name_span,
-                })
+                entries.append(
+                    {
+                        "url": f"{_BASE_URL}{href}",
+                        "lang": lang_span,
+                        "name": name_span,
+                    }
+                )
             return entries
         except Exception as e:
             logger.debug("Subscene: listing error for %s: %s", page_url, e)
@@ -215,7 +217,9 @@ class SubsceneProvider(SubtitleProvider):
                 return None
             soup = BeautifulSoup(resp.text, "html.parser")
             # Download link: <a id="downloadButton" href="/subtitle/download/...">
-            a = soup.find("a", id="downloadButton") or soup.select_one("a[href*='/subtitle/download']")
+            a = soup.find("a", id="downloadButton") or soup.select_one(
+                "a[href*='/subtitle/download']"
+            )
             if a:
                 href = a.get("href", "")
                 return f"{_BASE_URL}{href}" if href.startswith("/") else href

--- a/backend/providers/turkcealtyazi.py
+++ b/backend/providers/turkcealtyazi.py
@@ -1,0 +1,230 @@
+"""Turkcealtyazi subtitle provider.
+
+Turkcealtyazi.org is the largest Turkish subtitle community site.
+Account registration is required for downloads.
+
+Base URL: https://turkcealtyazi.org
+Auth:     Username + Password (required)
+Rate:     10 req / 60 s
+License:  GPL-3.0
+"""
+
+import io
+import logging
+import zipfile
+
+try:
+    from bs4 import BeautifulSoup
+
+    _HAS_BS4 = True
+except ImportError:
+    _HAS_BS4 = False
+
+from providers import register_provider
+from providers.base import (
+    ProviderAuthError,
+    SubtitleFormat,
+    SubtitleProvider,
+    SubtitleResult,
+    VideoQuery,
+)
+from providers.http_session import create_session
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL = "https://turkcealtyazi.org"
+_LOGIN_URL = f"{_BASE_URL}/giris"
+_SEARCH_URL = f"{_BASE_URL}/ara"
+_BROWSER_UA = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+)
+
+
+@register_provider
+class TurkcealtyaziProvider(SubtitleProvider):
+    """Turkcealtyazi subtitle provider.
+
+    Scrapes turkcealtyazi.org for Turkish subtitles. Requires a registered
+    account (username + password). Requires beautifulsoup4.
+    """
+
+    name = "turkcealtyazi"
+    languages = {"tr"}
+    config_fields = [
+        {"key": "turkcealtyazi_username", "label": "Username", "type": "text", "required": True,
+         "description": "Benutzername auf turkcealtyazi.org"},
+        {"key": "turkcealtyazi_password", "label": "Password", "type": "password", "required": True},
+    ]
+    rate_limit = (10, 60)
+    timeout = 20
+    max_retries = 2
+
+    def __init__(self, username: str = "", password: str = "", **kwargs):
+        super().__init__(**kwargs)
+        self.username = username
+        self.password = password
+        self.session = None
+        self._logged_in = False
+
+    def initialize(self):
+        if not self.username or not self.password:
+            logger.warning("Turkcealtyazi: username and password are required")
+            return
+
+        self.session = create_session(
+            max_retries=2,
+            backoff_factor=1.5,
+            timeout=self.timeout,
+            user_agent=_BROWSER_UA,
+        )
+        self.session.headers.update({
+            "Accept-Language": "tr-TR,tr;q=0.9,en;q=0.8",
+            "Referer": _BASE_URL,
+        })
+        self._login()
+
+    def terminate(self):
+        if self.session:
+            self.session.close()
+            self.session = None
+        self._logged_in = False
+
+    def health_check(self) -> tuple[bool, str]:
+        if not self.username or not self.password:
+            return False, "Credentials not configured"
+        if not self.session:
+            return False, "Not initialized"
+        if not _HAS_BS4:
+            return False, "beautifulsoup4 not installed"
+        if not self._logged_in:
+            return False, "Not logged in"
+        try:
+            resp = self.session.get(_BASE_URL, timeout=10)
+            return (True, "OK") if resp.status_code == 200 else (False, f"HTTP {resp.status_code}")
+        except Exception as e:
+            return False, str(e)
+
+    def _login(self):
+        """Login to turkcealtyazi.org."""
+        try:
+            # First, GET the login page to pick up CSRF tokens if any
+            self.session.get(_LOGIN_URL, timeout=self.timeout)
+            resp = self.session.post(
+                _LOGIN_URL,
+                data={
+                    "username": self.username,
+                    "password": self.password,
+                    "remember": "on",
+                },
+                timeout=self.timeout,
+            )
+            # Check for logged-in indicator (profile link, username in page)
+            if resp.status_code == 200 and self.username.lower() in resp.text.lower():
+                self._logged_in = True
+                logger.debug("Turkcealtyazi: logged in as %s", self.username)
+            else:
+                logger.warning("Turkcealtyazi: login failed for %s (HTTP %d)", self.username, resp.status_code)
+        except Exception as e:
+            logger.warning("Turkcealtyazi: login error: %s", e)
+
+    def search(self, query: VideoQuery) -> list[SubtitleResult]:
+        if not self.session or not self._logged_in:
+            logger.debug("Turkcealtyazi: not logged in, skipping search")
+            return []
+        if not _HAS_BS4:
+            logger.warning("Turkcealtyazi: beautifulsoup4 not installed")
+            return []
+        if "tr" not in (query.languages or []):
+            return []
+
+        search_title = query.series_title or query.title
+        if not search_title:
+            return []
+
+        logger.debug("Turkcealtyazi: searching '%s'", search_title)
+
+        try:
+            resp = self.session.get(
+                f"{_SEARCH_URL}/{search_title}",
+                timeout=self.timeout,
+            )
+            if resp.status_code != 200:
+                return []
+            soup = BeautifulSoup(resp.text, "html.parser")
+            results = []
+            # Result rows: links to subtitle pages
+            for a in soup.select("a[href*='/alt/']"):
+                href = a.get("href", "")
+                name = a.get_text(strip=True)
+                if not href or not name:
+                    continue
+                url = href if href.startswith("http") else f"{_BASE_URL}{href}"
+                subtitle_id = url.rstrip("/").split("/")[-1]
+                results.append(
+                    SubtitleResult(
+                        provider_name=self.name,
+                        subtitle_id=subtitle_id,
+                        language="tr",
+                        format=SubtitleFormat.SRT,
+                        filename=f"{name}.srt",
+                        download_url=url,
+                        release_info=name,
+                        matches={"series"} if query.series_title else set(),
+                        provider_data={"detail_url": url},
+                    )
+                )
+
+            logger.info("Turkcealtyazi: found %d results", len(results))
+            return results
+        except Exception as e:
+            logger.debug("Turkcealtyazi: search error: %s", e)
+            return []
+
+    def _get_download_url(self, detail_url: str) -> str | None:
+        """Follow the subtitle detail page to find the actual download link."""
+        try:
+            resp = self.session.get(detail_url, timeout=self.timeout)
+            if resp.status_code != 200:
+                return None
+            soup = BeautifulSoup(resp.text, "html.parser")
+            # Download button: <a class="btn" href="/indir/..."> or similar
+            for a in soup.select("a[href*='/indir/'], a[href*='/download/']"):
+                href = a.get("href", "")
+                if href:
+                    return href if href.startswith("http") else f"{_BASE_URL}{href}"
+        except Exception as e:
+            logger.debug("Turkcealtyazi: detail page error: %s", e)
+        return None
+
+    def download(self, result: SubtitleResult) -> bytes:
+        if not self.session:
+            raise RuntimeError("Turkcealtyazi not initialized")
+        if not self._logged_in:
+            raise ProviderAuthError("Turkcealtyazi: not logged in")
+
+        detail_url = (result.provider_data or {}).get("detail_url") or result.download_url
+        dl_url = self._get_download_url(detail_url)
+        if not dl_url:
+            raise RuntimeError(f"Turkcealtyazi: no download URL found on {detail_url}")
+
+        resp = self.session.get(dl_url, headers={"Referer": detail_url}, timeout=self.timeout)
+        if resp.status_code != 200:
+            raise RuntimeError(f"Turkcealtyazi download failed: HTTP {resp.status_code}")
+
+        content = resp.content
+
+        if content[:2] == b"PK":
+            try:
+                with zipfile.ZipFile(io.BytesIO(content)) as zf:
+                    for name in zf.namelist():
+                        if name.lower().endswith((".srt", ".ass", ".ssa", ".vtt")):
+                            content = zf.read(name)
+                            result.filename = name
+                            break
+            except Exception as e:
+                logger.warning("Turkcealtyazi: ZIP extraction failed: %s", e)
+
+        result.content = content
+        logger.info("Turkcealtyazi: downloaded %s (%d bytes)", result.filename, len(content))
+        return content

--- a/backend/providers/turkcealtyazi.py
+++ b/backend/providers/turkcealtyazi.py
@@ -52,9 +52,19 @@ class TurkcealtyaziProvider(SubtitleProvider):
     name = "turkcealtyazi"
     languages = {"tr"}
     config_fields = [
-        {"key": "turkcealtyazi_username", "label": "Username", "type": "text", "required": True,
-         "description": "Benutzername auf turkcealtyazi.org"},
-        {"key": "turkcealtyazi_password", "label": "Password", "type": "password", "required": True},
+        {
+            "key": "turkcealtyazi_username",
+            "label": "Username",
+            "type": "text",
+            "required": True,
+            "description": "Benutzername auf turkcealtyazi.org",
+        },
+        {
+            "key": "turkcealtyazi_password",
+            "label": "Password",
+            "type": "password",
+            "required": True,
+        },
     ]
     rate_limit = (10, 60)
     timeout = 20
@@ -78,10 +88,12 @@ class TurkcealtyaziProvider(SubtitleProvider):
             timeout=self.timeout,
             user_agent=_BROWSER_UA,
         )
-        self.session.headers.update({
-            "Accept-Language": "tr-TR,tr;q=0.9,en;q=0.8",
-            "Referer": _BASE_URL,
-        })
+        self.session.headers.update(
+            {
+                "Accept-Language": "tr-TR,tr;q=0.9,en;q=0.8",
+                "Referer": _BASE_URL,
+            }
+        )
         self._login()
 
     def terminate(self):
@@ -124,7 +136,9 @@ class TurkcealtyaziProvider(SubtitleProvider):
                 self._logged_in = True
                 logger.debug("Turkcealtyazi: logged in as %s", self.username)
             else:
-                logger.warning("Turkcealtyazi: login failed for %s (HTTP %d)", self.username, resp.status_code)
+                logger.warning(
+                    "Turkcealtyazi: login failed for %s (HTTP %d)", self.username, resp.status_code
+                )
         except Exception as e:
             logger.warning("Turkcealtyazi: login error: %s", e)
 

--- a/backend/providers/tvsubtitles.py
+++ b/backend/providers/tvsubtitles.py
@@ -151,7 +151,9 @@ class TVSubtitlesProvider(SubtitleProvider):
             logger.debug("TVSubtitles: show search error: %s", e)
         return None
 
-    def _get_episode_subtitles(self, show_id: str, season: int, episode: int, lang_name: str) -> list[dict]:
+    def _get_episode_subtitles(
+        self, show_id: str, season: int, episode: int, lang_name: str
+    ) -> list[dict]:
         """Fetch subtitle entries for a specific episode and language."""
         try:
             # Try episode page: /episode-{show_id}-{season}x{episode}.html
@@ -173,10 +175,12 @@ class TVSubtitlesProvider(SubtitleProvider):
                     continue
                 href = dl_link.get("href", "")
                 release = cells[1].get_text(strip=True) if len(cells) > 1 else ""
-                entries.append({
-                    "url": f"{_BASE_URL}{href}" if href.startswith("/") else href,
-                    "release": release,
-                })
+                entries.append(
+                    {
+                        "url": f"{_BASE_URL}{href}" if href.startswith("/") else href,
+                        "release": release,
+                    }
+                )
             return entries
         except Exception as e:
             logger.debug("TVSubtitles: episode fetch error: %s", e)
@@ -197,7 +201,12 @@ class TVSubtitlesProvider(SubtitleProvider):
         if not search_title:
             return []
 
-        logger.debug("TVSubtitles: searching '%s' S%02dE%02d", search_title, query.season or 0, query.episode or 0)
+        logger.debug(
+            "TVSubtitles: searching '%s' S%02dE%02d",
+            search_title,
+            query.season or 0,
+            query.episode or 0,
+        )
 
         show = self._find_show(search_title)
         if not show:
@@ -222,7 +231,9 @@ class TVSubtitlesProvider(SubtitleProvider):
                         subtitle_id=subtitle_id,
                         language=lang_code,
                         format=SubtitleFormat.SRT,
-                        filename=f"{entry['release']}.srt" if entry["release"] else f"{subtitle_id}.srt",
+                        filename=f"{entry['release']}.srt"
+                        if entry["release"]
+                        else f"{subtitle_id}.srt",
                         download_url=entry["url"],
                         release_info=entry["release"],
                         matches={"series", "season", "episode"},

--- a/backend/providers/tvsubtitles.py
+++ b/backend/providers/tvsubtitles.py
@@ -1,0 +1,264 @@
+"""TVSubtitles subtitle provider.
+
+TVSubtitles is a long-running subtitle aggregator specialising in TV series.
+Supports many European and Asian languages. No authentication required.
+
+Base URL: https://www.tvsubtitles.net
+Auth:     None required
+Rate:     15 req / 60 s
+License:  GPL-3.0
+"""
+
+import io
+import logging
+import zipfile
+
+try:
+    from bs4 import BeautifulSoup
+
+    _HAS_BS4 = True
+except ImportError:
+    _HAS_BS4 = False
+
+from providers import register_provider
+from providers.base import (
+    SubtitleFormat,
+    SubtitleProvider,
+    SubtitleResult,
+    VideoQuery,
+)
+from providers.http_session import create_session
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL = "https://www.tvsubtitles.net"
+_BROWSER_UA = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+)
+
+# TVSubtitles language names in HTML (lowercase, as used in class/text)
+_LANG_NAMES = {
+    "ar": "arabic",
+    "bg": "bulgarian",
+    "cs": "czech",
+    "da": "danish",
+    "nl": "dutch",
+    "en": "english",
+    "fi": "finnish",
+    "fr": "french",
+    "de": "german",
+    "el": "greek",
+    "he": "hebrew",
+    "hr": "croatian",
+    "hu": "hungarian",
+    "id": "indonesian",
+    "it": "italian",
+    "ja": "japanese",
+    "ko": "korean",
+    "ms": "malay",
+    "no": "norwegian",
+    "pl": "polish",
+    "pt": "portuguese",
+    "ro": "romanian",
+    "ru": "russian",
+    "sr": "serbian",
+    "sk": "slovak",
+    "sl": "slovenian",
+    "es": "spanish",
+    "sv": "swedish",
+    "th": "thai",
+    "tr": "turkish",
+    "uk": "ukrainian",
+    "vi": "vietnamese",
+    "zh": "chinese",
+    "zh-hans": "chinese",
+    "zh-hant": "chinese",
+}
+
+
+@register_provider
+class TVSubtitlesProvider(SubtitleProvider):
+    """TVSubtitles subtitle provider.
+
+    Specialises in TV series subtitles with broad language support.
+    Uses HTML scraping via BeautifulSoup4.
+    """
+
+    name = "tvsubtitles"
+    languages = set(_LANG_NAMES.keys())
+    config_fields = []
+    rate_limit = (15, 60)
+    timeout = 20
+    max_retries = 2
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.session = None
+
+    def initialize(self):
+        self.session = create_session(
+            max_retries=2,
+            backoff_factor=1.5,
+            timeout=self.timeout,
+            user_agent=_BROWSER_UA,
+        )
+        self.session.headers.update({"Accept-Language": "en-US,en;q=0.9"})
+
+    def terminate(self):
+        if self.session:
+            self.session.close()
+            self.session = None
+
+    def health_check(self) -> tuple[bool, str]:
+        if not self.session:
+            return False, "Not initialized"
+        if not _HAS_BS4:
+            return False, "beautifulsoup4 not installed"
+        try:
+            resp = self.session.get(_BASE_URL, timeout=10)
+            return (True, "OK") if resp.status_code == 200 else (False, f"HTTP {resp.status_code}")
+        except Exception as e:
+            return False, str(e)
+
+    def _find_show(self, title: str) -> dict | None:
+        """Search for a show by title, return {id, name} or None."""
+        try:
+            resp = self.session.post(
+                f"{_BASE_URL}/search.php",
+                data={"q": title},
+                headers={"Referer": _BASE_URL},
+                timeout=self.timeout,
+            )
+            if resp.status_code != 200:
+                return None
+            soup = BeautifulSoup(resp.text, "html.parser")
+            # Results: <ul id="r" class="left"> with <a href="/tvshow-{id}.html">
+            for a in soup.select("ul#r a[href*='tvshow-']"):
+                href = a.get("href", "")
+                name = a.get_text(strip=True)
+                if href and name and title.lower() in name.lower():
+                    show_id = href.replace("/tvshow-", "").replace(".html", "").strip("/")
+                    return {"id": show_id, "name": name, "url": f"{_BASE_URL}{href}"}
+            # Fallback: first result
+            first = soup.select_one("ul#r a[href*='tvshow-']")
+            if first:
+                href = first.get("href", "")
+                name = first.get_text(strip=True)
+                show_id = href.replace("/tvshow-", "").replace(".html", "").strip("/")
+                return {"id": show_id, "name": name, "url": f"{_BASE_URL}{href}"}
+        except Exception as e:
+            logger.debug("TVSubtitles: show search error: %s", e)
+        return None
+
+    def _get_episode_subtitles(self, show_id: str, season: int, episode: int, lang_name: str) -> list[dict]:
+        """Fetch subtitle entries for a specific episode and language."""
+        try:
+            # Try episode page: /episode-{show_id}-{season}x{episode}.html
+            ep_url = f"{_BASE_URL}/episode-{show_id}-{season}x{episode}.html"
+            resp = self.session.get(ep_url, timeout=self.timeout)
+            if resp.status_code != 200:
+                return []
+            soup = BeautifulSoup(resp.text, "html.parser")
+            entries = []
+            for row in soup.select("table tr"):
+                cells = row.find_all("td")
+                if len(cells) < 3:
+                    continue
+                lang_cell = cells[0].get_text(strip=True).lower()
+                if lang_name not in lang_cell:
+                    continue
+                dl_link = row.find("a", href=lambda h: h and "download" in h)
+                if not dl_link:
+                    continue
+                href = dl_link.get("href", "")
+                release = cells[1].get_text(strip=True) if len(cells) > 1 else ""
+                entries.append({
+                    "url": f"{_BASE_URL}{href}" if href.startswith("/") else href,
+                    "release": release,
+                })
+            return entries
+        except Exception as e:
+            logger.debug("TVSubtitles: episode fetch error: %s", e)
+            return []
+
+    def search(self, query: VideoQuery) -> list[SubtitleResult]:
+        if not self.session:
+            return []
+        if not _HAS_BS4:
+            logger.warning("TVSubtitles: beautifulsoup4 not installed")
+            return []
+
+        # TV shows only
+        if query.is_movie or not query.is_episode:
+            return []
+
+        search_title = query.series_title or query.title
+        if not search_title:
+            return []
+
+        logger.debug("TVSubtitles: searching '%s' S%02dE%02d", search_title, query.season or 0, query.episode or 0)
+
+        show = self._find_show(search_title)
+        if not show:
+            logger.debug("TVSubtitles: show not found for '%s'", search_title)
+            return []
+
+        results = []
+        search_langs = query.languages or ["en"]
+
+        for lang_code in search_langs:
+            lang_name = _LANG_NAMES.get(lang_code)
+            if not lang_name:
+                continue
+            entries = self._get_episode_subtitles(
+                show["id"], query.season or 1, query.episode or 1, lang_name
+            )
+            for entry in entries[:5]:
+                subtitle_id = entry["url"].rstrip("/").split("/")[-1]
+                results.append(
+                    SubtitleResult(
+                        provider_name=self.name,
+                        subtitle_id=subtitle_id,
+                        language=lang_code,
+                        format=SubtitleFormat.SRT,
+                        filename=f"{entry['release']}.srt" if entry["release"] else f"{subtitle_id}.srt",
+                        download_url=entry["url"],
+                        release_info=entry["release"],
+                        matches={"series", "season", "episode"},
+                        provider_data={"show_name": show["name"]},
+                    )
+                )
+
+        logger.info("TVSubtitles: found %d results", len(results))
+        return results
+
+    def download(self, result: SubtitleResult) -> bytes:
+        if not self.session:
+            raise RuntimeError("TVSubtitles not initialized")
+
+        resp = self.session.get(
+            result.download_url,
+            headers={"Referer": _BASE_URL},
+            timeout=self.timeout,
+        )
+        if resp.status_code != 200:
+            raise RuntimeError(f"TVSubtitles download failed: HTTP {resp.status_code}")
+
+        content = resp.content
+
+        # Extract from ZIP if needed
+        if content[:2] == b"PK":
+            try:
+                with zipfile.ZipFile(io.BytesIO(content)) as zf:
+                    for name in zf.namelist():
+                        if name.lower().endswith((".srt", ".ass", ".ssa", ".vtt")):
+                            content = zf.read(name)
+                            result.filename = name
+                            break
+            except Exception as e:
+                logger.warning("TVSubtitles: ZIP extraction failed: %s", e)
+
+        result.content = content
+        logger.info("TVSubtitles: downloaded %s (%d bytes)", result.filename, len(content))
+        return content

--- a/backend/routes/__init__.py
+++ b/backend/routes/__init__.py
@@ -16,6 +16,7 @@ def register_blueprints(app):
     from routes.filter_presets import bp as filter_presets_bp
     from routes.hooks import bp as hooks_bp
     from routes.integrations import bp as integrations_bp
+    from routes.languages import bp as languages_bp
     from routes.library import bp as library_bp
     from routes.marketplace import bp as marketplace_bp
     from routes.mediaservers import bp as mediaservers_bp
@@ -60,6 +61,7 @@ def register_blueprints(app):
         notifications_mgmt_bp,
         cleanup_bp,
         integrations_bp,
+        languages_bp,
         audio_bp,
         spell_bp,
         ocr_bp,

--- a/backend/routes/config.py
+++ b/backend/routes/config.py
@@ -184,6 +184,7 @@ def update_config():
     from mediaserver import invalidate_media_server_manager as _inv_media
     from notifier import invalidate_notifier as _inv_notifier
     from providers import invalidate_manager as _inv_providers
+    from providers import update_manager_providers as _upd_providers
     from radarr_client import invalidate_client as _inv_radarr
     from sonarr_client import invalidate_client as _inv_sonarr
 
@@ -191,21 +192,19 @@ def update_config():
         _inv_sonarr()
     if any(k.startswith("radarr_") for k in saved_keys):
         _inv_radarr()
-    if any(
-        k.startswith("provider")
-        or k.startswith("scoring_")
-        or k
-        in {
-            "opensubtitles_api_key",
-            "jimaku_api_key",
-            "subdl_api_key",
-            "min_score",
-            "source_language",
-            "target_language",
-        }
-        for k in saved_keys
-    ):
-        _inv_providers()
+
+    _credential_keys = {"opensubtitles_api_key", "jimaku_api_key", "subdl_api_key",
+                        "min_score", "source_language", "target_language"}
+    _provider_keys = {k for k in saved_keys
+                      if k.startswith("provider") or k.startswith("scoring_")
+                      or k in _credential_keys}
+    if _provider_keys:
+        if _provider_keys == {"providers_enabled"}:
+            # Only the enabled-set changed: selectively add/remove, keep others intact
+            _upd_providers(all_overrides.get("providers_enabled", ""))
+        else:
+            # Credentials or other provider config changed: full reinit
+            _inv_providers()
     if any(
         k.startswith("jellyfin_")
         or k.startswith("emby_")

--- a/backend/routes/config.py
+++ b/backend/routes/config.py
@@ -193,13 +193,21 @@ def update_config():
     if any(k.startswith("radarr_") for k in saved_keys):
         _inv_radarr()
 
-    _credential_keys = {"opensubtitles_api_key", "jimaku_api_key", "subdl_api_key",
-                        "min_score", "source_language", "target_language"}
+    _credential_keys = {
+        "opensubtitles_api_key",
+        "jimaku_api_key",
+        "subdl_api_key",
+        "min_score",
+        "source_language",
+        "target_language",
+    }
     # providers_hidden is UI-only; exclude it from backend provider invalidation
-    _provider_keys = {k for k in saved_keys
-                      if (k.startswith("provider") or k.startswith("scoring_")
-                          or k in _credential_keys)
-                      and k != "providers_hidden"}
+    _provider_keys = {
+        k
+        for k in saved_keys
+        if (k.startswith("provider") or k.startswith("scoring_") or k in _credential_keys)
+        and k != "providers_hidden"
+    }
     if _provider_keys:
         if _provider_keys == {"providers_enabled"}:
             # Only the enabled-set changed: selectively add/remove, keep others intact

--- a/backend/routes/config.py
+++ b/backend/routes/config.py
@@ -195,9 +195,11 @@ def update_config():
 
     _credential_keys = {"opensubtitles_api_key", "jimaku_api_key", "subdl_api_key",
                         "min_score", "source_language", "target_language"}
+    # providers_hidden is UI-only; exclude it from backend provider invalidation
     _provider_keys = {k for k in saved_keys
-                      if k.startswith("provider") or k.startswith("scoring_")
-                      or k in _credential_keys}
+                      if (k.startswith("provider") or k.startswith("scoring_")
+                          or k in _credential_keys)
+                      and k != "providers_hidden"}
     if _provider_keys:
         if _provider_keys == {"providers_enabled"}:
             # Only the enabled-set changed: selectively add/remove, keep others intact

--- a/backend/routes/config.py
+++ b/backend/routes/config.py
@@ -192,7 +192,7 @@ def update_config():
     if any(k.startswith("radarr_") for k in saved_keys):
         _inv_radarr()
     if any(
-        k.startswith("provider_")
+        k.startswith("provider")
         or k.startswith("scoring_")
         or k
         in {

--- a/backend/routes/languages.py
+++ b/backend/routes/languages.py
@@ -1,0 +1,39 @@
+"""Languages route — /api/v1/languages."""
+
+from flask import Blueprint, jsonify
+
+from cache_response import cached_get
+
+bp = Blueprint("languages", __name__, url_prefix="/api/v1")
+
+
+@bp.route("/languages", methods=["GET"])
+@cached_get(ttl_seconds=3600)
+def get_languages():
+    """Return the list of supported languages for the UI language picker.
+    ---
+    get:
+      tags:
+        - Config
+      summary: Supported languages
+      description: Returns all languages supported by Sublarr, ordered alphabetically by name.
+      responses:
+        200:
+          description: List of language objects
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    code:
+                      type: string
+                      description: ISO 639-1 language code (e.g. "de")
+                    name:
+                      type: string
+                      description: English language name (e.g. "German")
+    """
+    from config import SUPPORTED_LANGUAGES
+
+    return jsonify(SUPPORTED_LANGUAGES)

--- a/backend/tests/test_new_providers.py
+++ b/backend/tests/test_new_providers.py
@@ -1,0 +1,492 @@
+"""Unit tests for the 4 new subtitle providers."""
+
+from unittest.mock import MagicMock, patch
+
+
+class TestSubsceneProvider:
+    """Tests for the Subscene provider."""
+
+    def test_import_and_name(self):
+        from providers.subscene import SubsceneProvider
+
+        p = SubsceneProvider()
+        assert p.name == "subscene"
+
+    def test_languages(self):
+        from providers.subscene import SubsceneProvider
+
+        p = SubsceneProvider()
+        assert "en" in p.languages
+        assert "de" in p.languages
+        assert "ja" in p.languages
+        assert len(p.languages) >= 50
+
+    def test_no_credentials_required(self):
+        from providers.subscene import SubsceneProvider
+
+        p = SubsceneProvider()
+        assert p.config_fields == []
+
+    def test_health_check_not_initialized(self):
+        from providers.subscene import SubsceneProvider
+
+        p = SubsceneProvider()
+        healthy, msg = p.health_check()
+        assert not healthy
+
+    def test_initialize_creates_session(self):
+        from providers.subscene import SubsceneProvider
+
+        p = SubsceneProvider()
+        with patch("providers.subscene.create_session") as mock_cs:
+            mock_session = MagicMock()
+            mock_cs.return_value = mock_session
+            p.initialize()
+            assert p.session is not None
+
+    def test_terminate_closes_session(self):
+        from providers.subscene import SubsceneProvider
+
+        p = SubsceneProvider()
+        p.session = MagicMock()
+        p.terminate()
+        assert p.session is None
+
+    def test_search_returns_empty_without_session(self):
+        from providers.base import VideoQuery
+        from providers.subscene import SubsceneProvider
+
+        p = SubsceneProvider()
+        q = VideoQuery(title="Test", languages=["en"])
+        assert p.search(q) == []
+
+    def test_search_skips_unsupported_language(self):
+        from providers.base import VideoQuery
+        from providers.subscene import SubsceneProvider
+
+        p = SubsceneProvider()
+        p.session = MagicMock()
+        q = VideoQuery(title="Test", languages=["xx-unknown"])
+        # All unknown langs → no requests made, empty result
+        with patch("providers.subscene._HAS_BS4", True):
+            result = p.search(q)
+        assert result == []
+
+    def test_download_raises_without_session(self):
+        import pytest
+
+        from providers.base import SubtitleResult
+        from providers.subscene import SubsceneProvider
+
+        p = SubsceneProvider()
+        r = SubtitleResult(
+            provider_name="subscene",
+            subtitle_id="1",
+            language="en",
+            download_url="https://example.com",
+        )
+        with pytest.raises(RuntimeError):
+            p.download(r)
+
+    def test_no_bs4_health_check(self):
+        from providers.subscene import SubsceneProvider
+
+        p = SubsceneProvider()
+        p.session = MagicMock()
+        with patch("providers.subscene._HAS_BS4", False):
+            healthy, msg = p.health_check()
+            assert not healthy
+            assert "beautifulsoup4" in msg.lower()
+
+    def test_no_bs4_search_returns_empty(self):
+        from providers.base import VideoQuery
+        from providers.subscene import SubsceneProvider
+
+        p = SubsceneProvider()
+        p.session = MagicMock()
+        q = VideoQuery(title="Test", languages=["en"])
+        with patch("providers.subscene._HAS_BS4", False):
+            result = p.search(q)
+        assert result == []
+
+
+class TestTVSubtitlesProvider:
+    """Tests for the TVSubtitles provider."""
+
+    def test_import_and_name(self):
+        from providers.tvsubtitles import TVSubtitlesProvider
+
+        p = TVSubtitlesProvider()
+        assert p.name == "tvsubtitles"
+
+    def test_languages(self):
+        from providers.tvsubtitles import TVSubtitlesProvider
+
+        p = TVSubtitlesProvider()
+        assert "en" in p.languages
+        assert "de" in p.languages
+        assert len(p.languages) >= 25
+
+    def test_no_credentials_required(self):
+        from providers.tvsubtitles import TVSubtitlesProvider
+
+        p = TVSubtitlesProvider()
+        assert p.config_fields == []
+
+    def test_health_check_not_initialized(self):
+        from providers.tvsubtitles import TVSubtitlesProvider
+
+        p = TVSubtitlesProvider()
+        healthy, msg = p.health_check()
+        assert not healthy
+
+    def test_initialize_creates_session(self):
+        from providers.tvsubtitles import TVSubtitlesProvider
+
+        p = TVSubtitlesProvider()
+        with patch("providers.tvsubtitles.create_session") as mock_cs:
+            mock_cs.return_value = MagicMock()
+            p.initialize()
+            assert p.session is not None
+
+    def test_terminate_closes_session(self):
+        from providers.tvsubtitles import TVSubtitlesProvider
+
+        p = TVSubtitlesProvider()
+        p.session = MagicMock()
+        p.terminate()
+        assert p.session is None
+
+    def test_search_returns_empty_without_session(self):
+        from providers.base import VideoQuery
+        from providers.tvsubtitles import TVSubtitlesProvider
+
+        p = TVSubtitlesProvider()
+        q = VideoQuery(title="Test", languages=["en"])
+        assert p.search(q) == []
+
+    def test_search_skips_movies(self):
+        from providers.base import VideoQuery
+        from providers.tvsubtitles import TVSubtitlesProvider
+
+        p = TVSubtitlesProvider()
+        p.session = MagicMock()
+        q = VideoQuery(title="Inception", languages=["en"])
+        with patch("providers.tvsubtitles._HAS_BS4", True), \
+             patch.object(type(q), "is_movie", new_callable=lambda: property(lambda self: True)):
+            result = p.search(q)
+        assert result == []
+
+    def test_download_raises_without_session(self):
+        import pytest
+
+        from providers.base import SubtitleResult
+        from providers.tvsubtitles import TVSubtitlesProvider
+
+        p = TVSubtitlesProvider()
+        r = SubtitleResult(
+            provider_name="tvsubtitles",
+            subtitle_id="1",
+            language="en",
+            download_url="https://example.com",
+        )
+        with pytest.raises(RuntimeError):
+            p.download(r)
+
+    def test_no_bs4_health_check(self):
+        from providers.tvsubtitles import TVSubtitlesProvider
+
+        p = TVSubtitlesProvider()
+        p.session = MagicMock()
+        with patch("providers.tvsubtitles._HAS_BS4", False):
+            healthy, msg = p.health_check()
+            assert not healthy
+            assert "beautifulsoup4" in msg.lower()
+
+    def test_no_bs4_search_returns_empty(self):
+        from providers.base import VideoQuery
+        from providers.tvsubtitles import TVSubtitlesProvider
+
+        p = TVSubtitlesProvider()
+        p.session = MagicMock()
+        q = VideoQuery(title="Test", languages=["en"])
+        with patch("providers.tvsubtitles._HAS_BS4", False):
+            result = p.search(q)
+        assert result == []
+
+
+class TestAddic7edProvider:
+    """Tests for the Addic7ed provider."""
+
+    def test_import_and_name(self):
+        from providers.addic7ed import Addic7edProvider
+
+        p = Addic7edProvider()
+        assert p.name == "addic7ed"
+
+    def test_languages(self):
+        from providers.addic7ed import Addic7edProvider
+
+        p = Addic7edProvider()
+        assert "en" in p.languages
+        assert "de" in p.languages
+        assert len(p.languages) >= 30
+
+    def test_credentials_optional(self):
+        from providers.addic7ed import Addic7edProvider
+
+        p = Addic7edProvider()
+        fields = {f["key"]: f for f in p.config_fields}
+        assert "addic7ed_username" in fields
+        assert fields["addic7ed_username"]["required"] is False
+        assert "addic7ed_password" in fields
+        assert fields["addic7ed_password"]["required"] is False
+
+    def test_health_check_not_initialized(self):
+        from providers.addic7ed import Addic7edProvider
+
+        p = Addic7edProvider()
+        healthy, msg = p.health_check()
+        assert not healthy
+
+    def test_initialize_creates_session(self):
+        from providers.addic7ed import Addic7edProvider
+
+        p = Addic7edProvider()
+        with patch("providers.addic7ed.create_session") as mock_cs:
+            mock_cs.return_value = MagicMock()
+            p.initialize()
+            assert p.session is not None
+
+    def test_initialize_without_credentials_no_login(self):
+        from providers.addic7ed import Addic7edProvider
+
+        p = Addic7edProvider()
+        with patch("providers.addic7ed.create_session") as mock_cs:
+            mock_cs.return_value = MagicMock()
+            with patch.object(p, "_login") as mock_login:
+                p.initialize()
+                mock_login.assert_not_called()
+        assert not p._logged_in
+
+    def test_initialize_with_credentials_calls_login(self):
+        from providers.addic7ed import Addic7edProvider
+
+        p = Addic7edProvider(username="user", password="pass")
+        with patch("providers.addic7ed.create_session") as mock_cs:
+            mock_cs.return_value = MagicMock()
+            with patch.object(p, "_login") as mock_login:
+                p.initialize()
+                mock_login.assert_called_once()
+
+    def test_terminate_closes_session(self):
+        from providers.addic7ed import Addic7edProvider
+
+        p = Addic7edProvider()
+        p.session = MagicMock()
+        p.terminate()
+        assert p.session is None
+
+    def test_search_returns_empty_without_session(self):
+        from providers.base import VideoQuery
+        from providers.addic7ed import Addic7edProvider
+
+        p = Addic7edProvider()
+        q = VideoQuery(title="Test", languages=["en"])
+        assert p.search(q) == []
+
+    def test_search_skips_movies(self):
+        from providers.base import VideoQuery
+        from providers.addic7ed import Addic7edProvider
+
+        p = Addic7edProvider()
+        p.session = MagicMock()
+        q = VideoQuery(title="Inception", languages=["en"])
+        with patch("providers.addic7ed._HAS_BS4", True), \
+             patch.object(type(q), "is_movie", new_callable=lambda: property(lambda self: True)):
+            result = p.search(q)
+        assert result == []
+
+    def test_download_raises_without_session(self):
+        import pytest
+
+        from providers.base import SubtitleResult
+        from providers.addic7ed import Addic7edProvider
+
+        p = Addic7edProvider()
+        r = SubtitleResult(
+            provider_name="addic7ed",
+            subtitle_id="1",
+            language="en",
+            download_url="https://example.com",
+        )
+        with pytest.raises(RuntimeError):
+            p.download(r)
+
+    def test_no_bs4_health_check(self):
+        from providers.addic7ed import Addic7edProvider
+
+        p = Addic7edProvider()
+        p.session = MagicMock()
+        with patch("providers.addic7ed._HAS_BS4", False):
+            healthy, msg = p.health_check()
+            assert not healthy
+            assert "beautifulsoup4" in msg.lower()
+
+    def test_no_bs4_search_returns_empty(self):
+        from providers.base import VideoQuery
+        from providers.addic7ed import Addic7edProvider
+
+        p = Addic7edProvider()
+        p.session = MagicMock()
+        q = VideoQuery(title="Test", languages=["en"])
+        with patch("providers.addic7ed._HAS_BS4", False):
+            result = p.search(q)
+        assert result == []
+
+
+class TestTurkcealtyaziProvider:
+    """Tests for the Turkcealtyazi provider."""
+
+    def test_import_and_name(self):
+        from providers.turkcealtyazi import TurkcealtyaziProvider
+
+        p = TurkcealtyaziProvider()
+        assert p.name == "turkcealtyazi"
+
+    def test_languages(self):
+        from providers.turkcealtyazi import TurkcealtyaziProvider
+
+        p = TurkcealtyaziProvider()
+        assert "tr" in p.languages
+        assert len(p.languages) == 1
+
+    def test_credentials_required(self):
+        from providers.turkcealtyazi import TurkcealtyaziProvider
+
+        p = TurkcealtyaziProvider()
+        fields = {f["key"]: f for f in p.config_fields}
+        assert "turkcealtyazi_username" in fields
+        assert fields["turkcealtyazi_username"]["required"] is True
+        assert "turkcealtyazi_password" in fields
+        assert fields["turkcealtyazi_password"]["required"] is True
+
+    def test_health_check_missing_credentials(self):
+        from providers.turkcealtyazi import TurkcealtyaziProvider
+
+        p = TurkcealtyaziProvider()
+        healthy, msg = p.health_check()
+        assert not healthy
+        assert "credential" in msg.lower() or "configured" in msg.lower()
+
+    def test_health_check_not_logged_in(self):
+        from providers.turkcealtyazi import TurkcealtyaziProvider
+
+        p = TurkcealtyaziProvider(username="u", password="p")
+        p.session = MagicMock()
+        with patch("providers.turkcealtyazi._HAS_BS4", True):
+            healthy, msg = p.health_check()
+            assert not healthy
+
+    def test_initialize_without_credentials_skips(self):
+        from providers.turkcealtyazi import TurkcealtyaziProvider
+
+        p = TurkcealtyaziProvider()
+        p.initialize()
+        assert p.session is None
+
+    def test_initialize_with_credentials_creates_session(self):
+        from providers.turkcealtyazi import TurkcealtyaziProvider
+
+        p = TurkcealtyaziProvider(username="user", password="pass")
+        with patch("providers.turkcealtyazi.create_session") as mock_cs:
+            mock_session = MagicMock()
+            mock_cs.return_value = mock_session
+            with patch.object(p, "_login"):
+                p.initialize()
+                assert p.session is not None
+
+    def test_terminate_closes_session(self):
+        from providers.turkcealtyazi import TurkcealtyaziProvider
+
+        p = TurkcealtyaziProvider()
+        p.session = MagicMock()
+        p.terminate()
+        assert p.session is None
+        assert not p._logged_in
+
+    def test_search_returns_empty_not_logged_in(self):
+        from providers.base import VideoQuery
+        from providers.turkcealtyazi import TurkcealtyaziProvider
+
+        p = TurkcealtyaziProvider()
+        q = VideoQuery(title="Test", languages=["tr"])
+        assert p.search(q) == []
+
+    def test_search_skips_non_turkish(self):
+        from providers.base import VideoQuery
+        from providers.turkcealtyazi import TurkcealtyaziProvider
+
+        p = TurkcealtyaziProvider(username="u", password="p")
+        p.session = MagicMock()
+        p._logged_in = True
+        q = VideoQuery(title="Test", languages=["en"])
+        with patch("providers.turkcealtyazi._HAS_BS4", True):
+            result = p.search(q)
+        assert result == []
+
+    def test_download_raises_without_session(self):
+        import pytest
+
+        from providers.base import SubtitleResult
+        from providers.turkcealtyazi import TurkcealtyaziProvider
+
+        p = TurkcealtyaziProvider()
+        r = SubtitleResult(
+            provider_name="turkcealtyazi",
+            subtitle_id="1",
+            language="tr",
+            download_url="https://example.com",
+        )
+        with pytest.raises(RuntimeError):
+            p.download(r)
+
+    def test_download_raises_not_logged_in(self):
+        import pytest
+
+        from providers.base import SubtitleResult
+        from providers.turkcealtyazi import TurkcealtyaziProvider
+
+        p = TurkcealtyaziProvider()
+        p.session = MagicMock()
+        r = SubtitleResult(
+            provider_name="turkcealtyazi",
+            subtitle_id="1",
+            language="tr",
+            download_url="https://example.com",
+        )
+        with pytest.raises(Exception):
+            p.download(r)
+
+    def test_no_bs4_health_check(self):
+        from providers.turkcealtyazi import TurkcealtyaziProvider
+
+        p = TurkcealtyaziProvider(username="u", password="p")
+        p.session = MagicMock()
+        p._logged_in = True
+        with patch("providers.turkcealtyazi._HAS_BS4", False):
+            healthy, msg = p.health_check()
+            assert not healthy
+            assert "beautifulsoup4" in msg.lower()
+
+    def test_no_bs4_search_returns_empty(self):
+        from providers.base import VideoQuery
+        from providers.turkcealtyazi import TurkcealtyaziProvider
+
+        p = TurkcealtyaziProvider(username="u", password="p")
+        p.session = MagicMock()
+        p._logged_in = True
+        q = VideoQuery(title="Test", languages=["tr"])
+        with patch("providers.turkcealtyazi._HAS_BS4", False):
+            result = p.search(q)
+        assert result == []

--- a/backend/tests/test_new_providers.py
+++ b/backend/tests/test_new_providers.py
@@ -172,8 +172,10 @@ class TestTVSubtitlesProvider:
         p = TVSubtitlesProvider()
         p.session = MagicMock()
         q = VideoQuery(title="Inception", languages=["en"])
-        with patch("providers.tvsubtitles._HAS_BS4", True), \
-             patch.object(type(q), "is_movie", new_callable=lambda: property(lambda self: True)):
+        with (
+            patch("providers.tvsubtitles._HAS_BS4", True),
+            patch.object(type(q), "is_movie", new_callable=lambda: property(lambda self: True)),
+        ):
             result = p.search(q)
         assert result == []
 
@@ -288,30 +290,32 @@ class TestAddic7edProvider:
         assert p.session is None
 
     def test_search_returns_empty_without_session(self):
-        from providers.base import VideoQuery
         from providers.addic7ed import Addic7edProvider
+        from providers.base import VideoQuery
 
         p = Addic7edProvider()
         q = VideoQuery(title="Test", languages=["en"])
         assert p.search(q) == []
 
     def test_search_skips_movies(self):
-        from providers.base import VideoQuery
         from providers.addic7ed import Addic7edProvider
+        from providers.base import VideoQuery
 
         p = Addic7edProvider()
         p.session = MagicMock()
         q = VideoQuery(title="Inception", languages=["en"])
-        with patch("providers.addic7ed._HAS_BS4", True), \
-             patch.object(type(q), "is_movie", new_callable=lambda: property(lambda self: True)):
+        with (
+            patch("providers.addic7ed._HAS_BS4", True),
+            patch.object(type(q), "is_movie", new_callable=lambda: property(lambda self: True)),
+        ):
             result = p.search(q)
         assert result == []
 
     def test_download_raises_without_session(self):
         import pytest
 
-        from providers.base import SubtitleResult
         from providers.addic7ed import Addic7edProvider
+        from providers.base import SubtitleResult
 
         p = Addic7edProvider()
         r = SubtitleResult(
@@ -334,8 +338,8 @@ class TestAddic7edProvider:
             assert "beautifulsoup4" in msg.lower()
 
     def test_no_bs4_search_returns_empty(self):
-        from providers.base import VideoQuery
         from providers.addic7ed import Addic7edProvider
+        from providers.base import VideoQuery
 
         p = Addic7edProvider()
         p.session = MagicMock()

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1549,4 +1549,9 @@ export async function batchDeleteSeriesSubtitles(
   return data
 }
 
+export async function getSupportedLanguages(): Promise<{ code: string; name: string }[]> {
+  const { data } = await api.get('/languages')
+  return data
+}
+
 export default api

--- a/frontend/src/components/health/HealthDashboardWidget.tsx
+++ b/frontend/src/components/health/HealthDashboardWidget.tsx
@@ -40,8 +40,9 @@ export function HealthDashboardWidget({ className }: HealthDashboardWidgetProps)
 
   // Compute summary from latest data point
   const latest = trends[trends.length - 1]
-  const totalIssues = trends.reduce((sum, t) => sum + t.issues_count, 0)
-  const totalChecked = trends.reduce((sum, t) => sum + t.files_checked, 0)
+  const totalIssues = trends.reduce((sum, t) => sum + (t.issues_count ?? 0), 0)
+  const totalChecked = trends.reduce((sum, t) => sum + (t.files_checked ?? 0), 0)
+  const latestScore = Math.round(latest.avg_score ?? 0)
 
   return (
     <div className={className ?? ''}>
@@ -52,9 +53,9 @@ export function HealthDashboardWidget({ className }: HealthDashboardWidgetProps)
             className="text-2xl font-bold tabular-nums"
             style={{ fontFamily: 'var(--font-mono)' }}
           >
-            {Math.round(latest.avg_score)}
+            {latestScore}
           </span>
-          <HealthBadge score={Math.round(latest.avg_score)} size="sm" />
+          <HealthBadge score={latestScore} size="sm" />
         </div>
         <div className="text-xs space-y-0.5" style={{ color: 'var(--text-secondary)' }}>
           <div>

--- a/frontend/src/components/shared/LanguageSelect.tsx
+++ b/frontend/src/components/shared/LanguageSelect.tsx
@@ -1,0 +1,125 @@
+import { useState, useRef, useEffect } from 'react'
+import { ChevronDown, Search } from 'lucide-react'
+import { useSupportedLanguages } from '@/hooks/useApi'
+
+interface LanguageSelectProps {
+  value: string
+  onChange: (code: string, name: string) => void
+  placeholder?: string
+}
+
+export function LanguageSelect({ value, onChange, placeholder = 'Sprache wählen…' }: LanguageSelectProps) {
+  const { data: languages = [] } = useSupportedLanguages()
+  const [open, setOpen] = useState(false)
+  const [search, setSearch] = useState('')
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const current = languages.find((l) => l.code === value)
+
+  const filtered = search
+    ? languages.filter(
+        (l) =>
+          l.name.toLowerCase().includes(search.toLowerCase()) ||
+          l.code.toLowerCase().includes(search.toLowerCase())
+      )
+    : languages
+
+  useEffect(() => {
+    if (!open) return
+    const handleClick = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false)
+        setSearch('')
+      }
+    }
+    document.addEventListener('mousedown', handleClick)
+    return () => document.removeEventListener('mousedown', handleClick)
+  }, [open])
+
+  useEffect(() => {
+    if (!open) setSearch('')
+  }, [open])
+
+  return (
+    <div ref={containerRef} className="relative w-full">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="w-full flex items-center justify-between px-3 py-2 rounded-md text-sm focus:outline-none"
+        style={{
+          backgroundColor: 'var(--bg-primary)',
+          border: '1px solid var(--border)',
+          color: current ? 'var(--text-primary)' : 'var(--text-muted)',
+          fontFamily: 'var(--font-mono)',
+          fontSize: '13px',
+        }}
+      >
+        <span>
+          {current ? `${current.name} (${current.code})` : value || placeholder}
+        </span>
+        <ChevronDown size={14} style={{ color: 'var(--text-muted)', flexShrink: 0, marginLeft: '8px' }} />
+      </button>
+
+      {open && (
+        <div
+          className="absolute z-50 w-full mt-1 rounded-md overflow-hidden"
+          style={{
+            backgroundColor: 'var(--bg-surface)',
+            border: '1px solid var(--border)',
+            boxShadow: '0 4px 16px rgba(0,0,0,0.3)',
+          }}
+        >
+          {/* Search input */}
+          <div className="flex items-center gap-2 px-2 py-1.5" style={{ borderBottom: '1px solid var(--border)' }}>
+            <Search size={12} style={{ color: 'var(--text-muted)', flexShrink: 0 }} />
+            <input
+              autoFocus
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Suchen…"
+              className="flex-1 bg-transparent text-[12px] focus:outline-none"
+              style={{ color: 'var(--text-primary)' }}
+            />
+          </div>
+
+          {/* Language list */}
+          <div className="overflow-y-auto" style={{ maxHeight: '200px' }}>
+            {filtered.length === 0 ? (
+              <p className="px-3 py-2 text-[12px]" style={{ color: 'var(--text-muted)' }}>
+                Keine Sprache gefunden
+              </p>
+            ) : (
+              filtered.map((lang) => (
+                <button
+                  key={lang.code}
+                  type="button"
+                  onClick={() => {
+                    onChange(lang.code, lang.name)
+                    setOpen(false)
+                  }}
+                  className="w-full flex items-center justify-between px-3 py-1.5 text-left text-[12px] transition-colors"
+                  style={{
+                    color: lang.code === value ? 'var(--accent)' : 'var(--text-primary)',
+                    backgroundColor: lang.code === value ? 'var(--accent-bg)' : 'transparent',
+                  }}
+                  onMouseEnter={(e) => {
+                    if (lang.code !== value) e.currentTarget.style.backgroundColor = 'var(--bg-surface-hover)'
+                  }}
+                  onMouseLeave={(e) => {
+                    if (lang.code !== value) e.currentTarget.style.backgroundColor = 'transparent'
+                  }}
+                >
+                  <span>{lang.name}</span>
+                  <span style={{ color: 'var(--text-muted)', fontFamily: 'var(--font-mono)', fontSize: '11px' }}>
+                    {lang.code}
+                  </span>
+                </button>
+              ))
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -131,7 +131,7 @@ export function useUpdateConfig() {
       if (keys.some(k => k.startsWith('sonarr_') || k.startsWith('radarr_'))) {
         queryClient.invalidateQueries({ queryKey: ['library'] })
       }
-      if (keys.some(k => k.startsWith('provider_') || k.startsWith('scoring_'))) {
+      if (keys.some(k => k.startsWith('provider') || k.startsWith('scoring_'))) {
         queryClient.invalidateQueries({ queryKey: ['providers'] })
         queryClient.invalidateQueries({ queryKey: ['provider-stats'] })
       }

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -63,6 +63,7 @@ import {
   getBackendTemplates,
   updateSeriesSettings, getAnidbMappingStatus, refreshAnidbMapping,
   getScannerStatus,
+  getSupportedLanguages,
 } from '@/api/client'
 import type {
   LanguageProfile, BackendConfig, MediaServerInstance, HookConfig, WebhookConfig, LogRotationConfig, FilterScope, BatchAction,
@@ -70,6 +71,16 @@ import type {
   CleanupRule,
 } from '@/lib/types'
 import type { DownloadSpecificPayload } from '@/api/client'
+
+// ─── Languages ───────────────────────────────────────────────────────────────
+
+export function useSupportedLanguages() {
+  return useQuery({
+    queryKey: ['languages'],
+    queryFn: getSupportedLanguages,
+    staleTime: Infinity,
+  })
+}
 
 // ─── Health ──────────────────────────────────────────────────────────────────
 

--- a/frontend/src/pages/Settings/ProvidersTab.tsx
+++ b/frontend/src/pages/Settings/ProvidersTab.tsx
@@ -25,6 +25,7 @@ export function ProvidersTab({
   const [testResults, setTestResults] = useState<Record<string, { healthy: boolean; message: string } | 'testing'>>({})
   const [localPriority, setLocalPriority] = useState<string[] | null>(null)
   const [editingProvider, setEditingProvider] = useState<string | null>(null)
+  const [isNewProvider, setIsNewProvider] = useState(false)
   const [showAddModal, setShowAddModal] = useState(false)
 
   const providers = providersData?.providers ?? []
@@ -40,6 +41,9 @@ export function ProvidersTab({
         .map((name) => providers.find((p) => p.name === name))
         .filter((p): p is ProviderInfo => p !== undefined)
     : providers
+
+  const activeProviders = orderedProviders.filter((p) => p.enabled)
+  const availableProviders = orderedProviders.filter((p) => !p.enabled)
 
   const handleTest = (name: string) => {
     setTestResults((prev) => ({ ...prev, [name]: 'testing' }))
@@ -63,6 +67,13 @@ export function ProvidersTab({
     const allNames = providers.map((p) => p.name)
     const newValue = enabledSet.size === allNames.length ? '' : Array.from(enabledSet).join(',')
     onSave({ providers_enabled: newValue })
+  }
+
+  const handleRemove = (name: string) => {
+    handleToggle(name, true)
+    setEditingProvider(null)
+    setIsNewProvider(false)
+    toast(`Provider ${name.replace(/_/g, ' ')} entfernt`)
   }
 
   const handleMove = (index: number, direction: 'up' | 'down') => {
@@ -95,6 +106,11 @@ export function ProvidersTab({
     })()
   }
 
+  const handleCloseEdit = () => {
+    setEditingProvider(null)
+    setIsNewProvider(false)
+  }
+
   if (providersLoading) {
     return (
       <div className="flex items-center justify-center h-32">
@@ -110,14 +126,12 @@ export function ProvidersTab({
     ? orderedProviders.indexOf(editingProviderData)
     : -1
 
-  const disabledProviders = orderedProviders.filter((p) => !p.enabled)
-
   return (
     <div className="space-y-4">
       {/* Header */}
       <div className="flex items-center justify-between">
         <span className="text-xs font-medium" style={{ color: 'var(--text-secondary)' }}>
-          {orderedProviders.length} Provider konfiguriert
+          {activeProviders.length} aktiv / {orderedProviders.length} verfügbar
         </span>
         <button
           onClick={() => handleClearCache()}
@@ -135,7 +149,7 @@ export function ProvidersTab({
 
       {/* Tile Grid */}
       <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
-        {orderedProviders.map((provider, idx) => (
+        {activeProviders.map((provider, idx) => (
           <ProviderTile
             key={provider.name}
             provider={provider}
@@ -143,17 +157,30 @@ export function ProvidersTab({
             priority={idx + 1}
             testResult={testResults[provider.name]}
             onOpenEdit={() => setEditingProvider(provider.name)}
+            onToggle={() => handleToggle(provider.name, provider.enabled)}
+            onRemove={() => handleRemove(provider.name)}
           />
         ))}
 
-        {/* "+" Tile — only if disabled providers exist */}
-        {disabledProviders.length > 0 && (
+        {/* Empty state */}
+        {activeProviders.length === 0 && (
+          <div
+            className="col-span-full py-10 text-center text-sm"
+            style={{ color: 'var(--text-muted)' }}
+          >
+            Noch kein Provider aktiv — klicke auf + um einen hinzuzufügen.
+          </div>
+        )}
+
+        {/* "+" tile — always visible when available providers exist */}
+        {availableProviders.length > 0 && (
           <button
             onClick={() => setShowAddModal(true)}
-            className="h-24 flex flex-col items-center justify-center gap-1 rounded transition-all duration-150"
+            className="flex flex-col items-center justify-center gap-1 rounded transition-all duration-150"
             style={{
               border: '2px dashed var(--border)',
               color: 'var(--text-muted)',
+              minHeight: '7rem',
             }}
             onMouseEnter={(e) => {
               e.currentTarget.style.borderColor = 'var(--accent-dim)'
@@ -165,7 +192,7 @@ export function ProvidersTab({
             }}
           >
             <Plus size={22} />
-            <span className="text-[11px] font-medium">Provider aktivieren</span>
+            <span className="text-[11px] font-medium">Provider hinzufügen</span>
           </button>
         )}
       </div>
@@ -183,6 +210,7 @@ export function ProvidersTab({
             editingProviderData.config_fields.map((f) => [f.key, values[f.key] ?? ''])
           )}
           testResult={testResults[editingProviderData.name]}
+          isNew={isNewProvider}
           onFieldChange={onFieldChange}
           onTest={() => handleTest(editingProviderData.name)}
           onToggle={() => handleToggle(editingProviderData.name, editingProviderData.enabled)}
@@ -190,17 +218,19 @@ export function ProvidersTab({
           onMoveDown={() => handleMove(editingProviderIdx, 'down')}
           onClearCache={() => handleClearCache(editingProviderData.name)}
           onReEnable={() => handleReEnable(editingProviderData.name)}
-          onClose={() => setEditingProvider(null)}
+          onRemove={() => handleRemove(editingProviderData.name)}
+          onClose={handleCloseEdit}
         />
       )}
 
       {/* Add Modal */}
       {showAddModal && (
         <AddProviderModal
-          disabledProviders={disabledProviders}
+          availableProviders={availableProviders}
           onSelect={(name) => {
             handleToggle(name, false)
             setEditingProvider(name)
+            setIsNewProvider(true)
             setShowAddModal(false)
           }}
           onClose={() => setShowAddModal(false)}

--- a/frontend/src/pages/Settings/ProvidersTab.tsx
+++ b/frontend/src/pages/Settings/ProvidersTab.tsx
@@ -42,8 +42,18 @@ export function ProvidersTab({
         .filter((p): p is ProviderInfo => p !== undefined)
     : providers
 
-  const activeProviders = orderedProviders.filter((p) => p.enabled)
-  const availableProviders = orderedProviders.filter((p) => !p.enabled)
+  // providers_hidden: comma-separated names that are truly removed from the grid
+  const hiddenNamesRaw = values['providers_hidden'] ?? ''
+  const hiddenNames = new Set(
+    hiddenNamesRaw ? hiddenNamesRaw.split(',').map((s) => s.trim()).filter(Boolean) : []
+  )
+
+  // Grid shows all non-hidden providers (both enabled AND disabled)
+  const shownProviders = orderedProviders.filter((p) => !hiddenNames.has(p.name))
+  // + modal shows only hidden/removed providers
+  const hiddenProviders = orderedProviders.filter((p) => hiddenNames.has(p.name))
+
+  const activeCount = shownProviders.filter((p) => p.enabled).length
 
   const handleTest = (name: string) => {
     setTestResults((prev) => ({ ...prev, [name]: 'testing' }))
@@ -69,11 +79,38 @@ export function ProvidersTab({
     onSave({ providers_enabled: newValue })
   }
 
-  const handleRemove = (name: string) => {
-    handleToggle(name, true)
+  // Entfernen: adds to providers_hidden AND disables in providers_enabled
+  const handleHide = (name: string) => {
+    const newHiddenSet = new Set(hiddenNames)
+    newHiddenSet.add(name)
+    const newHiddenValue = Array.from(newHiddenSet).join(',')
+
+    const enabledSet = new Set(providers.filter((p) => p.enabled).map((p) => p.name))
+    enabledSet.delete(name)
+    const allNames = providers.map((p) => p.name)
+    const newEnabledValue = enabledSet.size === allNames.length ? '' : Array.from(enabledSet).join(',')
+
+    onSave({ providers_hidden: newHiddenValue, providers_enabled: newEnabledValue })
     setEditingProvider(null)
     setIsNewProvider(false)
     toast(`Provider ${name.replace(/_/g, ' ')} entfernt`)
+  }
+
+  // Hinzufügen: removes from providers_hidden AND enables in providers_enabled
+  const handleAddProvider = (name: string) => {
+    const newHiddenSet = new Set(hiddenNames)
+    newHiddenSet.delete(name)
+    const newHiddenValue = Array.from(newHiddenSet).join(',')
+
+    const enabledSet = new Set(providers.filter((p) => p.enabled).map((p) => p.name))
+    enabledSet.add(name)
+    const allNames = providers.map((p) => p.name)
+    const newEnabledValue = enabledSet.size === allNames.length ? '' : Array.from(enabledSet).join(',')
+
+    onSave({ providers_hidden: newHiddenValue, providers_enabled: newEnabledValue })
+    setEditingProvider(name)
+    setIsNewProvider(true)
+    setShowAddModal(false)
   }
 
   const handleMove = (index: number, direction: 'up' | 'down') => {
@@ -120,10 +157,10 @@ export function ProvidersTab({
   }
 
   const editingProviderData = editingProvider
-    ? orderedProviders.find((p) => p.name === editingProvider) ?? null
+    ? shownProviders.find((p) => p.name === editingProvider) ?? null
     : null
   const editingProviderIdx = editingProviderData
-    ? orderedProviders.indexOf(editingProviderData)
+    ? shownProviders.indexOf(editingProviderData)
     : -1
 
   return (
@@ -131,7 +168,7 @@ export function ProvidersTab({
       {/* Header */}
       <div className="flex items-center justify-between">
         <span className="text-xs font-medium" style={{ color: 'var(--text-secondary)' }}>
-          {activeProviders.length} aktiv / {orderedProviders.length} verfügbar
+          {activeCount} aktiv / {shownProviders.length} konfiguriert
         </span>
         <button
           onClick={() => handleClearCache()}
@@ -149,7 +186,7 @@ export function ProvidersTab({
 
       {/* Tile Grid */}
       <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
-        {activeProviders.map((provider, idx) => (
+        {shownProviders.map((provider, idx) => (
           <ProviderTile
             key={provider.name}
             provider={provider}
@@ -158,22 +195,22 @@ export function ProvidersTab({
             testResult={testResults[provider.name]}
             onOpenEdit={() => setEditingProvider(provider.name)}
             onToggle={() => handleToggle(provider.name, provider.enabled)}
-            onRemove={() => handleRemove(provider.name)}
+            onRemove={() => handleHide(provider.name)}
           />
         ))}
 
         {/* Empty state */}
-        {activeProviders.length === 0 && (
+        {shownProviders.length === 0 && (
           <div
             className="col-span-full py-10 text-center text-sm"
             style={{ color: 'var(--text-muted)' }}
           >
-            Noch kein Provider aktiv — klicke auf + um einen hinzuzufügen.
+            Noch kein Provider konfiguriert — klicke auf + um einen hinzuzufügen.
           </div>
         )}
 
-        {/* "+" tile — always visible when available providers exist */}
-        {availableProviders.length > 0 && (
+        {/* "+" tile — shows when there are hidden providers to re-add */}
+        {hiddenProviders.length > 0 && (
           <button
             onClick={() => setShowAddModal(true)}
             className="flex flex-col items-center justify-center gap-1 rounded transition-all duration-150"
@@ -204,8 +241,8 @@ export function ProvidersTab({
           cacheCount={statsData?.cache[editingProviderData.name]?.total ?? 0}
           priority={editingProviderIdx + 1}
           isFirst={editingProviderIdx === 0}
-          isLast={editingProviderIdx === orderedProviders.length - 1}
-          totalProviders={orderedProviders.length}
+          isLast={editingProviderIdx === shownProviders.length - 1}
+          totalProviders={shownProviders.length}
           fieldValues={Object.fromEntries(
             editingProviderData.config_fields.map((f) => [f.key, values[f.key] ?? ''])
           )}
@@ -218,21 +255,16 @@ export function ProvidersTab({
           onMoveDown={() => handleMove(editingProviderIdx, 'down')}
           onClearCache={() => handleClearCache(editingProviderData.name)}
           onReEnable={() => handleReEnable(editingProviderData.name)}
-          onRemove={() => handleRemove(editingProviderData.name)}
+          onRemove={() => handleHide(editingProviderData.name)}
           onClose={handleCloseEdit}
         />
       )}
 
-      {/* Add Modal */}
+      {/* Add Modal — shows removed/hidden providers */}
       {showAddModal && (
         <AddProviderModal
-          availableProviders={availableProviders}
-          onSelect={(name) => {
-            handleToggle(name, false)
-            setEditingProvider(name)
-            setIsNewProvider(true)
-            setShowAddModal(false)
-          }}
+          availableProviders={hiddenProviders}
+          onSelect={handleAddProvider}
           onClose={() => setShowAddModal(false)}
         />
       )}

--- a/frontend/src/pages/Settings/index.tsx
+++ b/frontend/src/pages/Settings/index.tsx
@@ -14,6 +14,7 @@ import { getHealth } from '@/api/client'
 import { toast } from '@/components/shared/Toast'
 import { Toggle } from '@/components/shared/Toggle'
 import { SettingRow } from '@/components/shared/SettingRow'
+import { LanguageSelect } from '@/components/shared/LanguageSelect'
 import { HELP_TEXT } from './settingsHelpText'
 import { SettingsCard } from '@/components/shared/SettingsCard'
 import type { ConnectionStatus } from '@/components/shared/ConnectionBadge'
@@ -80,7 +81,7 @@ const TABS = NAV_GROUPS.flatMap((g) => g.items)
 export interface FieldConfig {
   key: string
   label: string
-  type: 'text' | 'number' | 'password' | 'toggle'
+  type: 'text' | 'number' | 'password' | 'toggle' | 'language-select'
   placeholder?: string
   tab: string
   description?: string
@@ -101,14 +102,16 @@ const FIELDS: FieldConfig[] = [
     description: 'SQLite-Datenbankdatei. Nur ändern wenn die DB verschoben wurde.',
     advanced: true },
   // Translation
-  { key: 'source_language', label: 'Source Language Code', type: 'text', placeholder: 'en', tab: 'Translation',
-    description: 'ISO 639-1 Sprachcode der Quellsprache, z.B. "en".' },
-  { key: 'target_language', label: 'Target Language Code', type: 'text', placeholder: 'de', tab: 'Translation',
-    description: 'ISO 639-1 Sprachcode der Zielsprache, z.B. "de".' },
-  { key: 'source_language_name', label: 'Source Language Name', type: 'text', placeholder: 'English', tab: 'Translation',
-    description: 'Vollständiger Name der Quellsprache für LLM-Prompts.' },
-  { key: 'target_language_name', label: 'Target Language Name', type: 'text', placeholder: 'German', tab: 'Translation',
-    description: 'Vollständiger Name der Zielsprache für LLM-Prompts.' },
+  { key: 'source_language', label: 'Source Language', type: 'language-select', tab: 'Translation',
+    description: 'Quellsprache der Untertitel (z.B. Englisch). Setzt auch den Sprachnamen für LLM-Prompts.' },
+  { key: 'target_language', label: 'Target Language', type: 'language-select', tab: 'Translation',
+    description: 'Zielsprache für Übersetzungen und Provider-Suche (z.B. Deutsch).' },
+  { key: 'source_language_name', label: 'Source Language Name (Override)', type: 'text', placeholder: 'English', tab: 'Translation',
+    description: 'Vollständiger Name der Quellsprache für LLM-Prompts. Wird automatisch beim Sprachwechsel gesetzt.',
+    advanced: true },
+  { key: 'target_language_name', label: 'Target Language Name (Override)', type: 'text', placeholder: 'German', tab: 'Translation',
+    description: 'Vollständiger Name der Zielsprache für LLM-Prompts. Wird automatisch beim Sprachwechsel gesetzt.',
+    advanced: true },
   { key: 'hi_removal_enabled', label: 'Remove Hearing Impaired Tags', type: 'toggle', tab: 'Translation',
     description: 'Entfernt [Geräuschbeschreibungen] und (Sprechertags) aus Untertiteln.' },
   // Automation — Upgrade
@@ -652,6 +655,14 @@ function SettingsPageInner() {
           checked={values[field.key] === 'true'}
           onChange={(v) => setValues((prev) => ({ ...prev, [field.key]: String(v) }))}
           disabled={field.key === 'wanted_auto_translate' && values['wanted_auto_extract'] !== 'true'}
+        />
+      ) : field.type === 'language-select' ? (
+        <LanguageSelect
+          value={values[field.key] ?? ''}
+          onChange={(code, name) => {
+            const nameKey = field.key + '_name'
+            setValues((prev) => ({ ...prev, [field.key]: code, [nameKey]: name }))
+          }}
         />
       ) : (
         <input

--- a/frontend/src/pages/Settings/providers/AddProviderModal.tsx
+++ b/frontend/src/pages/Settings/providers/AddProviderModal.tsx
@@ -80,7 +80,7 @@ export function AddProviderModal({ availableProviders, onSelect, onClose }: AddP
         <div className="py-1 max-h-96 overflow-y-auto">
           {availableProviders.length === 0 ? (
             <p className="px-4 py-6 text-center text-sm" style={{ color: 'var(--text-muted)' }}>
-              Alle Provider sind bereits aktiv.
+              Alle Provider sind bereits in der Liste.
             </p>
           ) : (
             availableProviders.map((provider) => (

--- a/frontend/src/pages/Settings/providers/AddProviderModal.tsx
+++ b/frontend/src/pages/Settings/providers/AddProviderModal.tsx
@@ -1,14 +1,37 @@
 import { useEffect } from 'react'
-import { X, ChevronRight } from 'lucide-react'
+import { X, ChevronRight, Key, User, Zap } from 'lucide-react'
 import type { ProviderInfo } from '@/lib/types'
+import { getCredentialBadge, getProviderDescription, type CredentialType } from './providerUtils'
 
 interface AddProviderModalProps {
-  disabledProviders: ProviderInfo[]
+  availableProviders: ProviderInfo[]
   onSelect: (name: string) => void
   onClose: () => void
 }
 
-export function AddProviderModal({ disabledProviders, onSelect, onClose }: AddProviderModalProps) {
+function CredentialBadge({ type }: { type: CredentialType }) {
+  const config: Record<CredentialType, { label: string; color: string; Icon: typeof Zap }> = {
+    free: { label: 'Gratis', color: 'var(--success)', Icon: Zap },
+    api_key: { label: 'API Key', color: 'var(--warning)', Icon: Key },
+    login: { label: 'Login', color: 'var(--accent)', Icon: User },
+  }
+  const { label, color, Icon } = config[type]
+
+  return (
+    <span
+      className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded text-[10px] font-medium shrink-0"
+      style={{
+        backgroundColor: `color-mix(in srgb, ${color} 12%, transparent)`,
+        color,
+      }}
+    >
+      <Icon size={9} />
+      {label}
+    </span>
+  )
+}
+
+export function AddProviderModal({ availableProviders, onSelect, onClose }: AddProviderModalProps) {
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose() }
     document.addEventListener('keydown', handleKey)
@@ -36,10 +59,10 @@ export function AddProviderModal({ disabledProviders, onSelect, onClose }: AddPr
         >
           <div>
             <p className="text-[11px] font-medium mb-0.5" style={{ color: 'var(--text-muted)' }}>
-              Provider
+              Schritt 1 von 2
             </p>
             <p className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
-              Provider aktivieren
+              Provider hinzufügen
             </p>
           </div>
           <button
@@ -54,37 +77,35 @@ export function AddProviderModal({ disabledProviders, onSelect, onClose }: AddPr
         </div>
 
         {/* Provider list */}
-        <div className="py-1 max-h-80 overflow-y-auto">
-          {disabledProviders.length === 0 ? (
+        <div className="py-1 max-h-96 overflow-y-auto">
+          {availableProviders.length === 0 ? (
             <p className="px-4 py-6 text-center text-sm" style={{ color: 'var(--text-muted)' }}>
-              Alle Provider sind bereits aktiviert.
+              Alle Provider sind bereits aktiv.
             </p>
           ) : (
-            disabledProviders.map((provider) => {
-              const fieldCount = provider.config_fields.length
-              return (
-                <button
-                  key={provider.name}
-                  onClick={() => onSelect(provider.name)}
-                  className="w-full flex items-center justify-between px-4 py-2.5 transition-colors text-left"
-                  style={{ color: 'var(--text-primary)' }}
-                  onMouseEnter={(e) => { e.currentTarget.style.backgroundColor = 'var(--bg-surface-hover)' }}
-                  onMouseLeave={(e) => { e.currentTarget.style.backgroundColor = 'transparent' }}
-                >
-                  <div>
-                    <span className="text-sm font-medium capitalize block">
+            availableProviders.map((provider) => (
+              <button
+                key={provider.name}
+                onClick={() => onSelect(provider.name)}
+                className="w-full flex items-center justify-between px-4 py-3 transition-colors text-left"
+                style={{ color: 'var(--text-primary)' }}
+                onMouseEnter={(e) => { e.currentTarget.style.backgroundColor = 'var(--bg-surface-hover)' }}
+                onMouseLeave={(e) => { e.currentTarget.style.backgroundColor = 'transparent' }}
+              >
+                <div className="flex-1 min-w-0 mr-2">
+                  <div className="flex items-center gap-2 mb-0.5">
+                    <span className="text-sm font-medium capitalize">
                       {provider.name.replace(/_/g, ' ')}
                     </span>
-                    <span className="text-[11px]" style={{ color: 'var(--text-muted)' }}>
-                      {fieldCount === 0
-                        ? 'Keine Zugangsdaten erforderlich'
-                        : `${fieldCount} Feld${fieldCount !== 1 ? 'er' : ''} konfigurieren`}
-                    </span>
+                    <CredentialBadge type={getCredentialBadge(provider.name)} />
                   </div>
-                  <ChevronRight size={14} style={{ color: 'var(--text-muted)' }} />
-                </button>
-              )
-            })
+                  <span className="text-[11px] block truncate" style={{ color: 'var(--text-muted)' }}>
+                    {getProviderDescription(provider.name)}
+                  </span>
+                </div>
+                <ChevronRight size={14} className="shrink-0" style={{ color: 'var(--text-muted)' }} />
+              </button>
+            ))
           )}
         </div>
       </div>

--- a/frontend/src/pages/Settings/providers/ProviderEditModal.tsx
+++ b/frontend/src/pages/Settings/providers/ProviderEditModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { X, Loader2, TestTube, ChevronUp, ChevronDown, Trash2, Download, Database } from 'lucide-react'
 import { SettingRow } from '@/components/shared/SettingRow'
 import type { ProviderInfo } from '@/lib/types'
@@ -23,6 +23,8 @@ interface ProviderEditModalProps {
   onMoveDown: () => void
   onClearCache: () => void
   onReEnable: () => void
+  onRemove?: () => void
+  isNew?: boolean
   onClose: () => void
 }
 
@@ -30,8 +32,10 @@ export function ProviderEditModal({
   provider, cacheCount, priority, isFirst, isLast, totalProviders,
   fieldValues, testResult,
   onFieldChange, onTest, onToggle, onMoveUp, onMoveDown,
-  onClearCache, onReEnable, onClose,
+  onClearCache, onReEnable, onRemove, isNew, onClose,
 }: ProviderEditModalProps) {
+  const [confirmRemove, setConfirmRemove] = useState(false)
+
   // Escape key closes modal
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose() }
@@ -66,7 +70,7 @@ export function ProviderEditModal({
         >
           <div>
             <p className="text-[11px] font-medium mb-0.5" style={{ color: 'var(--text-muted)' }}>
-              Provider bearbeiten
+              {isNew ? 'Schritt 2 von 2 · ' : ''}Provider bearbeiten
             </p>
             <p className="text-sm font-semibold capitalize" style={{ color: 'var(--text-primary)' }}>
               {provider.name.replace(/_/g, ' ')}
@@ -289,9 +293,42 @@ export function ProviderEditModal({
           className="flex items-center justify-between px-4 py-3 shrink-0"
           style={{ borderTop: '1px solid var(--border)', backgroundColor: 'var(--bg-elevated)' }}
         >
-          {/* Left: Cache clear (conditional) */}
-          <div>
-            {cacheCount > 0 && (
+          {/* Left: Remove (with inline confirm) or Cache clear */}
+          <div className="flex items-center gap-2">
+            {onRemove && !confirmRemove && (
+              <button
+                onClick={() => setConfirmRemove(true)}
+                className="flex items-center gap-1.5 px-2.5 py-1.5 rounded text-xs font-medium transition-all hover:opacity-80"
+                style={{
+                  border: '1px solid color-mix(in srgb, var(--error) 40%, var(--border))',
+                  color: 'var(--error)',
+                  backgroundColor: 'var(--bg-primary)',
+                }}
+              >
+                <Trash2 size={12} />
+                Entfernen
+              </button>
+            )}
+            {onRemove && confirmRemove && (
+              <div className="flex items-center gap-1.5">
+                <span className="text-xs" style={{ color: 'var(--text-muted)' }}>Wirklich?</span>
+                <button
+                  onClick={onRemove}
+                  className="px-2.5 py-1.5 rounded text-xs font-medium"
+                  style={{ backgroundColor: 'var(--error)', color: 'white' }}
+                >
+                  Ja
+                </button>
+                <button
+                  onClick={() => setConfirmRemove(false)}
+                  className="px-2.5 py-1.5 rounded text-xs font-medium"
+                  style={{ border: '1px solid var(--border)', color: 'var(--text-muted)' }}
+                >
+                  Nein
+                </button>
+              </div>
+            )}
+            {!confirmRemove && cacheCount > 0 && (
               <button
                 onClick={onClearCache}
                 className="flex items-center gap-1.5 px-2.5 py-1.5 rounded text-xs font-medium transition-all hover:opacity-80"
@@ -302,7 +339,7 @@ export function ProviderEditModal({
                 }}
               >
                 <Trash2 size={12} />
-                Cache leeren ({cacheCount})
+                Cache ({cacheCount})
               </button>
             )}
           </div>

--- a/frontend/src/pages/Settings/providers/ProviderTile.tsx
+++ b/frontend/src/pages/Settings/providers/ProviderTile.tsx
@@ -33,7 +33,8 @@ export function ProviderTile({
         border: '1px solid var(--border)',
         borderLeft: `4px solid ${borderColor}`,
         minHeight: '7rem',
-        transition: 'background-color 150ms',
+        transition: 'background-color 150ms, opacity 150ms',
+        opacity: provider.enabled ? 1 : 0.5,
       }}
       onClick={onOpenEdit}
       onMouseEnter={(e) => { e.currentTarget.style.backgroundColor = 'var(--bg-surface-hover)' }}

--- a/frontend/src/pages/Settings/providers/ProviderTile.tsx
+++ b/frontend/src/pages/Settings/providers/ProviderTile.tsx
@@ -1,6 +1,9 @@
-import { Pencil, Download, Database, Clock } from 'lucide-react'
+import { Pencil, Download, Database, Clock, Trash2, Power } from 'lucide-react'
 import type { ProviderInfo } from '@/lib/types'
-import { getStatusColor, getStatusLabel, getStatusBg, getSuccessRateColor } from './providerUtils'
+import {
+  getStatusColor, getStatusLabel, getStatusBg,
+  getSuccessRateColor, getStatusBorderColor,
+} from './providerUtils'
 
 interface ProviderTileProps {
   provider: ProviderInfo
@@ -8,93 +11,131 @@ interface ProviderTileProps {
   priority: number
   testResult?: { healthy: boolean; message: string } | 'testing'
   onOpenEdit: () => void
+  onToggle: () => void
+  onRemove: () => void
 }
 
-export function ProviderTile({ provider, cacheCount, priority, onOpenEdit }: ProviderTileProps) {
+export function ProviderTile({
+  provider, cacheCount, priority,
+  onOpenEdit, onToggle, onRemove,
+}: ProviderTileProps) {
   const statusColor = getStatusColor(provider)
   const statusLabel = getStatusLabel(provider)
   const statusBg = getStatusBg(provider)
+  const borderColor = getStatusBorderColor(provider)
   const hasStats = provider.stats && provider.stats.total_searches > 0
 
   return (
-    <button
-      onClick={onOpenEdit}
-      className="relative text-left rounded p-3 transition-all duration-150 group"
+    <div
+      className="relative rounded overflow-hidden group cursor-pointer"
       style={{
         backgroundColor: 'var(--bg-surface)',
         border: '1px solid var(--border)',
-        opacity: provider.enabled ? 1 : 0.65,
+        borderLeft: `4px solid ${borderColor}`,
+        minHeight: '7rem',
+        transition: 'background-color 150ms',
       }}
-      onMouseEnter={(e) => {
-        e.currentTarget.style.borderColor = 'var(--accent-dim)'
-        e.currentTarget.style.backgroundColor = 'var(--bg-surface-hover)'
-      }}
-      onMouseLeave={(e) => {
-        e.currentTarget.style.borderColor = 'var(--border)'
-        e.currentTarget.style.backgroundColor = 'var(--bg-surface)'
-      }}
+      onClick={onOpenEdit}
+      onMouseEnter={(e) => { e.currentTarget.style.backgroundColor = 'var(--bg-surface-hover)' }}
+      onMouseLeave={(e) => { e.currentTarget.style.backgroundColor = 'var(--bg-surface)' }}
     >
-      {/* Edit icon — top right */}
-      <Pencil
-        size={12}
-        className="absolute top-2.5 right-2.5 opacity-0 group-hover:opacity-100 transition-opacity"
-        style={{ color: 'var(--accent)' }}
-      />
+      <div className="p-3">
+        {/* Provider name + rank */}
+        <div className="flex items-center justify-between mb-1.5 pr-16">
+          <span
+            className="text-[13px] font-semibold capitalize truncate"
+            style={{ color: 'var(--text-primary)' }}
+          >
+            {provider.name.replace(/_/g, ' ')}
+          </span>
+          <span className="text-[10px] shrink-0 ml-1" style={{ color: 'var(--text-muted)' }}>
+            #{priority}
+          </span>
+        </div>
 
-      {/* Provider name + rank */}
-      <div className="flex items-center justify-between pr-4 mb-1.5">
+        {/* Status badge */}
         <span
-          className="text-[13px] font-semibold capitalize truncate"
-          style={{ color: 'var(--text-primary)' }}
+          className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium mb-2"
+          style={{ backgroundColor: statusBg, color: statusColor }}
         >
-          {provider.name.replace(/_/g, ' ')}
+          <span className="w-1.5 h-1.5 rounded-full shrink-0" style={{ backgroundColor: statusColor }} />
+          {statusLabel}
         </span>
-        <span className="text-[10px] shrink-0 ml-1" style={{ color: 'var(--text-muted)' }}>
-          #{priority}
-        </span>
+
+        {/* Stats row */}
+        {provider.enabled && (
+          <div className="flex items-center gap-2.5 text-[10px]" style={{ color: 'var(--text-muted)' }}>
+            <span className="flex items-center gap-1">
+              <Download size={10} />
+              {provider.downloads}
+            </span>
+            <span className="flex items-center gap-1">
+              <Database size={10} />
+              {cacheCount}
+            </span>
+            {hasStats && provider.stats.avg_response_time_ms > 0 && (
+              <span className="flex items-center gap-1">
+                <Clock size={10} />
+                {Math.round(provider.stats.avg_response_time_ms)}ms
+              </span>
+            )}
+          </div>
+        )}
+
+        {/* Success rate bar */}
+        {provider.enabled && hasStats && (
+          <div className="mt-2 h-0.5 rounded-full" style={{ backgroundColor: 'var(--bg-primary)' }}>
+            <div
+              className="h-full rounded-full transition-all"
+              style={{
+                width: `${provider.stats.success_rate * 100}%`,
+                backgroundColor: getSuccessRateColor(provider.stats.success_rate),
+              }}
+            />
+          </div>
+        )}
       </div>
 
-      {/* Status badge */}
-      <span
-        className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium mb-2"
-        style={{ backgroundColor: statusBg, color: statusColor }}
+      {/* Hover action buttons — top right */}
+      <div
+        className="absolute top-1.5 right-1.5 flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity"
+        onClick={(e) => e.stopPropagation()}
       >
-        <span className="w-1.5 h-1.5 rounded-full shrink-0" style={{ backgroundColor: statusColor }} />
-        {statusLabel}
-      </span>
-
-      {/* Stats row */}
-      {provider.enabled && (
-        <div className="flex items-center gap-2.5 text-[10px]" style={{ color: 'var(--text-muted)' }}>
-          <span className="flex items-center gap-1">
-            <Download size={10} />
-            {provider.downloads}
-          </span>
-          <span className="flex items-center gap-1">
-            <Database size={10} />
-            {cacheCount}
-          </span>
-          {hasStats && provider.stats.avg_response_time_ms > 0 && (
-            <span className="flex items-center gap-1">
-              <Clock size={10} />
-              {Math.round(provider.stats.avg_response_time_ms)}ms
-            </span>
-          )}
-        </div>
-      )}
-
-      {/* Success rate bar */}
-      {provider.enabled && hasStats && (
-        <div className="mt-2 h-0.5 rounded-full" style={{ backgroundColor: 'var(--bg-primary)' }}>
-          <div
-            className="h-full rounded-full transition-all"
-            style={{
-              width: `${provider.stats.success_rate * 100}%`,
-              backgroundColor: getSuccessRateColor(provider.stats.success_rate),
-            }}
-          />
-        </div>
-      )}
-    </button>
+        <button
+          onClick={onToggle}
+          className="p-1.5 rounded transition-colors"
+          title={provider.enabled ? 'Deaktivieren' : 'Aktivieren'}
+          style={{ backgroundColor: 'var(--bg-elevated)', color: provider.enabled ? 'var(--accent)' : 'var(--text-muted)' }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.color = provider.enabled ? 'var(--warning)' : 'var(--success)'
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.color = provider.enabled ? 'var(--accent)' : 'var(--text-muted)'
+          }}
+        >
+          <Power size={11} />
+        </button>
+        <button
+          onClick={onOpenEdit}
+          className="p-1.5 rounded transition-colors"
+          title="Bearbeiten"
+          style={{ backgroundColor: 'var(--bg-elevated)', color: 'var(--text-muted)' }}
+          onMouseEnter={(e) => { e.currentTarget.style.color = 'var(--accent)' }}
+          onMouseLeave={(e) => { e.currentTarget.style.color = 'var(--text-muted)' }}
+        >
+          <Pencil size={11} />
+        </button>
+        <button
+          onClick={onRemove}
+          className="p-1.5 rounded transition-colors"
+          title="Entfernen"
+          style={{ backgroundColor: 'var(--bg-elevated)', color: 'var(--text-muted)' }}
+          onMouseEnter={(e) => { e.currentTarget.style.color = 'var(--error)' }}
+          onMouseLeave={(e) => { e.currentTarget.style.color = 'var(--text-muted)' }}
+        >
+          <Trash2 size={11} />
+        </button>
+      </div>
+    </div>
   )
 }

--- a/frontend/src/pages/Settings/providers/providerUtils.ts
+++ b/frontend/src/pages/Settings/providers/providerUtils.ts
@@ -84,6 +84,30 @@ const PROVIDER_META: Record<string, ProviderMeta> = {
     description: 'Spanischsprachige Untertitel-Plattform',
     credentialType: 'free',
   },
+  animetosho: {
+    description: 'Anime-Fansub-Releases, kein Konto erforderlich',
+    credentialType: 'free',
+  },
+  kitsunekko: {
+    description: 'Japanische Originalsprache (ASS), kein Konto nötig',
+    credentialType: 'free',
+  },
+  napisy24: {
+    description: 'Polnische Untertitel, kein Konto erforderlich',
+    credentialType: 'free',
+  },
+  titrari: {
+    description: 'Rumänische Untertitel, kein Konto erforderlich',
+    credentialType: 'free',
+  },
+  legendasdivx: {
+    description: 'Portugiesische Untertitel — Konto auf legendasdivx.pt erforderlich',
+    credentialType: 'login',
+  },
+  whisper_subgen: {
+    description: 'Lokale KI-Transkription via selbst-gehostetes Subgen',
+    credentialType: 'api_key',
+  },
   whisperai: {
     description: 'Lokale KI-Transkription via Whisper-Modell',
     credentialType: 'free',

--- a/frontend/src/pages/Settings/providers/providerUtils.ts
+++ b/frontend/src/pages/Settings/providers/providerUtils.ts
@@ -8,10 +8,17 @@ export function getStatusColor(provider: ProviderInfo): string {
 }
 
 export function getStatusLabel(provider: ProviderInfo): string {
-  if (!provider.enabled) return 'Disabled'
-  if (provider.stats?.auto_disabled) return 'Auto-disabled'
-  if (!provider.initialized) return 'Not initialized'
+  if (!provider.enabled) return 'Deaktiviert'
+  if (provider.stats?.auto_disabled) return 'Automatisch deaktiviert'
+  if (!provider.initialized) return 'Nicht konfiguriert'
   return provider.healthy ? 'Healthy' : 'Error'
+}
+
+export function getStatusBorderColor(provider: ProviderInfo): string {
+  if (!provider.enabled) return 'var(--border)'
+  if (provider.stats?.auto_disabled) return 'var(--warning)'
+  if (!provider.initialized) return 'var(--warning)'
+  return provider.healthy ? 'var(--success)' : 'var(--error)'
 }
 
 export function getStatusBg(provider: ProviderInfo): string {
@@ -27,6 +34,68 @@ export function getSuccessRateColor(rate: number): string {
   if (rate > 0.8) return 'var(--success)'
   if (rate > 0.5) return 'var(--warning)'
   return 'var(--error)'
+}
+
+export type CredentialType = 'free' | 'api_key' | 'login'
+
+interface ProviderMeta {
+  description: string
+  credentialType: CredentialType
+}
+
+const PROVIDER_META: Record<string, ProviderMeta> = {
+  opensubtitles: {
+    description: 'Größte Untertitel-Datenbank — REST API v1',
+    credentialType: 'api_key',
+  },
+  opensubtitles_com: {
+    description: 'Größte Untertitel-Datenbank — REST API v1',
+    credentialType: 'api_key',
+  },
+  opensubtitlesvip: {
+    description: 'OpenSubtitles VIP-Zugang mit erhöhtem Tageslimit',
+    credentialType: 'login',
+  },
+  podnapisi: {
+    description: 'Slawische & europäische Sprachen, kein Konto nötig',
+    credentialType: 'free',
+  },
+  subscene: {
+    description: 'Große Community-Sammlung mit vielen Sprachen',
+    credentialType: 'free',
+  },
+  subdl: {
+    description: 'Schnelle Downloads, gute Anime-Abdeckung',
+    credentialType: 'api_key',
+  },
+  zimuku: {
+    description: 'Chinesische Untertitel spezialisiert',
+    credentialType: 'free',
+  },
+  jimaku: {
+    description: 'Japanische & Anime-Untertitel aus aktuellen Streams',
+    credentialType: 'api_key',
+  },
+  assrt: {
+    description: 'Chinesische Untertitel mit Qualitätsbewertung',
+    credentialType: 'free',
+  },
+  gestdown: {
+    description: 'Spanischsprachige Untertitel-Plattform',
+    credentialType: 'free',
+  },
+  whisperai: {
+    description: 'Lokale KI-Transkription via Whisper-Modell',
+    credentialType: 'free',
+  },
+}
+
+export function getCredentialBadge(providerName: string): CredentialType {
+  return PROVIDER_META[providerName]?.credentialType ?? 'free'
+}
+
+export function getProviderDescription(providerName: string): string {
+  return PROVIDER_META[providerName]?.description ?? 'Untertitel-Provider'
 }
 
 export function getFieldDescription(key: string, label: string): string {

--- a/frontend/src/pages/Settings/providers/providerUtils.ts
+++ b/frontend/src/pages/Settings/providers/providerUtils.ts
@@ -112,6 +112,22 @@ const PROVIDER_META: Record<string, ProviderMeta> = {
     description: 'Lokale KI-Transkription via Whisper-Modell',
     credentialType: 'free',
   },
+  subscene: {
+    description: 'Große Community-Sammlung — 60+ Sprachen, kein Konto nötig',
+    credentialType: 'free',
+  },
+  addic7ed: {
+    description: 'TV-Serien-Spezialist mit episodengenauen Untertiteln — optionaler Account',
+    credentialType: 'login',
+  },
+  tvsubtitles: {
+    description: 'Klassischer Multi-Sprachen-Aggregator für TV-Serien',
+    credentialType: 'free',
+  },
+  turkcealtyazi: {
+    description: 'Größter türkischer Untertitel-Provider — Account erforderlich',
+    credentialType: 'login',
+  },
 }
 
 export function getCredentialBadge(providerName: string): CredentialType {


### PR DESCRIPTION
## Summary

### Provider UI Redesign
- **Deaktivieren** (Power button): tile stays in grid at 50% opacity, shows "Deaktiviert" badge
- **Entfernen** (Trash button): removes tile from grid completely; provider moves back to `+` pool
- New `providers_hidden` config key separates "disabled-but-visible" from "removed-from-grid"
- Reactive health checks (on-demand only, no polling); selective enable/disable via `ProviderManager.update_providers()`
- Fixed `PROVIDER_META` for legendasdivx, whisper_subgen and all free providers

### 4 New Subtitle Providers
- **Subscene** — 55 languages, free, HTML scraping (BS4)
- **Addic7ed** — 36 languages, TV series, optional login, BS4
- **TVSubtitles** — 35 languages, TV series, no auth, BS4
- **Turkcealtyazi** — Turkish only, required login, BS4
- All providers use established `_HAS_BS4` graceful-fallback pattern

### Language Expansion
- `_LANGUAGE_TAGS` expanded from 25 to ~70 ISO 639-1 languages
- New `SUPPORTED_LANGUAGES` constant (63 entries) served via `GET /api/v1/languages` (cached 1h)
- `LanguageSelect` dropdown component: searchable, updates both code and `_name` fields
- `source_language` / `target_language` settings now use the dropdown instead of plain text inputs

## Files Changed
- `backend/config.py` — language expansion + new credential fields
- `backend/providers/` — 4 new provider files + `__init__.py` registrations
- `backend/routes/languages.py` — new endpoint
- `backend/routes/config.py` — exclude `providers_hidden` from provider reinit trigger
- `frontend/src/components/shared/LanguageSelect.tsx` — new component
- `frontend/src/pages/Settings/` — ProvidersTab, ProviderTile, AddProviderModal, ProviderEditModal, index.tsx, providerUtils.ts
- `frontend/src/hooks/useApi.ts`, `api/client.ts` — language hooks

## Test plan
- [x] Backend pytest: 90 passed, 0 new failures
- [x] Frontend lint: 0 errors
- [x] TypeScript: 0 type errors
- [x] Provider import test: all 4 providers load with correct name + language counts
- [ ] Manual: Deaktivieren grays tile, Entfernen removes from grid
- [ ] Manual: `+` tile shows only removed providers
- [ ] Manual: Language dropdown searchable, sets source/target lang
- [ ] Manual: Subscene / Addic7ed / TVSubtitles / Turkcealtyazi appear in provider list

🤖 Generated with [Claude Code](https://claude.com/claude-code)