### PR TITLE
fix: wanted search/download broken by missing app context and cache bugs

### DIFF
--- a/backend/providers/__init__.py
+++ b/backend/providers/__init__.py
@@ -585,6 +585,7 @@ class ProviderManager:
                 hearing_impaired=r_data.get("hearing_impaired", False),
                 forced=r_data.get("forced", False),
                 score=r_data.get("score", 0),
+                provider_data=r_data.get("provider_data", {}),
             )
             results.append(result)
         return results
@@ -933,6 +934,7 @@ class ProviderManager:
                     "hearing_impaired": r.hearing_impaired,
                     "forced": r.forced,
                     "score": r.score,
+                    "provider_data": r.provider_data,
                 }
                 for r in all_results
             ]
@@ -1130,11 +1132,11 @@ class ProviderManager:
         # Validate output path is within allowed media directory (path traversal guard)
         try:
             from config import get_settings as _get_settings
+            from security_utils import is_safe_path as _is_safe_path
 
             _settings = _get_settings()
-            _media_path = os.path.abspath(getattr(_settings, "media_path", "/media"))
-            _abs_output = os.path.abspath(output_path)
-            if not _abs_output.startswith(_media_path + os.sep):
+            _media_path = getattr(_settings, "media_path", "/media")
+            if not _is_safe_path(output_path, _media_path):
                 raise ValueError(
                     f"save_subtitle: output_path {output_path!r} is outside media_path"
                 )

--- a/backend/routes/wanted.py
+++ b/backend/routes/wanted.py
@@ -426,13 +426,16 @@ def search_wanted(item_id):
     if not item:
         return jsonify({"error": "Item not found"}), 404
 
+    app = current_app._get_current_object()
+
     def _run():
-        try:
-            result = search_wanted_item(item_id)
-            emit_event("wanted_item_searched", result)
-        except Exception as e:
-            logger.exception("Wanted search failed for item_id=%s", item_id)
-            emit_event("wanted_item_searched", {"wanted_id": item_id, "error": str(e)})
+        with app.app_context():
+            try:
+                result = search_wanted_item(item_id)
+                emit_event("wanted_item_searched", result)
+            except Exception as e:
+                logger.exception("Wanted search failed for item_id=%s", item_id)
+                emit_event("wanted_item_searched", {"wanted_id": item_id, "error": str(e)})
 
     thread = threading.Thread(target=_run, daemon=True)
     thread.start()
@@ -480,21 +483,24 @@ def process_wanted(item_id):
     if not item:
         return jsonify({"error": "Item not found"}), 404
 
+    app = current_app._get_current_object()
+
     def _run():
-        try:
-            result = process_wanted_item(item_id)
-            emit_event("wanted_item_processed", result)
-            if result.get("upgraded"):
-                emit_event(
-                    "upgrade_complete",
-                    {
-                        "file_path": result.get("output_path"),
-                        "provider": result.get("provider"),
-                    },
-                )
-        except Exception as e:
-            logger.exception("Wanted process failed for item_id=%s", item_id)
-            emit_event("wanted_item_processed", {"wanted_id": item_id, "error": str(e)})
+        with app.app_context():
+            try:
+                result = process_wanted_item(item_id)
+                emit_event("wanted_item_processed", result)
+                if result.get("upgraded"):
+                    emit_event(
+                        "upgrade_complete",
+                        {
+                            "file_path": result.get("output_path"),
+                            "provider": result.get("provider"),
+                        },
+                    )
+            except Exception as e:
+                logger.exception("Wanted process failed for item_id=%s", item_id)
+                emit_event("wanted_item_processed", {"wanted_id": item_id, "error": str(e)})
 
     thread = threading.Thread(target=_run, daemon=True)
     thread.start()
@@ -720,7 +726,7 @@ def wanted_search_all():
         return jsonify({"error": "Search already running"}), 409
 
     def _run_search():
-        scanner.search_all(socketio=socketio)
+        scanner._run_search_with_context(socketio=socketio)
 
     thread = threading.Thread(target=_run_search, daemon=True)
     thread.start()

--- a/backend/security_utils.py
+++ b/backend/security_utils.py
@@ -25,7 +25,11 @@ def is_safe_path(file_path: str, base_dir: str) -> bool:
     """
     real_path = os.path.realpath(file_path)
     real_base = os.path.realpath(base_dir)
-    return real_path.startswith(real_base + os.sep) or real_path == real_base
+    # Normalize real_base to always end with sep so startswith works correctly
+    # for root paths like "E:\" that already end with the separator.
+    if not real_base.endswith(os.sep):
+        real_base = real_base + os.sep
+    return real_path.startswith(real_base) or real_path + os.sep == real_base
 
 
 def safe_zip_extract(zip_file: zipfile.ZipFile, dest_dir: str) -> None:


### PR DESCRIPTION
## Summary

Three independent bugs that together made subtitle search + download completely non-functional via the Wanted page:

- **App context missing in background threads** — `search_wanted`, `process_wanted`, and `wanted_search_all` routes spawned threads without Flask app context. `get_wanted_item()` uses flask-sqlalchemy scoped sessions (keyed by thread), which require an active app context → `RuntimeError: Working outside of application context`. The exception was silently swallowed by the catch-all, returning only `{"error": "..."}` to the frontend with no visible cause.

- **Provider cache drops `provider_data`** — `ProviderManager.search()` caches results as JSON but omits `provider_data`. `_deserialize_results()` reconstructs `SubtitleResult` objects without it, so `provider_data = {}`. When `opensubtitles.download()` reads `result.provider_data.get("file_id")` it gets `None` → `"No file_id in provider_data"`.

- **`is_safe_path()` fails for root drive paths** — When `media_path = "E:/"`, `os.path.abspath("E:/")` → `"E:\"`. Adding `os.sep` gives `"E:\\"` (double backslash), which no real path starts with. The inline duplicate of this check in `save_subtitle()` had the same bug. Fixed `is_safe_path()` to normalize the base path (ensure it ends with sep exactly once), and replaced the inline check with a call to `is_safe_path()`.

## Files changed

| File | Change |
|------|--------|
| `backend/routes/wanted.py` | Added `app = current_app._get_current_object()` + `with app.app_context():` in `search_wanted` and `process_wanted` threads; `wanted_search_all` now calls `scanner._run_search_with_context()` |
| `backend/providers/__init__.py` | Added `provider_data` to cache serialization dict; restored it in `_deserialize_results()`; replaced inline path check in `save_subtitle()` with `is_safe_path()` |
| `backend/security_utils.py` | Fixed `is_safe_path()` to normalize base path before `startswith` check |

## Test plan

- [x] Backend tests: 139 passed, ruff clean
- [x] Manual: `POST /wanted/362/download-specific` → `{"success": true, "path": "E:\...\Akiba Maid War - S01E12 - Das Ende von Moe [1080p h264 AAC].de.srt"}` — file on disk (26400 bytes)
- [ ] Interactive search dialog download button works end-to-end in UI
- [ ] Process/auto-search routes also work in background (same fix pattern)