### PR TITLE
feat: show update available badge in sidebar when newer GitHub release exists

### DIFF
--- a/backend/routes/system.py
+++ b/backend/routes/system.py
@@ -17,6 +17,31 @@ from sqlalchemy import text
 from version import __version__
 
 bp = Blueprint("system", __name__, url_prefix="/api/v1")
+
+# ─── Update check (GitHub releases) ──────────────────────────────────────────
+
+_GITHUB_REPO = "Abrechen2/sublarr"
+_UPDATE_CACHE_TTL = 6 * 60 * 60  # 6 hours
+_update_cache: dict = {"result": None, "checked_at": None}
+
+
+def _is_newer_version(tag: str, current: str) -> bool:
+    """Return True if tag represents a newer stable version than current.
+
+    Strips 'v' prefix and pre-release suffixes (e.g. -beta) before comparing
+    (major, minor, patch) integer tuples. No external dependencies.
+    """
+
+    def _parse(v: str) -> tuple[int, ...]:
+        v = v.lstrip("v").split("-")[0]
+        try:
+            return tuple(int(x) for x in v.split(".")[:3])
+        except ValueError:
+            return (0, 0, 0)
+
+    return _parse(tag) > _parse(current)
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -157,6 +182,81 @@ def health():
             "services": service_status,
         }
     ), status_code
+
+
+@bp.route("/update", methods=["GET"])
+def check_update():
+    """Check GitHub for a newer stable release.
+
+    Result is cached for 6 hours. Never raises — returns available=false on
+    any error so the UI degrades gracefully.
+    ---
+    get:
+      tags:
+        - System
+      summary: Check for updates
+      description: Checks GitHub releases for a newer stable version. Cached for 6 hours.
+      responses:
+        200:
+          description: Update check result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  available:
+                    type: boolean
+                  latest:
+                    type: string
+                    nullable: true
+                  current:
+                    type: string
+                  url:
+                    type: string
+                    nullable: true
+    """
+    global _update_cache
+
+    now = time.time()
+    cached = _update_cache
+    if (
+        cached["result"] is not None
+        and cached["checked_at"] is not None
+        and now - cached["checked_at"] < _UPDATE_CACHE_TTL
+    ):
+        return jsonify(cached["result"])
+
+    fallback = {"available": False, "latest": None, "current": __version__, "url": None}
+    try:
+        import requests as _req
+
+        resp = _req.get(
+            f"https://api.github.com/repos/{_GITHUB_REPO}/releases/latest",
+            timeout=5,
+            headers={"Accept": "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28"},
+        )
+        if resp.status_code == 200:
+            data = resp.json()
+            tag = data.get("tag_name", "")
+            url = data.get("html_url", "")
+            # Skip pre-releases (the /releases/latest endpoint already excludes them,
+            # but guard explicitly in case that changes)
+            if tag and not data.get("prerelease", False):
+                result: dict = {
+                    "available": _is_newer_version(tag, __version__),
+                    "latest": tag,
+                    "current": __version__,
+                    "url": url,
+                }
+            else:
+                result = fallback
+        else:
+            result = fallback
+    except Exception:
+        result = fallback
+
+    _update_cache = {"result": result, "checked_at": now}
+    return jsonify(result)
 
 
 @bp.route("/health/detailed", methods=["GET"])

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,6 +1,6 @@
 import axios from 'axios'
 import type {
-  HealthStatus, Stats, PaginatedJobs, Job, BatchState,
+  HealthStatus, UpdateInfo, Stats, PaginatedJobs, Job, BatchState,
   LibraryInfo, SeriesDetail, AppConfig, PaginatedWanted, WantedSummary,
   WantedSearchResponse, WantedBatchStatus, ProviderInfo, ProviderStats,
   RetranslateStatus, LanguageProfile, EpisodeHistoryEntry,
@@ -40,6 +40,11 @@ api.interceptors.request.use((config) => {
 
 export async function getHealth(): Promise<HealthStatus> {
   const { data } = await api.get('/health')
+  return data
+}
+
+export async function getUpdateInfo(): Promise<UpdateInfo> {
+  const { data } = await api.get('/update')
   return data
 }
 

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -19,7 +19,7 @@ import {
   Star,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
-import { useHealth } from '@/hooks/useApi'
+import { useHealth, useUpdateInfo } from '@/hooks/useApi'
 import { ThemeToggle } from '@/components/shared/ThemeToggle'
 import { LanguageSwitcher } from '@/components/shared/LanguageSwitcher'
 import { ScanProgressIndicator } from '@/components/shared/ScanProgressIndicator'
@@ -66,6 +66,7 @@ const navGroups: NavGroup[] = [
 
 export function Sidebar() {
   const { data: health } = useHealth()
+  const { data: updateInfo } = useUpdateInfo()
   const { t } = useTranslation('common')
   const [mobileOpen, setMobileOpen] = useState(false)
   const isHealthy = health?.status === 'healthy'
@@ -282,6 +283,18 @@ export function Sidebar() {
               v{health?.version ?? '…'}
             </span>
           </div>
+          {updateInfo?.available && updateInfo.url && (
+            <a
+              href={updateInfo.url}
+              target="_blank"
+              rel="noreferrer"
+              className="flex items-center gap-1 mt-0.5"
+              style={{ color: 'var(--accent)', fontSize: '10px', fontFamily: 'var(--font-mono)' }}
+            >
+              <span>↑</span>
+              <span>{updateInfo.latest} verfügbar</span>
+            </a>
+          )}
         </div>
       </aside>
     </>

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/react-query'
 import {
-  getHealth, getStats, getJobs,
+  getHealth, getUpdateInfo, getStats, getJobs,
   getBatchStatus, getConfig, updateConfig, getLibrary, getSeriesDetail,
   translateFile, startBatch, getLogs,
   getWantedItems, getWantedSummary, refreshWanted,
@@ -90,6 +90,17 @@ export function useHealth() {
     queryKey: ['health'],
     queryFn: getHealth,
     refetchInterval: 30000,
+  })
+}
+
+export function useUpdateInfo() {
+  const sixHours = 6 * 60 * 60 * 1000
+  return useQuery({
+    queryKey: ['update-info'],
+    queryFn: getUpdateInfo,
+    staleTime: sixHours,
+    refetchInterval: sixHours,
+    retry: 1,
   })
 }
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -26,6 +26,13 @@ export interface HealthStatus {
   services: Record<string, string>
 }
 
+export interface UpdateInfo {
+  available: boolean
+  latest: string | null
+  current: string
+  url: string | null
+}
+
 export interface Stats {
   total_translated: number
   total_failed: number


### PR DESCRIPTION
## Summary
- Adds `GET /api/v1/update` backend endpoint that checks GitHub releases for a newer stable version (6h in-memory cache, no rate limit issues)
- Adds `UpdateInfo` TypeScript interface, `getUpdateInfo()` API client function, and `useUpdateInfo()` TanStack Query hook (6h staleTime + refetchInterval)
- Renders `↑ vX.Y.Z verfügbar` as a clickable link below the version number in the Sidebar footer — only visible when a newer stable release exists

## Test plan
- [ ] Backend: `curl http://localhost:5765/api/v1/update` returns `{"available": bool, "latest": "...", "current": "...", "url": "..."}`
- [ ] Version comparison correctly identifies newer versions (strips `v` prefix and `-beta`/`-alpha` suffixes)
- [ ] Badge appears only when `available: true` and `url` is set
- [ ] Badge links to the GitHub release URL
- [ ] No badge when current version is already the latest
- [ ] Backend tests pass: `cd backend && python -m pytest --tb=short -q`
- [ ] Frontend tests pass: `cd frontend && npm run lint && npm run test -- --run`