### PR TITLE
fix: postgres startup compat and SPA 404 on page reload

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -46,7 +46,7 @@ The current UI is functional but not final. The goal is a clean, modern interfac
 
 ---
 
-## v0.14.0 ✅ (Complete — Current)
+## v0.14.0 ✅ (Complete)
 
 - Provider UI Redesign — Bazarr-style tile grid; Deaktivieren grays tile in place (50% opacity), Entfernen removes to `+` pool; `providers_hidden` config key; reactive health checks on demand only
 - Provider — Subscene — 55-language community subtitle database, no account required
@@ -57,7 +57,21 @@ The current UI is functional but not final. The goal is a clean, modern interfac
 
 ---
 
-## v0.15.0 (Download Security & Sanitization)
+## v0.15.0 ✅ (Complete — Current)
+
+- Sidebar — Update available badge — pulsing badge appears when a newer GitHub release exists; fetched from GitHub Releases API once on load and cached; clicking opens the release page
+- Library — Grid/Thumbnail view — toggle button (table ↔ grid); poster images from Sonarr/Radarr with missing-count badge; preference persisted in localStorage; fallback film-slate SVG
+- Library — Status and profile filters — filter by status (all / has missing / complete) and by profile name; client-side filtering via useMemo
+- Wanted — Extracted status + Sidecar Cleanup — extracting an embedded subtitle now sets status `extracted` instead of removing the item; new cleanup endpoint deletes non-target-language sidecars; teal badge + filter tab in UI
+- Wanted — Error and retry display — failed items show failure reason as tooltip; upcoming retry time shown below badge
+- Settings — Search field — real-time filter for settings tabs
+- SeriesDetail — EpisodeActionMenu — replaces icon-only buttons with labelled primary + `⋯ More` dropdown grouped by category
+- Fix: Wanted search and download — broken by missing Flask app context in background threads and stale provider cache
+- Fix: PostgreSQL startup — `rowid` → `id` in dedup query; `MIN(title)` aggregate in search index; pre-Alembic column patch for `source`; SPA 404 on page reload
+
+---
+
+## v0.16.0 (Download Security & Sanitization)
 
 Goals: Harden the subtitle download pipeline against malicious files from untrusted sources. Background: crafted subtitle files can exploit parser bugs in media players (VLC, Kodi, Jellyfin, Plex) — Sublarr as an automatic downloader must sanitize before files reach the media library.
 
@@ -72,7 +86,7 @@ Goals: Harden the subtitle download pipeline against malicious files from untrus
 
 ---
 
-## v0.16.0 (Subtitle Intelligence)
+## v0.17.0 (Subtitle Intelligence)
 
 Goals: Make Sublarr smarter about what to search for and what to accept.
 
@@ -87,7 +101,7 @@ Goals: Make Sublarr smarter about what to search for and what to accept.
 
 ---
 
-## v0.17.0 (Provider Maturity)
+## v0.18.0 (Provider Maturity)
 
 Goals: Close remaining gap to Bazarr in provider coverage, subtitle type handling, and community integration.
 
@@ -99,7 +113,7 @@ Goals: Close remaining gap to Bazarr in provider coverage, subtitle type handlin
 
 ---
 
-## v0.18.0 (Stream Removal — Safe Remux)
+## v0.19.0 (Stream Removal — Safe Remux)
 
 Goals: Safely remove embedded subtitle streams from video files after extraction, with full rollback capability.
 
@@ -113,7 +127,7 @@ Goals: Safely remove embedded subtitle streams from video files after extraction
 
 ---
 
-## v0.19.0 (Collaboration and Export)
+## v0.20.0 (Collaboration and Export)
 
 Goals: Make Sublarr useful as a subtitle processing pipeline, not just consumer.
 
@@ -125,7 +139,7 @@ Goals: Make Sublarr useful as a subtitle processing pipeline, not just consumer.
 
 ---
 
-## v0.20.0 (Performance and Scalability)
+## v0.21.0 (Performance and Scalability)
 
 Goals: Handle larger libraries without degradation.
 
@@ -137,7 +151,7 @@ Goals: Handle larger libraries without degradation.
 
 ---
 
-## v0.21.0 (Advanced Anime Support)
+## v0.22.0 (Advanced Anime Support)
 
 Goals: First-class support for complex anime subtitle scenarios.
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -110,6 +110,35 @@ def _setup_logging(settings) -> None:
     root.addHandler(ws_handler)
 
 
+def _patch_pre_alembic_columns(engine, inspect_fn) -> None:
+    """Add columns that exist in Alembic migrations but are missing from pre-Alembic databases.
+
+    create_all() is a no-op on existing tables, so DBs created before Alembic
+    was introduced may be missing columns added via later migrations.
+    """
+    from sqlalchemy import text
+
+    insp = inspect_fn(engine)
+    patches = []
+
+    if insp.has_table("subtitle_downloads"):
+        existing = {c["name"] for c in insp.get_columns("subtitle_downloads")}
+        if "source" not in existing:
+            patches.append(
+                "ALTER TABLE subtitle_downloads ADD COLUMN source TEXT DEFAULT 'provider'"
+            )
+
+    if not patches:
+        return
+
+    with engine.connect() as conn:
+        for stmt in patches:
+            conn.execute(text(stmt))
+        conn.commit()
+
+    logger.info("Pre-Alembic DB: patched %d missing column(s)", len(patches))
+
+
 def create_app(testing=False):
     """Create and configure the Flask application.
 
@@ -119,7 +148,11 @@ def create_app(testing=False):
     Returns:
         Configured Flask application instance.
     """
-    app = Flask(__name__, static_folder="static", static_url_path="")
+    # static_folder=None disables Flask's built-in /<path:filename> route which
+    # would intercept SPA routes (e.g. /wanted) and return 404 before our
+    # catch-all serve_spa() can serve index.html. Static files are served by
+    # serve_spa() itself via send_from_directory("static", ...).
+    app = Flask(__name__, static_folder=None)
     app.config["MAX_CONTENT_LENGTH"] = 16 * 1024 * 1024  # 16 MB — prevent request body DoS
 
     # Load config
@@ -181,6 +214,9 @@ def create_app(testing=False):
         if not _inspect(sa_db.engine).has_table("alembic_version"):
             sa_db.create_all()
             logger.info("Fresh DB: ran create_all()")
+            # Pre-Alembic DB: patch any columns that were added via Alembic migrations
+            # but are missing because create_all() is a no-op on existing tables.
+            _patch_pre_alembic_columns(sa_db.engine, _inspect)
         else:
             # Run pending Alembic migrations automatically so new columns are always present
             try:
@@ -240,8 +276,8 @@ def create_app(testing=False):
             with sa_db.engine.connect() as _conn:
                 _dedup_result = _conn.execute(
                     _text(
-                        "DELETE FROM wanted_items WHERE rowid NOT IN ("
-                        "  SELECT MIN(rowid) FROM wanted_items"
+                        "DELETE FROM wanted_items WHERE id NOT IN ("
+                        "  SELECT MIN(id) FROM wanted_items"
                         "  GROUP BY file_path,"
                         "    COALESCE(target_language, ''),"
                         "    COALESCE(subtitle_type, 'full')"

--- a/backend/app.py
+++ b/backend/app.py
@@ -490,8 +490,7 @@ def _register_app_routes(app):
 
 
 def _start_schedulers(settings, app=None):
-    """Start background schedulers (wanted scanner, database backup, standalone watcher, cleanup).
-    """  # noqa: D200
+    """Start background schedulers (wanted scanner, database backup, standalone watcher, cleanup)."""  # noqa: D200
     from wanted_scanner import get_scanner
 
     scanner = get_scanner()

--- a/backend/app.py
+++ b/backend/app.py
@@ -111,13 +111,16 @@ def _setup_logging(settings) -> None:
 
 
 def _patch_pre_alembic_columns(engine, inspect_fn) -> None:
-    """Add columns that exist in Alembic migrations but are missing from pre-Alembic databases.
+    """Add columns missing from pre-Alembic databases.
 
     create_all() is a no-op on existing tables, so DBs created before Alembic
     was introduced may be missing columns added via later migrations.
     """
+    import logging as _logging
+
     from sqlalchemy import text
 
+    _log = _logging.getLogger(__name__)
     insp = inspect_fn(engine)
     patches = []
 
@@ -136,7 +139,7 @@ def _patch_pre_alembic_columns(engine, inspect_fn) -> None:
             conn.execute(text(stmt))
         conn.commit()
 
-    logger.info("Pre-Alembic DB: patched %d missing column(s)", len(patches))
+    _log.info("Pre-Alembic DB: patched %d missing column(s)", len(patches))
 
 
 def create_app(testing=False):
@@ -487,7 +490,8 @@ def _register_app_routes(app):
 
 
 def _start_schedulers(settings, app=None):
-    """Start background schedulers (wanted scanner, database backup, standalone watcher, cleanup)."""
+    """Start background schedulers (wanted scanner, database backup, standalone watcher, cleanup).
+    """  # noqa: D200
     from wanted_scanner import get_scanner
 
     scanner = get_scanner()

--- a/backend/db/repositories/search.py
+++ b/backend/db/repositories/search.py
@@ -86,7 +86,7 @@ class SearchRepository(BaseRepository):
             conn.execute(
                 text("""
                 INSERT INTO search_series(id, title)
-                SELECT sonarr_series_id, title
+                SELECT sonarr_series_id, MIN(title)
                 FROM wanted_items
                 WHERE sonarr_series_id IS NOT NULL AND title IS NOT NULL
                 GROUP BY sonarr_series_id

--- a/backend/db/scoring.py
+++ b/backend/db/scoring.py
@@ -1,6 +1,24 @@
 """Scoring weights and provider modifier operations -- delegating to SQLAlchemy repository."""
 
-from db.repositories.scoring import ScoringRepository
+from db.repositories.scoring import (
+    ScoringRepository,
+    _DEFAULT_EPISODE_WEIGHTS,
+    _DEFAULT_MOVIE_WEIGHTS,
+)
+
+__all__ = [
+    "_DEFAULT_EPISODE_WEIGHTS",
+    "_DEFAULT_MOVIE_WEIGHTS",
+    "get_scoring_weights",
+    "set_scoring_weights",
+    "get_all_scoring_weights",
+    "reset_scoring_weights",
+    "get_effective_weights",
+    "get_provider_modifier",
+    "get_all_provider_modifiers",
+    "set_provider_modifier",
+    "delete_provider_modifier",
+]
 
 _repo = None
 

--- a/backend/db/scoring.py
+++ b/backend/db/scoring.py
@@ -1,9 +1,9 @@
 """Scoring weights and provider modifier operations -- delegating to SQLAlchemy repository."""
 
 from db.repositories.scoring import (
-    ScoringRepository,
     _DEFAULT_EPISODE_WEIGHTS,
     _DEFAULT_MOVIE_WEIGHTS,
+    ScoringRepository,
 )
 
 __all__ = [


### PR DESCRIPTION
## Summary
- **`rowid` → `id`** in `wanted_items` dedup query — PostgreSQL has no implicit `rowid` column; use the `id` primary key instead
- **`GROUP BY sonarr_series_id, MIN(title)`** in search index rebuild — PostgreSQL strict mode requires all non-aggregated SELECT columns in GROUP BY; switched to `MIN(title)` aggregate
- **Pre-Alembic column patch** — databases created before Alembic was introduced miss columns added via migrations; added `_patch_pre_alembic_columns()` to fill `source` (and future gaps) on startup
- **SPA 404 on page reload** — `static_url_path=\"\"` registered Flask's built-in `/<path:filename>` route which intercepted `/wanted`, `/library` etc. and returned 404 before our `serve_spa()` catch-all; fixed by setting `static_folder=None` so only our custom handler runs
- **`_DEFAULT_EPISODE_WEIGHTS` import** — re-exported from `db.scoring` so `routes/hooks.py` can import them without reaching into the repository layer

## Test plan
- [ ] Backend tests green
- [ ] Docker restart: no startup warnings for `rowid` or `GROUP BY`
- [ ] `/wanted` returns 200 on hard reload in browser
- [ ] History/scoring weights page loads without 500