### PR TITLE
fix: library poster zoom, card overlays, modal backdrop and fixed positioning

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -11,6 +11,7 @@ concurrency:
 
 jobs:
   claude-review:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -11,7 +11,6 @@ concurrency:
 
 jobs:
   claude-review:
-    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/backend/radarr_client.py
+++ b/backend/radarr_client.py
@@ -370,7 +370,11 @@ class RadarrClient:
                     "has_file": movie.get("hasFile", False),
                     "path": movie.get("path"),
                     "poster": next(
-                        (img.get("remoteUrl", "") for img in movie.get("images", []) if img.get("coverType") == "poster"),
+                        (
+                            img.get("remoteUrl", "")
+                            for img in movie.get("images", [])
+                            if img.get("coverType") == "poster"
+                        ),
                         "",
                     ),
                     "status": movie.get("status"),

--- a/backend/radarr_client.py
+++ b/backend/radarr_client.py
@@ -369,9 +369,10 @@ class RadarrClient:
                     "year": movie.get("year"),
                     "has_file": movie.get("hasFile", False),
                     "path": movie.get("path"),
-                    "poster": movie.get("images", [{}])[0].get("remoteUrl", "")
-                    if movie.get("images")
-                    else "",
+                    "poster": next(
+                        (img.get("remoteUrl", "") for img in movie.get("images", []) if img.get("coverType") == "poster"),
+                        "",
+                    ),
                     "status": movie.get("status"),
                 }
             )

--- a/backend/sonarr_client.py
+++ b/backend/sonarr_client.py
@@ -473,7 +473,11 @@ class SonarrClient:
                     ),
                     "path": series.get("path"),
                     "poster": next(
-                        (img.get("remoteUrl", "") for img in series.get("images", []) if img.get("coverType") == "poster"),
+                        (
+                            img.get("remoteUrl", "")
+                            for img in series.get("images", [])
+                            if img.get("coverType") == "poster"
+                        ),
                         "",
                     ),
                     "status": series.get("status"),

--- a/backend/sonarr_client.py
+++ b/backend/sonarr_client.py
@@ -472,9 +472,10 @@ class SonarrClient:
                         "episodeFileCount", series.get("episodeFileCount", 0)
                     ),
                     "path": series.get("path"),
-                    "poster": series.get("images", [{}])[0].get("remoteUrl", "")
-                    if series.get("images")
-                    else "",
+                    "poster": next(
+                        (img.get("remoteUrl", "") for img in series.get("images", []) if img.get("coverType") == "poster"),
+                        "",
+                    ),
                     "status": series.get("status"),
                 }
             )

--- a/frontend/src/components/dashboard/WidgetSettingsModal.tsx
+++ b/frontend/src/components/dashboard/WidgetSettingsModal.tsx
@@ -34,105 +34,105 @@ export function WidgetSettingsModal({ open, onClose }: WidgetSettingsModalProps)
         }}
         onClick={(e) => e.stopPropagation()}
       >
-          {/* Header */}
-          <div
-            className="flex items-center justify-between px-5 py-4"
-            style={{ borderBottom: '1px solid var(--border)' }}
-          >
-            <div>
-              <h2 className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
-                {t('widgets.settings_title')}
-              </h2>
-              <p className="text-xs mt-0.5" style={{ color: 'var(--text-muted)' }}>
-                {t('widgets.settings_description')}
-              </p>
-            </div>
-            <button
-              onClick={onClose}
-              className="p-1 rounded hover:opacity-80 transition-opacity"
-              style={{ color: 'var(--text-muted)' }}
-            >
-              <X size={16} />
-            </button>
+        {/* Header */}
+        <div
+          className="flex items-center justify-between px-5 py-4"
+          style={{ borderBottom: '1px solid var(--border)' }}
+        >
+          <div>
+            <h2 className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
+              {t('widgets.settings_title')}
+            </h2>
+            <p className="text-xs mt-0.5" style={{ color: 'var(--text-muted)' }}>
+              {t('widgets.settings_description')}
+            </p>
           </div>
+          <button
+            onClick={onClose}
+            className="p-1 rounded hover:opacity-80 transition-opacity"
+            style={{ color: 'var(--text-muted)' }}
+          >
+            <X size={16} />
+          </button>
+        </div>
 
-          {/* Widget List */}
-          <div className="px-5 py-3 space-y-1 max-h-[60vh] overflow-y-auto">
-            {WIDGET_REGISTRY.map((widget) => {
-              const Icon = widget.icon
-              const isHidden = hiddenWidgets.includes(widget.id)
+        {/* Widget List */}
+        <div className="px-5 py-3 space-y-1 max-h-[60vh] overflow-y-auto">
+          {WIDGET_REGISTRY.map((widget) => {
+            const Icon = widget.icon
+            const isHidden = hiddenWidgets.includes(widget.id)
 
-              return (
-                <div
-                  key={widget.id}
-                  className="flex items-center justify-between py-2 px-2 rounded-md transition-colors"
-                  style={{ backgroundColor: 'var(--bg-primary)' }}
+            return (
+              <div
+                key={widget.id}
+                className="flex items-center justify-between py-2 px-2 rounded-md transition-colors"
+                style={{ backgroundColor: 'var(--bg-primary)' }}
+              >
+                <div className="flex items-center gap-3">
+                  <Icon
+                    size={16}
+                    style={{ color: isHidden ? 'var(--text-muted)' : 'var(--accent)' }}
+                  />
+                  <span
+                    className="text-sm"
+                    style={{
+                      color: isHidden ? 'var(--text-muted)' : 'var(--text-primary)',
+                    }}
+                  >
+                    {t(widget.titleKey)}
+                  </span>
+                </div>
+
+                {/* Toggle Switch */}
+                <button
+                  onClick={() => toggleWidget(widget.id)}
+                  className="relative w-9 h-5 rounded-full transition-colors duration-200"
+                  style={{
+                    backgroundColor: isHidden
+                      ? 'var(--bg-surface)'
+                      : 'var(--accent)',
+                    border: '1px solid var(--border)',
+                  }}
+                  role="switch"
+                  aria-checked={!isHidden}
                 >
-                  <div className="flex items-center gap-3">
-                    <Icon
-                      size={16}
-                      style={{ color: isHidden ? 'var(--text-muted)' : 'var(--accent)' }}
-                    />
-                    <span
-                      className="text-sm"
-                      style={{
-                        color: isHidden ? 'var(--text-muted)' : 'var(--text-primary)',
-                      }}
-                    >
-                      {t(widget.titleKey)}
-                    </span>
-                  </div>
-
-                  {/* Toggle Switch */}
-                  <button
-                    onClick={() => toggleWidget(widget.id)}
-                    className="relative w-9 h-5 rounded-full transition-colors duration-200"
+                  <span
+                    className="absolute top-0.5 w-3.5 h-3.5 rounded-full transition-transform duration-200"
                     style={{
                       backgroundColor: isHidden
-                        ? 'var(--bg-surface)'
-                        : 'var(--accent)',
-                      border: '1px solid var(--border)',
+                        ? 'var(--text-muted)'
+                        : 'var(--bg-primary)',
+                      transform: isHidden ? 'translateX(2px)' : 'translateX(18px)',
                     }}
-                    role="switch"
-                    aria-checked={!isHidden}
-                  >
-                    <span
-                      className="absolute top-0.5 w-3.5 h-3.5 rounded-full transition-transform duration-200"
-                      style={{
-                        backgroundColor: isHidden
-                          ? 'var(--text-muted)'
-                          : 'var(--bg-primary)',
-                        transform: isHidden ? 'translateX(2px)' : 'translateX(18px)',
-                      }}
-                    />
-                  </button>
-                </div>
-              )
-            })}
-          </div>
-
-          {/* Footer */}
-          <div
-            className="px-5 py-3 flex justify-end"
-            style={{ borderTop: '1px solid var(--border)' }}
-          >
-            <button
-              onClick={() => {
-                resetToDefault()
-                onClose()
-              }}
-              className="flex items-center gap-2 px-3 py-1.5 rounded-md text-xs font-medium transition-all duration-150 hover:opacity-80"
-              style={{
-                backgroundColor: 'var(--bg-primary)',
-                border: '1px solid var(--border)',
-                color: 'var(--text-secondary)',
-              }}
-            >
-              <RotateCcw size={12} />
-              {t('widgets.reset_layout')}
-            </button>
-          </div>
+                  />
+                </button>
+              </div>
+            )
+          })}
         </div>
+
+        {/* Footer */}
+        <div
+          className="px-5 py-3 flex justify-end"
+          style={{ borderTop: '1px solid var(--border)' }}
+        >
+          <button
+            onClick={() => {
+              resetToDefault()
+              onClose()
+            }}
+            className="flex items-center gap-2 px-3 py-1.5 rounded-md text-xs font-medium transition-all duration-150 hover:opacity-80"
+            style={{
+              backgroundColor: 'var(--bg-primary)',
+              border: '1px solid var(--border)',
+              color: 'var(--text-secondary)',
+            }}
+          >
+            <RotateCcw size={12} />
+            {t('widgets.reset_layout')}
+          </button>
+        </div>
+      </div>
     </div>
   )
 }

--- a/frontend/src/components/dashboard/WidgetSettingsModal.tsx
+++ b/frontend/src/components/dashboard/WidgetSettingsModal.tsx
@@ -21,23 +21,19 @@ export function WidgetSettingsModal({ open, onClose }: WidgetSettingsModalProps)
   if (!open) return null
 
   return (
-    <>
-      {/* Backdrop */}
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      style={{ backgroundColor: 'rgba(0,0,0,0.5)', backdropFilter: 'blur(4px)' }}
+      onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
+    >
       <div
-        className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm"
-        onClick={onClose}
-      />
-
-      {/* Modal */}
-      <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-        <div
-          className="w-full max-w-md rounded-lg overflow-hidden shadow-2xl"
-          style={{
-            backgroundColor: 'var(--bg-surface)',
-            border: '1px solid var(--border)',
-          }}
-          onClick={(e) => e.stopPropagation()}
-        >
+        className="w-full max-w-md rounded-lg overflow-hidden shadow-2xl"
+        style={{
+          backgroundColor: 'var(--bg-surface)',
+          border: '1px solid var(--border)',
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
           {/* Header */}
           <div
             className="flex items-center justify-between px-5 py-4"
@@ -137,7 +133,6 @@ export function WidgetSettingsModal({ open, onClose }: WidgetSettingsModalProps)
             </button>
           </div>
         </div>
-      </div>
-    </>
+    </div>
   )
 }

--- a/frontend/src/components/editor/SubtitleEditorModal.tsx
+++ b/frontend/src/components/editor/SubtitleEditorModal.tsx
@@ -7,6 +7,7 @@
  */
 
 import { lazy, Suspense, useState, useEffect, useCallback, useRef } from 'react'
+import { createPortal } from 'react-dom'
 import { Loader2, X, Eye, Pencil, GitCompare, RefreshCw, Activity } from 'lucide-react'
 import { useQueryClient } from '@tanstack/react-query'
 import { useSubtitleContent } from '@/hooks/useApi'
@@ -181,7 +182,7 @@ export default function SubtitleEditorModal({
     ...(videoPath ? [{ key: 'waveform' as const, label: 'Waveform', icon: Activity }] : []),
   ]
 
-  return (
+  return createPortal(
     <div
       ref={overlayRef}
       className="fixed inset-0 z-50 flex items-center justify-center"
@@ -385,6 +386,7 @@ export default function SubtitleEditorModal({
           </Suspense>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   )
 }

--- a/frontend/src/components/editor/SubtitleTimeline.tsx
+++ b/frontend/src/components/editor/SubtitleTimeline.tsx
@@ -106,8 +106,7 @@ export default function SubtitleTimeline({
           <span
             key={i}
             className="absolute text-[10px] -translate-x-1/2"
-            style={{ color: 'var(--text-muted)' }}
-            style={{ left: `${left}%` }}
+            style={{ color: 'var(--text-muted)', left: `${left}%` }}
           >
             {formatTime(time)}
           </span>

--- a/frontend/src/components/library/LibraryGridCard.tsx
+++ b/frontend/src/components/library/LibraryGridCard.tsx
@@ -16,42 +16,44 @@ export function LibraryGridCard({ item, onClick }: LibraryGridCardProps) {
   return (
     <div
       onClick={onClick}
-      className="relative cursor-pointer rounded-lg overflow-hidden group"
+      className="cursor-pointer rounded-lg overflow-hidden group"
       style={{ border: '1px solid var(--border)' }}
     >
-      {/* Poster */}
-      {item.poster ? (
-        <img
-          src={item.poster}
-          alt={item.title}
-          className="w-full object-cover"
-          style={{ aspectRatio: '2/3' }}
-          loading="lazy"
-        />
-      ) : (
+      {/* Image area — overlays scoped here so they don't cover the title bar */}
+      <div className="relative">
+        {item.poster ? (
+          <img
+            src={item.poster}
+            alt={item.title}
+            className="w-full object-cover"
+            style={{ aspectRatio: '2/3' }}
+            loading="lazy"
+          />
+        ) : (
+          <div
+            className="w-full flex items-center justify-center"
+            style={{ aspectRatio: '2/3', backgroundColor: 'var(--bg-surface)' }}
+          >
+            <Film size={32} style={{ color: 'var(--text-muted)' }} />
+          </div>
+        )}
+
+        {/* Hover overlay */}
         <div
-          className="w-full flex items-center justify-center"
-          style={{ aspectRatio: '2/3', backgroundColor: 'var(--bg-surface)' }}
-        >
-          <Film size={32} style={{ color: 'var(--text-muted)' }} />
-        </div>
-      )}
+          className="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-150"
+          style={{ backgroundColor: 'rgba(0,0,0,0.3)' }}
+        />
 
-      {/* Missing badge */}
-      {missingCount > 0 && (
-        <span
-          className="absolute top-1 right-1 rounded px-1.5 py-0.5 text-[10px] font-bold text-white"
-          style={{ backgroundColor: 'var(--error)' }}
-        >
-          {missingCount}
-        </span>
-      )}
-
-      {/* Hover overlay */}
-      <div
-        className="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-150"
-        style={{ backgroundColor: 'rgba(0,0,0,0.3)' }}
-      />
+        {/* Missing badge — after hover overlay in DOM so it renders on top */}
+        {missingCount > 0 && (
+          <span
+            className="absolute top-1 right-1 rounded px-1.5 py-0.5 text-[10px] font-bold text-white"
+            style={{ backgroundColor: 'var(--error)' }}
+          >
+            {missingCount}
+          </span>
+        )}
+      </div>
 
       {/* Title bar */}
       <div

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -158,7 +158,6 @@ h2 {
   }
   to {
     opacity: 1;
-    transform: translateY(0);
   }
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -158,6 +158,7 @@ h2 {
   }
   to {
     opacity: 1;
+    transform: translateY(0);
   }
 }
 

--- a/frontend/src/pages/SeriesDetail.tsx
+++ b/frontend/src/pages/SeriesDetail.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useCallback, lazy, Suspense } from 'react'
+import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
@@ -1728,7 +1729,7 @@ export function SeriesDetailPage() {
       )}
 
       {/* Comparison Selector Modal */}
-      {compareSelectorEp && series && (
+      {compareSelectorEp && series && createPortal(
         <div
           className="fixed inset-0 z-50 flex items-center justify-center"
           style={{ backgroundColor: 'rgba(0,0,0,0.6)' }}
@@ -1753,11 +1754,12 @@ export function SeriesDetailPage() {
               onClose={() => setCompareSelectorEp(null)}
             />
           </div>
-        </div>
+        </div>,
+        document.body
       )}
 
       {/* Comparison View Modal */}
-      {comparisonPaths && (
+      {comparisonPaths && createPortal(
         <div
           className="fixed inset-0 z-50 flex flex-col"
           style={{ backgroundColor: 'var(--bg-primary)' }}
@@ -1774,11 +1776,12 @@ export function SeriesDetailPage() {
               onClose={() => setComparisonPaths(null)}
             />
           </Suspense>
-        </div>
+        </div>,
+        document.body
       )}
 
       {/* Sync Controls Modal */}
-      {syncFilePath && (
+      {syncFilePath && createPortal(
         <div
           className="fixed inset-0 z-50 flex items-center justify-center"
           style={{ backgroundColor: 'rgba(0,0,0,0.6)' }}
@@ -1804,7 +1807,8 @@ export function SeriesDetailPage() {
               />
             </Suspense>
           </div>
-        </div>
+        </div>,
+        document.body
       )}
 
       {/* Video Sync Modal (ffsubsync / alass) */}
@@ -1833,7 +1837,7 @@ export function SeriesDetailPage() {
       />
 
       {/* Health Check Panel Modal */}
-      {healthCheckPath && (
+      {healthCheckPath && createPortal(
         <div
           className="fixed inset-0 z-50 flex items-center justify-center"
           style={{ backgroundColor: 'rgba(0,0,0,0.6)' }}
@@ -1866,7 +1870,8 @@ export function SeriesDetailPage() {
               />
             </Suspense>
           </div>
-        </div>
+        </div>,
+        document.body
       )}
     </div>
   )


### PR DESCRIPTION
## Summary

- **Poster zoom** — \`sonarr_client\` + \`radarr_client\`: filter images by \`coverType == \"poster\"\` instead of taking \`images[0]\` (which was often a 758×140px banner, causing extreme zoom in the 2:3 card)
- **Card overlay stacking** — \`LibraryGridCard\`: scope overlays to the image-only inner div (prevent hover overlay from covering the title bar); place missing-count badge after the overlay in DOM so it renders on top
- **Modal backdrop click** — \`WidgetSettingsModal\`: rewrite from split z-50 backdrop/modal siblings (broken pattern — modal sibling was topmost, swallowing all clicks) to single wrapper div with \`e.target === e.currentTarget\` check
- **Modal fixed positioning** — \`SubtitleEditorModal\` + 4 inline modals in \`SeriesDetail\`: render via \`createPortal(…, document.body)\` so they are completely outside any ancestor stacking context. Root cause: \`.animate-in\` uses \`fadeSlideUp\` with \`fill-mode: both\`, which retains \`transform: matrix(1,0,0,1,0,0)\` permanently — this creates a stacking context that traps all \`position: fixed\` descendants within the wrapper instead of the full viewport. CSS fixes (removing the transform or setting \`transform: none\`) don't work because Chromium keeps the computed matrix value from fill-mode interpolation; \`createPortal\` is the correct fix.
- **Timeline color** — \`SubtitleTimeline\`: merge duplicate \`style\` props on time ruler span (second overwrote first, losing \`color: var(--text-muted)\`)

## Test plan

- [ ] Backend tests green (\`python -m pytest --tb=short -q\`)
- [ ] Frontend lint + tsc clean
- [ ] Library grid: posters show correctly (no banner zoom)
- [ ] Library grid: hover overlay stays within image area, missing badge visible on hover
- [ ] Dashboard widget settings modal: clicking outside closes it
- [ ] SeriesDetail: SubtitleEditorModal covers full viewport (not just the content area starting at x=240) — verified with Playwright: \`{x:0, width:1535, coversFullViewport:true}\`
- [ ] SeriesDetail: all other overlays (sync, health check, comparison) also cover full viewport