### PR TITLE
feat: OpenSubtitles API-level format filter for ASS preference

### DIFF
--- a/backend/providers/__init__.py
+++ b/backend/providers/__init__.py
@@ -718,6 +718,12 @@ class ProviderManager:
         Returns:
             List of SubtitleResult sorted by score (highest first)
         """
+        # Propagate format preference to providers so they can apply API-level filters
+        # (e.g. OpenSubtitles /subtitles?format=ass). This reduces response noise before
+        # client-side filtering. Only set if not already specified by the caller.
+        if format_filter and not query.preferred_format:
+            query.preferred_format = format_filter.value
+
         # Check cache first (two-tier: fast app cache, then persistent DB cache)
         cache_key = self._make_cache_key(query, format_filter)
         cache_ttl_minutes = getattr(self.settings, "provider_cache_ttl_minutes", 5)

--- a/backend/providers/base.py
+++ b/backend/providers/base.py
@@ -88,6 +88,11 @@ class VideoQuery:
     # Forced/signs subtitle search
     forced_only: bool = False  # When True, providers filter for forced/signs subtitles
 
+    # Format preference hint — set by ProviderManager when format_filter is active.
+    # Providers that support API-level format filtering (e.g. OpenSubtitles) use this
+    # to reduce noise before results are filtered client-side.
+    preferred_format: str = ""  # "ass", "srt", etc. — empty = no preference
+
     @property
     def is_episode(self) -> bool:
         return self.season is not None and self.episode is not None

--- a/backend/providers/opensubtitles.py
+++ b/backend/providers/opensubtitles.py
@@ -252,6 +252,12 @@ class OpenSubtitlesProvider(SubtitleProvider):
             logger.warning("OpenSubtitles: insufficient search criteria - params: %s", params)
             return []
 
+        # API-level format filter: reduces response noise when a specific format is requested.
+        # OpenSubtitles /subtitles accepts ?format=ass|srt|sub|... — only known formats are passed.
+        if query.preferred_format in _FORMAT_MAP:
+            params["format"] = query.preferred_format
+            logger.debug("OpenSubtitles: applying API format filter: %s", query.preferred_format)
+
         logger.debug("OpenSubtitles: API request params: %s", params)
         try:
             resp = self.session.get(f"{API_BASE}/subtitles", params=params)

--- a/backend/tests/test_new_providers.py
+++ b/backend/tests/test_new_providers.py
@@ -1,4 +1,4 @@
-"""Unit tests for the 4 new subtitle providers."""
+"""Unit tests for subtitle providers including OpenSubtitles format filter."""
 
 from unittest.mock import MagicMock, patch
 
@@ -494,3 +494,98 @@ class TestTurkcealtyaziProvider:
         with patch("providers.turkcealtyazi._HAS_BS4", False):
             result = p.search(q)
         assert result == []
+
+
+class TestOpenSubtitlesFormatFilter:
+    """Tests for OpenSubtitles API-level format filter (Option C)."""
+
+    def test_preferred_format_added_to_params_when_set(self):
+        """When preferred_format='ass', the API request includes format=ass."""
+        from providers.base import VideoQuery
+        from providers.opensubtitles import OpenSubtitlesProvider
+
+        provider = OpenSubtitlesProvider(api_key="test-key")
+        provider.session = MagicMock()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"data": []}
+        provider.session.get.return_value = mock_response
+
+        query = VideoQuery(
+            title="Test Movie",
+            languages=["de"],
+            preferred_format="ass",
+        )
+        provider.search(query)
+
+        call_kwargs = provider.session.get.call_args
+        params = call_kwargs[1]["params"] if "params" in call_kwargs[1] else call_kwargs[0][1]
+        assert params.get("format") == "ass"
+
+    def test_no_format_param_when_preferred_format_empty(self):
+        """When preferred_format is empty, no format param is sent to the API."""
+        from providers.base import VideoQuery
+        from providers.opensubtitles import OpenSubtitlesProvider
+
+        provider = OpenSubtitlesProvider(api_key="test-key")
+        provider.session = MagicMock()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"data": []}
+        provider.session.get.return_value = mock_response
+
+        query = VideoQuery(title="Test Movie", languages=["de"])
+        provider.search(query)
+
+        call_kwargs = provider.session.get.call_args
+        params = call_kwargs[1]["params"] if "params" in call_kwargs[1] else call_kwargs[0][1]
+        assert "format" not in params
+
+    def test_no_format_param_for_unknown_format(self):
+        """Unknown format strings are not forwarded to avoid invalid API params."""
+        from providers.base import VideoQuery
+        from providers.opensubtitles import OpenSubtitlesProvider
+
+        provider = OpenSubtitlesProvider(api_key="test-key")
+        provider.session = MagicMock()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"data": []}
+        provider.session.get.return_value = mock_response
+
+        query = VideoQuery(title="Test Movie", languages=["de"], preferred_format="unknown")
+        provider.search(query)
+
+        call_kwargs = provider.session.get.call_args
+        params = call_kwargs[1]["params"] if "params" in call_kwargs[1] else call_kwargs[0][1]
+        assert "format" not in params
+
+    def test_srt_format_also_forwarded(self):
+        """SRT format preference is also forwarded to the API."""
+        from providers.base import VideoQuery
+        from providers.opensubtitles import OpenSubtitlesProvider
+
+        provider = OpenSubtitlesProvider(api_key="test-key")
+        provider.session = MagicMock()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"data": []}
+        provider.session.get.return_value = mock_response
+
+        query = VideoQuery(title="Test Movie", languages=["de"], preferred_format="srt")
+        provider.search(query)
+
+        call_kwargs = provider.session.get.call_args
+        params = call_kwargs[1]["params"] if "params" in call_kwargs[1] else call_kwargs[0][1]
+        assert params.get("format") == "srt"
+
+    def test_video_query_preferred_format_default_empty(self):
+        """VideoQuery.preferred_format defaults to empty string (backward compatible)."""
+        from providers.base import VideoQuery
+
+        q = VideoQuery(title="Test")
+        assert q.preferred_format == ""


### PR DESCRIPTION
## Summary

- Adds `preferred_format: str = ""` to `VideoQuery` as a format hint for providers
- `ProviderManager.search()` sets it from `format_filter` before calling providers
- `OpenSubtitlesProvider.search()` adds `?format=ass|srt` to the API request when set
- Only known formats (`_FORMAT_MAP`: ass, srt, ssa, vtt) are forwarded — unknown/empty is ignored

## Why

When `process_wanted_item` searches for ASS subtitles (Step 1+2), the OpenSubtitles API previously returned **all** results (mostly SRT), which then passed through the client-side format filter as `UNKNOWN`. With the API-level filter, only ASS results come back from OpenSubtitles, so there's no ambiguity about which UNKNOWN-format results might actually be SRT.

## Test plan
- [x] 5 unit tests added to `TestOpenSubtitlesFormatFilter`
  - `?format=ass` is added when preferred_format="ass"
  - No `format` param when preferred_format is empty
  - No `format` param for unknown/unsupported format values
  - SRT preference is also forwarded correctly
  - `preferred_format` defaults to `""` (backward compatible)
- [x] Full backend test suite: 144 passed, 0 new failures
- [x] ruff check + format: all clean