### PR TITLE
fix: detect OpenSubtitles format from /download response filename

### DIFF
--- a/backend/providers/opensubtitles.py
+++ b/backend/providers/opensubtitles.py
@@ -399,6 +399,20 @@ class OpenSubtitlesProvider(SubtitleProvider):
         if not download_link:
             raise RuntimeError("No download link in response")
 
+        # The /download response returns the actual file_name with extension (e.g. "Movie.de.ass").
+        # The /subtitles search API omits the format field entirely for most entries, so this
+        # is the only reliable place to detect the real format before saving.
+        actual_filename = data.get("file_name", "")
+        if actual_filename:
+            ext = os.path.splitext(actual_filename)[1].lower().lstrip(".")
+            if ext in _FORMAT_MAP:
+                result.format = _FORMAT_MAP[ext]
+                logger.debug(
+                    "OpenSubtitles: format resolved from download filename: %s -> %s",
+                    actual_filename,
+                    result.format.value,
+                )
+
         # Download the actual file
         dl_resp = self.session.get(download_link)
         if dl_resp.status_code != 200:

--- a/backend/tests/test_new_providers.py
+++ b/backend/tests/test_new_providers.py
@@ -494,3 +494,103 @@ class TestTurkcealtyaziProvider:
         with patch("providers.turkcealtyazi._HAS_BS4", False):
             result = p.search(q)
         assert result == []
+
+
+class TestOpenSubtitlesDownloadFormatDetection:
+    """Tests for format detection via /download endpoint file_name (the real fix).
+
+    The /subtitles search API does not populate the 'format' attribute,
+    leaving all results as UNKNOWN. The /download endpoint returns a
+    file_name with the actual extension (e.g. 'Movie.de.ass'), which is
+    the only reliable source of format info before saving the file.
+    """
+
+    def _make_provider(self):
+        from providers.opensubtitles import OpenSubtitlesProvider
+        p = OpenSubtitlesProvider(api_key="test-key")
+        p.session = MagicMock()
+        return p
+
+    def _make_result(self, fmt="unknown"):
+        from providers.base import SubtitleFormat, SubtitleResult
+        return SubtitleResult(
+            provider_name="opensubtitles",
+            subtitle_id="123",
+            language="de",
+            format=SubtitleFormat(fmt),
+            provider_data={"file_id": 7391597},
+        )
+
+    def _mock_download(self, provider, file_name, content=b"1\n00:00:01,000 --> 00:00:02,000\nHello\n"):
+        dl_resp = MagicMock()
+        dl_resp.status_code = 200
+        dl_resp.content = content
+        provider.session.post.return_value = MagicMock(
+            status_code=200,
+            json=lambda: {"link": "https://example.com/file", "file_name": file_name},
+        )
+        provider.session.get.return_value = dl_resp
+
+    def test_format_set_to_srt_from_download_filename(self):
+        """UNKNOWN result → download returns .srt filename → format becomes SRT."""
+        from providers.base import SubtitleFormat
+        p = self._make_provider()
+        result = self._make_result("unknown")
+        self._mock_download(p, "[Crunchyroll] My Dress-Up Darling S01E12.Deutsch.srt")
+
+        p.download(result)
+
+        assert result.format == SubtitleFormat.SRT
+
+    def test_format_set_to_ass_from_download_filename(self):
+        """UNKNOWN result → download returns .ass filename → format becomes ASS."""
+        from providers.base import SubtitleFormat
+        p = self._make_provider()
+        result = self._make_result("unknown")
+        ass_content = b"[Script Info]\nScriptType: v4.00+\n"
+        self._mock_download(p, "Anime.S01E01.de.ass", ass_content)
+
+        p.download(result)
+
+        assert result.format == SubtitleFormat.ASS
+
+    def test_format_unchanged_when_no_filename_in_download_response(self):
+        """No file_name in download response → format stays UNKNOWN."""
+        from providers.base import SubtitleFormat
+        p = self._make_provider()
+        result = self._make_result("unknown")
+        dl_resp = MagicMock()
+        dl_resp.status_code = 200
+        dl_resp.content = b"content"
+        p.session.post.return_value = MagicMock(
+            status_code=200,
+            json=lambda: {"link": "https://example.com/file"},  # no file_name
+        )
+        p.session.get.return_value = dl_resp
+
+        p.download(result)
+
+        assert result.format == SubtitleFormat.UNKNOWN
+
+    def test_format_unchanged_for_unknown_extension(self):
+        """Unrecognised extension in download filename → format stays UNKNOWN."""
+        from providers.base import SubtitleFormat
+        p = self._make_provider()
+        result = self._make_result("unknown")
+        self._mock_download(p, "Subtitle.de.ger")  # .ger not in _FORMAT_MAP
+
+        p.download(result)
+
+        assert result.format == SubtitleFormat.UNKNOWN
+
+    def test_existing_known_format_not_overridden(self):
+        """If format was already known (ASS), download filename can still update it."""
+        from providers.base import SubtitleFormat
+        p = self._make_provider()
+        result = self._make_result("ass")  # already set by search
+        self._mock_download(p, "Subtitle.de.srt")  # download says SRT
+
+        p.download(result)
+
+        # Download file_name wins — it's the ground truth
+        assert result.format == SubtitleFormat.SRT

--- a/backend/tests/test_new_providers.py
+++ b/backend/tests/test_new_providers.py
@@ -507,12 +507,14 @@ class TestOpenSubtitlesDownloadFormatDetection:
 
     def _make_provider(self):
         from providers.opensubtitles import OpenSubtitlesProvider
+
         p = OpenSubtitlesProvider(api_key="test-key")
         p.session = MagicMock()
         return p
 
     def _make_result(self, fmt="unknown"):
         from providers.base import SubtitleFormat, SubtitleResult
+
         return SubtitleResult(
             provider_name="opensubtitles",
             subtitle_id="123",
@@ -521,7 +523,9 @@ class TestOpenSubtitlesDownloadFormatDetection:
             provider_data={"file_id": 7391597},
         )
 
-    def _mock_download(self, provider, file_name, content=b"1\n00:00:01,000 --> 00:00:02,000\nHello\n"):
+    def _mock_download(
+        self, provider, file_name, content=b"1\n00:00:01,000 --> 00:00:02,000\nHello\n"
+    ):
         dl_resp = MagicMock()
         dl_resp.status_code = 200
         dl_resp.content = content
@@ -534,6 +538,7 @@ class TestOpenSubtitlesDownloadFormatDetection:
     def test_format_set_to_srt_from_download_filename(self):
         """UNKNOWN result → download returns .srt filename → format becomes SRT."""
         from providers.base import SubtitleFormat
+
         p = self._make_provider()
         result = self._make_result("unknown")
         self._mock_download(p, "[Crunchyroll] My Dress-Up Darling S01E12.Deutsch.srt")
@@ -545,6 +550,7 @@ class TestOpenSubtitlesDownloadFormatDetection:
     def test_format_set_to_ass_from_download_filename(self):
         """UNKNOWN result → download returns .ass filename → format becomes ASS."""
         from providers.base import SubtitleFormat
+
         p = self._make_provider()
         result = self._make_result("unknown")
         ass_content = b"[Script Info]\nScriptType: v4.00+\n"
@@ -557,6 +563,7 @@ class TestOpenSubtitlesDownloadFormatDetection:
     def test_format_unchanged_when_no_filename_in_download_response(self):
         """No file_name in download response → format stays UNKNOWN."""
         from providers.base import SubtitleFormat
+
         p = self._make_provider()
         result = self._make_result("unknown")
         dl_resp = MagicMock()
@@ -575,6 +582,7 @@ class TestOpenSubtitlesDownloadFormatDetection:
     def test_format_unchanged_for_unknown_extension(self):
         """Unrecognised extension in download filename → format stays UNKNOWN."""
         from providers.base import SubtitleFormat
+
         p = self._make_provider()
         result = self._make_result("unknown")
         self._mock_download(p, "Subtitle.de.ger")  # .ger not in _FORMAT_MAP
@@ -586,6 +594,7 @@ class TestOpenSubtitlesDownloadFormatDetection:
     def test_existing_known_format_not_overridden(self):
         """If format was already known (ASS), download filename can still update it."""
         from providers.base import SubtitleFormat
+
         p = self._make_provider()
         result = self._make_result("ass")  # already set by search
         self._mock_download(p, "Subtitle.de.srt")  # download says SRT


### PR DESCRIPTION
## Summary

- The OpenSubtitles `/subtitles` search API never populates the `format` attribute (confirmed by live test)
- The `/download` endpoint returns a `file_name` field with the actual extension (e.g. `Movie.de.ass`)
- Now extracts format from this filename in `download()` → sets `result.format` before saving

## Live test findings (My Dress-Up Darling S01E12 DE)

| Test | Result |
|------|--------|
| `?format=ass` API param | Ignored — same results as no filter |
| `attrs.format` in search response | Always `<missing>` |
| `/download` response `file_name` | `[Crunchyroll] ... .Deutsch.srt` ✓ |
| Content sniff | SRT confirmed |
| Website shows ASS | Website metadata incorrect |

## Impact

- Format correctly set after download → file saved with correct extension
- Format shown correctly in UI history/library
- If a subtitle on OpenSubtitles is actually ASS, it now gets the +50 score bonus on re-use

## Test plan
- [x] 5 unit tests: srt from filename, ass from filename, missing filename, unknown ext, existing format override
- [x] Full backend suite: 144 passed, 0 new failures
- [x] ruff: clean