### PR TITLE
fix: update result.format after ZIP extraction in TVSubtitles and TurkceAltyazi

### DIFF
--- a/backend/providers/turkcealtyazi.py
+++ b/backend/providers/turkcealtyazi.py
@@ -34,6 +34,12 @@ logger = logging.getLogger(__name__)
 
 _BASE_URL = "https://turkcealtyazi.org"
 _LOGIN_URL = f"{_BASE_URL}/giris"
+_FORMAT_MAP = {
+    "srt": SubtitleFormat.SRT,
+    "ass": SubtitleFormat.ASS,
+    "ssa": SubtitleFormat.SSA,
+    "vtt": SubtitleFormat.VTT,
+}
 _SEARCH_URL = f"{_BASE_URL}/ara"
 _BROWSER_UA = (
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
@@ -235,6 +241,9 @@ class TurkcealtyaziProvider(SubtitleProvider):
                         if name.lower().endswith((".srt", ".ass", ".ssa", ".vtt")):
                             content = zf.read(name)
                             result.filename = name
+                            ext = name.lower().rsplit(".", 1)[-1] if "." in name else ""
+                            if ext in _FORMAT_MAP:
+                                result.format = _FORMAT_MAP[ext]
                             break
             except Exception as e:
                 logger.warning("Turkcealtyazi: ZIP extraction failed: %s", e)

--- a/backend/providers/tvsubtitles.py
+++ b/backend/providers/tvsubtitles.py
@@ -32,6 +32,12 @@ from providers.http_session import create_session
 logger = logging.getLogger(__name__)
 
 _BASE_URL = "https://www.tvsubtitles.net"
+_FORMAT_MAP = {
+    "srt": SubtitleFormat.SRT,
+    "ass": SubtitleFormat.ASS,
+    "ssa": SubtitleFormat.SSA,
+    "vtt": SubtitleFormat.VTT,
+}
 _BROWSER_UA = (
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
     "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
@@ -266,6 +272,9 @@ class TVSubtitlesProvider(SubtitleProvider):
                         if name.lower().endswith((".srt", ".ass", ".ssa", ".vtt")):
                             content = zf.read(name)
                             result.filename = name
+                            ext = name.lower().rsplit(".", 1)[-1] if "." in name else ""
+                            if ext in _FORMAT_MAP:
+                                result.format = _FORMAT_MAP[ext]
                             break
             except Exception as e:
                 logger.warning("TVSubtitles: ZIP extraction failed: %s", e)

--- a/backend/tests/test_new_providers.py
+++ b/backend/tests/test_new_providers.py
@@ -603,3 +603,162 @@ class TestOpenSubtitlesDownloadFormatDetection:
 
         # Download file_name wins — it's the ground truth
         assert result.format == SubtitleFormat.SRT
+
+
+class TestTVSubtitlesZipFormatDetection:
+    """Tests that TVSubtitles correctly updates format after ZIP extraction."""
+
+    def _make_zip(self, filename: str, file_content: bytes = b"subtitle content") -> bytes:
+        import io
+        import zipfile
+
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr(filename, file_content)
+        return buf.getvalue()
+
+    def test_format_set_to_ass_from_zip_entry(self):
+        from providers.base import SubtitleFormat, SubtitleResult
+        from providers.tvsubtitles import TVSubtitlesProvider
+
+        p = TVSubtitlesProvider()
+        p.session = MagicMock()
+        zip_bytes = self._make_zip("Subtitle.ass")
+        p.session.get.return_value = MagicMock(status_code=200, content=zip_bytes)
+
+        r = SubtitleResult(
+            provider_name="tvsubtitles",
+            subtitle_id="1",
+            language="de",
+            format=SubtitleFormat.SRT,
+            download_url="https://www.tvsubtitles.net/download-1.zip",
+        )
+        p.download(r)
+
+        assert r.format == SubtitleFormat.ASS
+        assert r.filename == "Subtitle.ass"
+
+    def test_format_set_to_srt_from_zip_entry(self):
+        from providers.base import SubtitleFormat, SubtitleResult
+        from providers.tvsubtitles import TVSubtitlesProvider
+
+        p = TVSubtitlesProvider()
+        p.session = MagicMock()
+        zip_bytes = self._make_zip("Subtitle.srt")
+        p.session.get.return_value = MagicMock(status_code=200, content=zip_bytes)
+
+        r = SubtitleResult(
+            provider_name="tvsubtitles",
+            subtitle_id="2",
+            language="en",
+            format=SubtitleFormat.SRT,
+            download_url="https://www.tvsubtitles.net/download-2.zip",
+        )
+        p.download(r)
+
+        assert r.format == SubtitleFormat.SRT
+        assert r.filename == "Subtitle.srt"
+
+    def test_format_unchanged_when_not_zip(self):
+        from providers.base import SubtitleFormat, SubtitleResult
+        from providers.tvsubtitles import TVSubtitlesProvider
+
+        p = TVSubtitlesProvider()
+        p.session = MagicMock()
+        raw_srt = b"1\n00:00:01,000 --> 00:00:02,000\nHello\n"
+        p.session.get.return_value = MagicMock(status_code=200, content=raw_srt)
+
+        r = SubtitleResult(
+            provider_name="tvsubtitles",
+            subtitle_id="3",
+            language="en",
+            format=SubtitleFormat.SRT,
+            download_url="https://www.tvsubtitles.net/download-3",
+        )
+        p.download(r)
+
+        assert r.format == SubtitleFormat.SRT
+
+
+class TestTurkcealtyaziZipFormatDetection:
+    """Tests that TurkceAltyazi correctly updates format after ZIP extraction."""
+
+    def _make_zip(self, filename: str, file_content: bytes = b"subtitle content") -> bytes:
+        import io
+        import zipfile
+
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr(filename, file_content)
+        return buf.getvalue()
+
+    def test_format_set_to_ass_from_zip_entry(self):
+        from providers.base import SubtitleFormat, SubtitleResult
+        from providers.turkcealtyazi import TurkcealtyaziProvider
+
+        p = TurkcealtyaziProvider(username="u", password="p")
+        p.session = MagicMock()
+        p._logged_in = True
+        zip_bytes = self._make_zip("Altyazi.ass")
+        p.session.get.return_value = MagicMock(status_code=200, content=zip_bytes)
+
+        r = SubtitleResult(
+            provider_name="turkcealtyazi",
+            subtitle_id="1",
+            language="tr",
+            format=SubtitleFormat.SRT,
+            download_url="https://turkcealtyazi.org/indir/1",
+            provider_data={"detail_url": "https://turkcealtyazi.org/alt/1"},
+        )
+        with patch.object(p, "_get_download_url", return_value="https://turkcealtyazi.org/indir/1"):
+            p.download(r)
+
+        assert r.format == SubtitleFormat.ASS
+        assert r.filename == "Altyazi.ass"
+
+    def test_format_set_to_srt_from_zip_entry(self):
+        from providers.base import SubtitleFormat, SubtitleResult
+        from providers.turkcealtyazi import TurkcealtyaziProvider
+
+        p = TurkcealtyaziProvider(username="u", password="p")
+        p.session = MagicMock()
+        p._logged_in = True
+        zip_bytes = self._make_zip("Altyazi.srt")
+        p.session.get.return_value = MagicMock(status_code=200, content=zip_bytes)
+
+        r = SubtitleResult(
+            provider_name="turkcealtyazi",
+            subtitle_id="2",
+            language="tr",
+            format=SubtitleFormat.SRT,
+            download_url="https://turkcealtyazi.org/indir/2",
+            provider_data={"detail_url": "https://turkcealtyazi.org/alt/2"},
+        )
+        with patch.object(p, "_get_download_url", return_value="https://turkcealtyazi.org/indir/2"):
+            p.download(r)
+
+        assert r.format == SubtitleFormat.SRT
+        assert r.filename == "Altyazi.srt"
+
+    def test_format_unchanged_when_not_zip(self):
+        from providers.base import SubtitleFormat, SubtitleResult
+        from providers.turkcealtyazi import TurkcealtyaziProvider
+
+        p = TurkcealtyaziProvider(username="u", password="p")
+        p.session = MagicMock()
+        p._logged_in = True
+        raw_srt = b"1\n00:00:01,000 --> 00:00:02,000\nMerhaba\n"
+        p.session.get.return_value = MagicMock(status_code=200, content=raw_srt)
+
+        r = SubtitleResult(
+            provider_name="turkcealtyazi",
+            subtitle_id="3",
+            language="tr",
+            format=SubtitleFormat.SRT,
+            download_url="https://turkcealtyazi.org/indir/3",
+            provider_data={"detail_url": "https://turkcealtyazi.org/alt/3"},
+        )
+        with patch.object(p, "_get_download_url", return_value="https://turkcealtyazi.org/indir/3"):
+            p.download(r)
+
+        assert r.format == SubtitleFormat.SRT


### PR DESCRIPTION
## Summary

- **TVSubtitles** and **TurkceAltyazi** both hardcoded `format=SRT` in `search()` and never updated it after ZIP extraction in `download()`
- This caused the ASS format bonus (+50 score) and format filter to be bypassed even when the ZIP contained an ASS file
- Fix: added `_FORMAT_MAP` at module level in both files and derive `result.format` from the extracted filename extension after ZIP extraction

## Changes

- `backend/providers/tvsubtitles.py` — add `_FORMAT_MAP`, update `result.format` in ZIP extraction block
- `backend/providers/turkcealtyazi.py` — same fix
- `backend/tests/test_new_providers.py` — 6 new tests (`TestTVSubtitlesZipFormatDetection`, `TestTurkcealtyaziZipFormatDetection`)

## Test plan
- [x] `TestTVSubtitlesZipFormatDetection` — 3 tests: ASS from ZIP, SRT from ZIP, unchanged when not ZIP
- [x] `TestTurkcealtyaziZipFormatDetection` — 3 tests: ASS from ZIP, SRT from ZIP, unchanged when not ZIP
- [x] All 25 existing TVSubtitles + TurkceAltyazi tests still pass
- [x] `ruff check` + `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)