### PR TITLE
fix: wanted_auto_translate=False not respected in process_wanted_item

### DIFF
--- a/backend/tests/test_wanted_search_reliability.py
+++ b/backend/tests/test_wanted_search_reliability.py
@@ -322,9 +322,14 @@ class TestAutoTranslateGuard:
         mock_manager.save_subtitle.return_value = temp_file.replace(".mkv", ".de.ass")
         mock_get_manager.return_value = mock_manager
 
-        with patch("translator.get_output_path_for_lang", return_value=temp_file.replace(".mkv", ".de.ass")), \
-             patch("wanted_search.record_subtitle_download"), \
-             patch("translator.translate_file") as mock_translate_file:
+        with (
+            patch(
+                "translator.get_output_path_for_lang",
+                return_value=temp_file.replace(".mkv", ".de.ass"),
+            ),
+            patch("wanted_search.record_subtitle_download"),
+            patch("translator.translate_file") as mock_translate_file,
+        ):
             result = process_wanted_item(1)
 
         mock_translate_file.assert_not_called()

--- a/backend/tests/test_wanted_search_reliability.py
+++ b/backend/tests/test_wanted_search_reliability.py
@@ -212,3 +212,121 @@ class TestTranslationPipelineResilience:
         assert not os.path.exists(temp_source_path), (
             "Temp file should have been cleaned up after failure"
         )
+
+
+class TestAutoTranslateGuard:
+    """Test that wanted_auto_translate=False prevents any translation from running."""
+
+    def _make_settings(self, auto_translate: bool):
+        s = MagicMock()
+        s.wanted_auto_translate = auto_translate
+        s.wanted_max_search_attempts = 3
+        s.target_language = "de"
+        s.source_language = "en"
+        s.source_language_name = "English"
+        s.target_language_name = "German"
+        s.upgrade_prefer_ass = True
+        s.upgrade_min_score_delta = 50
+        s.upgrade_window_days = 7
+        s.wanted_skip_srt_on_no_ass = True
+        return s
+
+    @patch("wanted_search.get_settings")
+    @patch("wanted_search.get_wanted_item")
+    @patch("wanted_search.get_provider_manager")
+    @patch("wanted_search.update_wanted_status")
+    @patch("wanted_search.update_wanted_search")
+    @patch("wanted_search.build_query_from_wanted")
+    def test_no_translation_when_auto_translate_disabled(
+        self,
+        mock_build_query,
+        mock_update_search,
+        mock_update_status,
+        mock_get_manager,
+        mock_get_item,
+        mock_get_settings,
+        temp_file,
+    ):
+        """When wanted_auto_translate=False, translate_file must never be called."""
+        mock_wanted_item = {
+            "id": 1,
+            "item_type": "episode",
+            "file_path": temp_file,
+            "target_language": "de",
+            "sonarr_series_id": 1,
+            "sonarr_episode_id": 1,
+            "search_count": 0,
+            "subtitle_type": "full",
+            "current_score": 0,
+            "upgrade_candidate": False,
+        }
+        mock_get_item.return_value = mock_wanted_item
+        mock_get_settings.return_value = self._make_settings(auto_translate=False)
+
+        # No provider returns anything — all searches return None
+        mock_manager = MagicMock()
+        mock_manager.search_and_download_best.return_value = None
+        mock_get_manager.return_value = mock_manager
+        mock_build_query.return_value = MagicMock()
+
+        with patch("translator.translate_file") as mock_translate_file:
+            result = process_wanted_item(1)
+
+        mock_translate_file.assert_not_called()
+        assert result["status"] == "not_found"
+        # Item must stay "wanted" so it can be retried later
+        mock_update_status.assert_called_with(1, "wanted")
+
+    @patch("wanted_search.get_settings")
+    @patch("wanted_search.get_wanted_item")
+    @patch("wanted_search.get_provider_manager")
+    @patch("wanted_search.update_wanted_status")
+    @patch("wanted_search.update_wanted_search")
+    @patch("wanted_search.build_query_from_wanted")
+    def test_direct_download_still_works_when_auto_translate_disabled(
+        self,
+        mock_build_query,
+        mock_update_search,
+        mock_update_status,
+        mock_get_manager,
+        mock_get_item,
+        mock_get_settings,
+        temp_file,
+    ):
+        """Step 1 (direct target ASS) must still work even when auto_translate=False."""
+        mock_wanted_item = {
+            "id": 1,
+            "item_type": "episode",
+            "file_path": temp_file,
+            "target_language": "de",
+            "sonarr_series_id": 1,
+            "sonarr_episode_id": 1,
+            "search_count": 0,
+            "subtitle_type": "full",
+            "current_score": 0,
+            "upgrade_candidate": False,
+        }
+        mock_get_item.return_value = mock_wanted_item
+        mock_get_settings.return_value = self._make_settings(auto_translate=False)
+
+        # Provider returns a direct DE ASS match
+        mock_result = MagicMock(spec=SubtitleResult)
+        mock_result.content = b"test content"
+        mock_result.provider_name = "opensubtitles"
+        mock_result.format = SubtitleFormat.ASS
+        mock_result.score = 100
+        mock_result.subtitle_id = "abc"
+
+        mock_manager = MagicMock()
+        mock_manager.search_and_download_best.return_value = mock_result
+        mock_manager.save_subtitle.return_value = temp_file.replace(".mkv", ".de.ass")
+        mock_get_manager.return_value = mock_manager
+
+        with patch("translator.get_output_path_for_lang", return_value=temp_file.replace(".mkv", ".de.ass")), \
+             patch("wanted_search.record_subtitle_download"), \
+             patch("translator.translate_file") as mock_translate_file:
+            result = process_wanted_item(1)
+
+        mock_translate_file.assert_not_called()
+        assert result["status"] == "found"
+        assert result["provider"] == "opensubtitles"

--- a/backend/wanted_search.py
+++ b/backend/wanted_search.py
@@ -504,6 +504,7 @@ def process_wanted_item(item_id: int) -> dict:
     current_score = item.get("current_score", 0)
     subtitle_type = item.get("subtitle_type", "full")
     manager = get_provider_manager()
+    auto_translate = getattr(settings, "wanted_auto_translate", True)
 
     # Forced subtitle handling: download-only, no translation
     if subtitle_type == "forced":
@@ -602,123 +603,127 @@ def process_wanted_item(item_id: int) -> dict:
         logger.warning("Wanted %d: Direct target ASS search failed: %s", item_id, e, exc_info=True)
 
     # Step 2: Try to find source language ASS for translation (Priority 2)
-    source_query = build_query_from_wanted(item)
-    source_query.languages = [settings.source_language]
-
-    try:
-        result = manager.search_and_download_best(source_query, format_filter=SubtitleFormat.ASS)
-        if result and result.content:
-            _ass_had_results = True
-            # Download source ASS and translate it
-            from translator import _translate_external_ass, get_output_path_for_lang
-
-            base = os.path.splitext(file_path)[0]
-            tmp_source_path = f"{base}.{settings.source_language}.ass"
-            try:
-                # Use the returned path — save_subtitle may adjust the extension
-                # (e.g. if the downloaded file turns out to be SRT, not ASS)
-                actual_source_path = manager.save_subtitle(result, tmp_source_path)
-                record_subtitle_download(
-                    result.provider_name,
-                    result.subtitle_id,
-                    settings.source_language,
-                    result.format.value if result.format.value != "unknown" else "ass",
-                    file_path,
-                    result.score,
-                )
-            except (OSError, RuntimeError) as save_error:
-                logger.error(
-                    "Wanted %d: Failed to save source ASS from %s: %s",
-                    item_id,
-                    result.provider_name,
-                    save_error,
-                )
-                raise  # skip to next step
-
-            # Build arr_context for glossary lookup
-            arr_context = {}
-            if item.get("sonarr_series_id"):
-                arr_context["sonarr_series_id"] = item["sonarr_series_id"]
-            if item.get("sonarr_episode_id"):
-                arr_context["sonarr_episode_id"] = item["sonarr_episode_id"]
-            if item.get("radarr_movie_id"):
-                arr_context["radarr_movie_id"] = item["radarr_movie_id"]
-
-            job = create_job(
-                file_path, force=False, arr_context=arr_context if arr_context else None
+    if auto_translate:
+        source_query = build_query_from_wanted(item)
+        source_query.languages = [settings.source_language]
+        try:
+            result = manager.search_and_download_best(
+                source_query, format_filter=SubtitleFormat.ASS
             )
-            update_job(job["id"], "running")
-            try:
-                translate_result = _translate_external_ass(
-                    file_path,
-                    actual_source_path,
-                    target_language=item_lang,
-                    target_language_name=settings.target_language_name,
-                    arr_context=arr_context if arr_context else None,
+            if result and result.content:
+                _ass_had_results = True
+                # Download source ASS and translate it
+                from translator import _translate_external_ass, get_output_path_for_lang
+
+                base = os.path.splitext(file_path)[0]
+                tmp_source_path = f"{base}.{settings.source_language}.ass"
+                try:
+                    # Use the returned path — save_subtitle may adjust the extension
+                    # (e.g. if the downloaded file turns out to be SRT, not ASS)
+                    actual_source_path = manager.save_subtitle(result, tmp_source_path)
+                    record_subtitle_download(
+                        result.provider_name,
+                        result.subtitle_id,
+                        settings.source_language,
+                        result.format.value if result.format.value != "unknown" else "ass",
+                        file_path,
+                        result.score,
+                    )
+                except (OSError, RuntimeError) as save_error:
+                    logger.error(
+                        "Wanted %d: Failed to save source ASS from %s: %s",
+                        item_id,
+                        result.provider_name,
+                        save_error,
+                    )
+                    raise  # skip to next step
+
+                # Build arr_context for glossary lookup
+                arr_context = {}
+                if item.get("sonarr_series_id"):
+                    arr_context["sonarr_series_id"] = item["sonarr_series_id"]
+                if item.get("sonarr_episode_id"):
+                    arr_context["sonarr_episode_id"] = item["sonarr_episode_id"]
+                if item.get("radarr_movie_id"):
+                    arr_context["radarr_movie_id"] = item["radarr_movie_id"]
+
+                job = create_job(
+                    file_path, force=False, arr_context=arr_context if arr_context else None
                 )
-            except Exception as trans_error:
-                logger.error(
-                    "Wanted %d: Translation failed for source ASS: %s",
-                    item_id,
-                    trans_error,
-                    exc_info=True,
-                )
-                update_job(job["id"], "failed", error=str(trans_error))
-                record_stat(success=False)
+                update_job(job["id"], "running")
+                try:
+                    translate_result = _translate_external_ass(
+                        file_path,
+                        actual_source_path,
+                        target_language=item_lang,
+                        target_language_name=settings.target_language_name,
+                        arr_context=arr_context if arr_context else None,
+                    )
+                except Exception as trans_error:
+                    logger.error(
+                        "Wanted %d: Translation failed for source ASS: %s",
+                        item_id,
+                        trans_error,
+                        exc_info=True,
+                    )
+                    update_job(job["id"], "failed", error=str(trans_error))
+                    record_stat(success=False)
+                    try:
+                        if os.path.exists(actual_source_path):
+                            os.remove(actual_source_path)
+                    except Exception:
+                        pass
+                    raise  # skip to next step
+
+                # Clean up temporary source file
                 try:
                     if os.path.exists(actual_source_path):
                         os.remove(actual_source_path)
                 except Exception:
                     pass
-                raise  # skip to next step
 
-            # Clean up temporary source file
-            try:
-                if os.path.exists(actual_source_path):
-                    os.remove(actual_source_path)
-            except Exception:
-                pass
-
-            if translate_result and translate_result.get("success"):
-                update_job(
-                    job["id"],
-                    "completed",
-                    result=translate_result,
-                    error=translate_result.get("error"),
-                )
-                s = translate_result.get("stats", {})
-                record_stat(
-                    success=True,
-                    skipped=s.get("skipped", False),
-                    fmt=s.get("format", ""),
-                    source=s.get("source", ""),
-                )
-                logger.info(
-                    "Wanted %d: Translated source ASS from provider %s",
-                    item_id,
-                    result.provider_name,
-                )
-                update_wanted_status(item_id, "found")
-                return {
-                    "wanted_id": item_id,
-                    "status": "found",
-                    "output_path": translate_result.get("output_path"),
-                    "provider": f"{result.provider_name} (translated)",
-                }
-            else:
-                update_job(
-                    job["id"],
-                    "failed",
-                    result=translate_result,
-                    error=translate_result.get("error")
-                    if translate_result
-                    else "Translation failed",
-                )
-                record_stat(success=False)
-    except Exception as e:
-        logger.warning(
-            "Wanted %d: Source ASS search/translation failed: %s", item_id, e, exc_info=True
-        )
+                if translate_result and translate_result.get("success"):
+                    update_job(
+                        job["id"],
+                        "completed",
+                        result=translate_result,
+                        error=translate_result.get("error"),
+                    )
+                    s = translate_result.get("stats", {})
+                    record_stat(
+                        success=True,
+                        skipped=s.get("skipped", False),
+                        fmt=s.get("format", ""),
+                        source=s.get("source", ""),
+                    )
+                    logger.info(
+                        "Wanted %d: Translated source ASS from provider %s",
+                        item_id,
+                        result.provider_name,
+                    )
+                    update_wanted_status(item_id, "found")
+                    return {
+                        "wanted_id": item_id,
+                        "status": "found",
+                        "output_path": translate_result.get("output_path"),
+                        "provider": f"{result.provider_name} (translated)",
+                    }
+                else:
+                    update_job(
+                        job["id"],
+                        "failed",
+                        result=translate_result,
+                        error=translate_result.get("error")
+                        if translate_result
+                        else "Translation failed",
+                    )
+                    record_stat(success=False)
+        except Exception as e:
+            logger.warning(
+                "Wanted %d: Source ASS search/translation failed: %s", item_id, e, exc_info=True
+            )
+    else:
+        logger.debug("Wanted %d: auto_translate disabled, skipping source ASS translation", item_id)
 
     # Early exit: skip SRT steps if no ASS was found in Steps 1+2 (providers likely have nothing)
     _skip_srt = getattr(settings, "wanted_skip_srt_on_no_ass", True) and not _ass_had_results
@@ -769,7 +774,7 @@ def process_wanted_item(item_id: int) -> dict:
             )
 
     # Step 4: Try to find source language SRT for translation (Priority 4)
-    if not _skip_srt:
+    if not _skip_srt and auto_translate:
         try:
             result = manager.search_and_download_best(
                 source_query, format_filter=SubtitleFormat.SRT
@@ -885,6 +890,16 @@ def process_wanted_item(item_id: int) -> dict:
             )
 
     # Step 5: Fall back to translate_file() which handles embedded subtitles (B1/C1-C4)
+    if not auto_translate:
+        logger.debug(
+            "Wanted %d: auto_translate disabled, no subtitle found without translation", item_id
+        )
+        update_wanted_status(item_id, "wanted")
+        return {
+            "wanted_id": item_id,
+            "status": "not_found",
+            "reason": "No subtitle found; translation disabled",
+        }
     try:
         from translator import translate_file
 


### PR DESCRIPTION
## Summary

- **Root cause:** Steps 2 (source-language ASS search + translate), 4 (source-language SRT search + translate), and 5 (embedded subtitle → translate_file) in `process_wanted_item()` executed translation unconditionally — the `wanted_auto_translate` setting was never checked
- **Effect:** Even with `wanted_auto_translate=False`, every wanted search that found no direct target-language subtitle automatically kicked off an LLM translation job via the fallback chain
- **Fix:** Added `auto_translate` guard variable (read once from settings). Steps 2 and 4 are skipped entirely when disabled (no source-language provider search either). Step 5 returns `status='not_found'` and resets the item to `"wanted"` so it retries on the next scheduled cycle
- **Unaffected:** Step 1 (direct target ASS download) and Step 3 (direct target SRT download) always run — download-only steps are not gated by `wanted_auto_translate`

## Test plan
- [ ] Backend tests green
- [ ] `test_no_translation_when_auto_translate_disabled` — translate_file is never called, status is not_found, item stays wanted
- [ ] `test_direct_download_still_works_when_auto_translate_disabled` — Step 1 still delivers direct downloads correctly
- [ ] Verify on production: no new translation jobs appear after merge when `wanted_auto_translate=False`