### PR TITLE
security: download security & subtitle sanitization

### DIFF
--- a/backend/archive_utils.py
+++ b/backend/archive_utils.py
@@ -1,0 +1,123 @@
+"""Shared archive extraction utilities with ZIP bomb and size protection.
+
+All subtitle providers that handle archive downloads should use these helpers
+instead of inline zipfile/rarfile calls, to ensure consistent security checks
+across the entire download pipeline.
+"""
+
+import io
+import logging
+import os
+import zipfile
+
+logger = logging.getLogger(__name__)
+
+_MAX_ARCHIVE_BYTES = 20 * 1024 * 1024  # 20 MB — reject before extraction
+_MAX_EXTRACTED_BYTES = 50 * 1024 * 1024  # 50 MB — total extracted
+_MAX_COMPRESSION_RATIO = 100  # 100:1 — ZIP bomb ratio
+_SUBTITLE_EXTENSIONS = frozenset({".ass", ".srt", ".ssa", ".vtt"})
+
+
+def extract_subtitles_from_zip(
+    data: bytes,
+    subtitle_exts: frozenset[str] = _SUBTITLE_EXTENSIONS,
+) -> list[tuple[str, bytes]]:
+    """In-memory ZIP extraction with ZIP bomb and size protection.
+
+    Args:
+        data: Raw ZIP archive bytes.
+        subtitle_exts: Allowed subtitle file extensions (with leading dot).
+
+    Returns:
+        List of (basename, content) tuples for matching subtitle files.
+
+    Raises:
+        ValueError: If archive exceeds size limits or compression ratio.
+    """
+    if len(data) > _MAX_ARCHIVE_BYTES:
+        raise ValueError(
+            f"Archive too large: {len(data) // (1024 * 1024)} MB > "
+            f"{_MAX_ARCHIVE_BYTES // (1024 * 1024)} MB limit"
+        )
+
+    try:
+        with zipfile.ZipFile(io.BytesIO(data)) as zf:
+            total_compressed = sum(info.compress_size for info in zf.infolist())
+            total_uncompressed = sum(info.file_size for info in zf.infolist())
+
+            if total_uncompressed > _MAX_EXTRACTED_BYTES:
+                raise ValueError(
+                    f"Archive extraction too large: {total_uncompressed // (1024 * 1024)} MB > "
+                    f"{_MAX_EXTRACTED_BYTES // (1024 * 1024)} MB limit"
+                )
+
+            # ZIP bomb ratio check (skip if nothing compressed — empty/stored zips)
+            if total_compressed > 0:
+                ratio = total_uncompressed / total_compressed
+                if ratio > _MAX_COMPRESSION_RATIO:
+                    raise ValueError(
+                        f"ZIP bomb detected: compression ratio {ratio:.0f}:1 exceeds "
+                        f"{_MAX_COMPRESSION_RATIO}:1 limit"
+                    )
+
+            results = []
+            for info in zf.infolist():
+                # Skip directory entries
+                if info.filename.endswith("/"):
+                    continue
+                # Strip any path components to prevent ZIP slip
+                basename = os.path.basename(info.filename)
+                if not basename:
+                    continue
+                ext = os.path.splitext(basename)[1].lower()
+                if ext not in subtitle_exts:
+                    continue
+                results.append((basename, zf.read(info.filename)))
+
+            return results
+
+    except zipfile.BadZipFile:
+        logger.warning("archive_utils: bad ZIP archive, skipping")
+        return []
+
+
+def extract_subtitles_from_rar(
+    data: bytes,
+    subtitle_exts: frozenset[str] = _SUBTITLE_EXTENSIONS,
+) -> list[tuple[str, bytes]]:
+    """In-memory RAR extraction with size protection.
+
+    Args:
+        data: Raw RAR archive bytes.
+        subtitle_exts: Allowed subtitle file extensions (with leading dot).
+
+    Returns:
+        List of (basename, content) tuples for matching subtitle files.
+
+    Raises:
+        ImportError: If the rarfile package is not installed.
+        ValueError: If archive exceeds the size limit.
+    """
+    if len(data) > _MAX_ARCHIVE_BYTES:
+        raise ValueError(
+            f"Archive too large: {len(data) // (1024 * 1024)} MB > "
+            f"{_MAX_ARCHIVE_BYTES // (1024 * 1024)} MB limit"
+        )
+
+    import rarfile  # optional dep — raises ImportError if absent
+
+    results = []
+    try:
+        with rarfile.RarFile(io.BytesIO(data)) as rf:
+            for info in rf.infolist():
+                basename = os.path.basename(info.filename)
+                if not basename:
+                    continue
+                ext = os.path.splitext(basename)[1].lower()
+                if ext not in subtitle_exts:
+                    continue
+                results.append((basename, rf.read(info.filename)))
+    except Exception as e:
+        logger.warning("archive_utils: RAR extraction failed: %s", e)
+
+    return results

--- a/backend/providers/__init__.py
+++ b/backend/providers/__init__.py
@@ -1145,6 +1145,17 @@ class ProviderManager:
         except Exception:
             pass  # Config not available — skip path validation (e.g. tests)
 
+        # Sanitize subtitle content before writing to disk
+        try:
+            from subtitle_sanitizer import sanitize_subtitle
+
+            result.content = sanitize_subtitle(result.content, result.format)
+        except ValueError as e:
+            raise RuntimeError(f"Subtitle failed security check: {e}") from e
+        except Exception as e:
+            logger.warning("Subtitle sanitization failed (skipping): %s", e)
+            # Non-fatal: log and continue on unexpected errors to preserve availability
+
         # Create directory with error handling
         try:
             dir_path = os.path.dirname(output_path)

--- a/backend/providers/animetosho.py
+++ b/backend/providers/animetosho.py
@@ -7,13 +7,12 @@ Architecture adapted from Bazarr's subliminal_patch animetosho provider (GPL-3.0
 API: https://feed.animetosho.org/
 """
 
-import io
 import logging
 import lzma
 import os
 import re
-import zipfile
 
+from archive_utils import _MAX_EXTRACTED_BYTES, extract_subtitles_from_zip
 from providers import register_provider
 from providers.base import (
     SubtitleFormat,
@@ -35,7 +34,7 @@ _FORMAT_MAP = {
 }
 
 
-_MAX_DECOMPRESSED_SIZE = 10 * 1024 * 1024  # 10 MB
+_MAX_DECOMPRESSED_SIZE = _MAX_EXTRACTED_BYTES  # aligned with archive extraction limit
 
 
 def _decompress_xz(data: bytes) -> bytes:
@@ -386,17 +385,12 @@ class AnimeToshoProvider(SubtitleProvider):
 
         # Handle ZIP if the downloaded file is actually a ZIP
         if content[:4] == b"PK\x03\x04":
-            try:
-                with zipfile.ZipFile(io.BytesIO(content)) as zf:
-                    for name in zf.namelist():
-                        ext = os.path.splitext(name)[1].lower()
-                        if ext in _SUBTITLE_EXTENSIONS:
-                            content = zf.read(name)
-                            result.filename = os.path.basename(name)
-                            result.format = _FORMAT_MAP.get(ext, SubtitleFormat.UNKNOWN)
-                            break
-            except zipfile.BadZipFile:
-                pass  # Not a ZIP, use content as-is
+            entries = extract_subtitles_from_zip(content)
+            if entries:
+                name, content = entries[0]
+                result.filename = os.path.basename(name)
+                ext = os.path.splitext(name)[1].lower()
+                result.format = _FORMAT_MAP.get(ext, SubtitleFormat.UNKNOWN)
 
         result.content = content
         logger.info("AnimeTosho: downloaded %s (%d bytes)", result.filename, len(content))

--- a/backend/providers/jimaku.py
+++ b/backend/providers/jimaku.py
@@ -10,7 +10,7 @@ API: https://jimaku.cc/api/docs
 import logging
 import os
 
-from archive_utils import extract_subtitles_from_zip, extract_subtitles_from_rar
+from archive_utils import extract_subtitles_from_rar, extract_subtitles_from_zip
 from providers import register_provider
 from providers.base import (
     ProviderAuthError,

--- a/backend/providers/jimaku.py
+++ b/backend/providers/jimaku.py
@@ -38,7 +38,6 @@ _FORMAT_MAP = {
 }
 
 
-
 def _score_subtitle_file(filename: str, query: VideoQuery) -> int:
     """Score a subtitle file name for relevance to the query.
 

--- a/backend/providers/jimaku.py
+++ b/backend/providers/jimaku.py
@@ -7,11 +7,10 @@ Architecture adapted from Bazarr's subliminal_patch jimaku provider (GPL-3.0).
 API: https://jimaku.cc/api/docs
 """
 
-import io
 import logging
 import os
-import zipfile
 
+from archive_utils import extract_subtitles_from_zip, extract_subtitles_from_rar
 from providers import register_provider
 from providers.base import (
     ProviderAuthError,
@@ -38,47 +37,6 @@ _FORMAT_MAP = {
     ".vtt": SubtitleFormat.VTT,
 }
 
-
-def _extract_from_zip(archive_content: bytes, query: VideoQuery) -> list[tuple[str, bytes]]:
-    """Extract subtitle files from a ZIP archive.
-
-    Returns list of (filename, content) tuples, filtered to best matches.
-    """
-    results = []
-    try:
-        with zipfile.ZipFile(io.BytesIO(archive_content)) as zf:
-            for name in zf.namelist():
-                ext = os.path.splitext(name)[1].lower()
-                if ext not in _SUBTITLE_EXTENSIONS:
-                    continue
-                # Skip directories
-                if name.endswith("/"):
-                    continue
-                content = zf.read(name)
-                results.append((os.path.basename(name), content))
-    except zipfile.BadZipFile:
-        logger.warning("Jimaku: bad ZIP archive")
-    return results
-
-
-def _extract_from_rar(archive_content: bytes, query: VideoQuery) -> list[tuple[str, bytes]]:
-    """Extract subtitle files from a RAR archive."""
-    results = []
-    try:
-        import rarfile
-
-        with rarfile.RarFile(io.BytesIO(archive_content)) as rf:
-            for name in rf.namelist():
-                ext = os.path.splitext(name)[1].lower()
-                if ext not in _SUBTITLE_EXTENSIONS:
-                    continue
-                content = rf.read(name)
-                results.append((os.path.basename(name), content))
-    except ImportError:
-        logger.warning("Jimaku: rarfile not installed, cannot extract RAR archives")
-    except Exception as e:
-        logger.warning("Jimaku: RAR extraction failed: %s", e)
-    return results
 
 
 def _score_subtitle_file(filename: str, query: VideoQuery) -> int:
@@ -454,9 +412,12 @@ class JimakuProvider(SubtitleProvider):
             )
 
             if ext == ".zip":
-                extracted = _extract_from_zip(content, query)
+                extracted = extract_subtitles_from_zip(content)
             elif ext == ".rar":
-                extracted = _extract_from_rar(content, query)
+                try:
+                    extracted = extract_subtitles_from_rar(content)
+                except ImportError:
+                    raise RuntimeError("rarfile not installed, cannot extract RAR archives")
             else:
                 raise RuntimeError(f"Unsupported archive format: {ext}")
 

--- a/backend/providers/kitsunekko.py
+++ b/backend/providers/kitsunekko.py
@@ -9,13 +9,12 @@ No authentication required.
 License: GPL-3.0
 """
 
-import io
 import logging
 import os
 import re
-import zipfile
 from urllib.parse import quote, urljoin
 
+from archive_utils import extract_subtitles_from_zip
 from providers import register_provider
 from providers.base import (
     ProviderError,
@@ -297,29 +296,18 @@ class KitsunekkoProvider(SubtitleProvider):
 
         content = resp.content
 
-        # Handle ZIP archives: extract first subtitle file
+        # Handle ZIP archives: extract best subtitle file (prefer .ass > .srt > .ssa)
         if result.provider_data.get("is_zip") or content[:4] == b"PK\x03\x04":
-            try:
-                with zipfile.ZipFile(io.BytesIO(content)) as zf:
-                    # Prefer .ass files, then .srt, then .ssa
-                    subtitle_files = []
-                    for name in zf.namelist():
-                        file_ext = os.path.splitext(name)[1].lower()
-                        if file_ext in {".ass", ".srt", ".ssa"}:
-                            # Priority: .ass=0 (highest), .srt=1, .ssa=2
-                            priority = {".ass": 0, ".srt": 1, ".ssa": 2}.get(file_ext, 3)
-                            subtitle_files.append((priority, name, file_ext))
-
-                    if subtitle_files:
-                        subtitle_files.sort()
-                        _, best_name, best_ext = subtitle_files[0]
-                        content = zf.read(best_name)
-                        result.filename = os.path.basename(best_name)
-                        result.format = _FORMAT_MAP.get(best_ext, SubtitleFormat.UNKNOWN)
-                    else:
-                        logger.warning("Kitsunekko: ZIP contains no subtitle files")
-            except zipfile.BadZipFile:
-                logger.debug("Kitsunekko: content is not a valid ZIP, using as-is")
+            _PRIORITY = {".ass": 0, ".srt": 1, ".ssa": 2}
+            entries = extract_subtitles_from_zip(content)
+            if entries:
+                entries.sort(key=lambda e: _PRIORITY.get(os.path.splitext(e[0])[1].lower(), 3))
+                best_name, content = entries[0]
+                result.filename = best_name
+                best_ext = os.path.splitext(best_name)[1].lower()
+                result.format = _FORMAT_MAP.get(best_ext, SubtitleFormat.UNKNOWN)
+            else:
+                logger.warning("Kitsunekko: ZIP contains no subtitle files")
 
         result.content = content
         logger.info("Kitsunekko: downloaded %s (%d bytes)", result.filename, len(content))

--- a/backend/providers/legendasdivx.py
+++ b/backend/providers/legendasdivx.py
@@ -10,14 +10,13 @@ lazy login, cookie persistence, and RAR/ZIP archive extraction.
 License: GPL-3.0
 """
 
-import io
 import logging
 import os
 import re
-import zipfile
 from datetime import date
 from urllib.parse import urljoin
 
+from archive_utils import extract_subtitles_from_zip, extract_subtitles_from_rar
 from providers import register_provider
 from providers.base import (
     ProviderAuthError,
@@ -49,13 +48,6 @@ except ImportError:
     _HAS_GUESSIT = False
     logger.debug("LegendasDivx: guessit not installed, using regex fallback for release parsing")
 
-try:
-    import rarfile
-
-    _HAS_RARFILE = True
-except ImportError:
-    _HAS_RARFILE = False
-    logger.debug("LegendasDivx: rarfile not installed, RAR archives will not be extractable")
 
 BASE_URL = "https://www.legendasdivx.pt"
 LOGIN_URL = f"{BASE_URL}/forum/ucp.php"
@@ -141,41 +133,6 @@ def _detect_format_from_filename(filename: str) -> SubtitleFormat:
     ext = os.path.splitext(filename)[1].lower()
     return _FORMAT_MAP.get(ext, SubtitleFormat.SRT)
 
-
-def _extract_subtitle_from_archive(content: bytes) -> tuple[str, bytes] | None:
-    """Extract the first subtitle file from a ZIP or RAR archive.
-
-    Returns (filename, content) or None if no subtitle found.
-    """
-    # ZIP detection
-    if content[:4] == b"PK\x03\x04":
-        try:
-            with zipfile.ZipFile(io.BytesIO(content)) as zf:
-                for name in zf.namelist():
-                    ext = os.path.splitext(name)[1].lower()
-                    if ext in _SUBTITLE_EXTENSIONS:
-                        return (os.path.basename(name), zf.read(name))
-        except zipfile.BadZipFile:
-            logger.warning("LegendasDivx: bad ZIP archive")
-        return None
-
-    # RAR detection
-    if content[:4] == b"Rar!":
-        if not _HAS_RARFILE:
-            logger.warning("LegendasDivx: RAR archive detected but rarfile not installed")
-            return None
-        try:
-            with rarfile.RarFile(io.BytesIO(content)) as rf:
-                for name in rf.namelist():
-                    ext = os.path.splitext(name)[1].lower()
-                    if ext in _SUBTITLE_EXTENSIONS:
-                        return (os.path.basename(name), rf.read(name))
-        except Exception as e:
-            logger.warning("LegendasDivx: RAR extraction failed: %s", e)
-        return None
-
-    # Not an archive
-    return None
 
 
 @register_provider
@@ -608,7 +565,16 @@ class LegendasDivxProvider(SubtitleProvider):
         content = resp.content
 
         # Try to extract from archive
-        extracted = _extract_subtitle_from_archive(content)
+        extracted = None
+        if content[:4] == b"PK\x03\x04":
+            entries = extract_subtitles_from_zip(content)
+            extracted = entries[0] if entries else None
+        elif content[:4] == b"Rar!":
+            try:
+                entries = extract_subtitles_from_rar(content)
+                extracted = entries[0] if entries else None
+            except ImportError:
+                logger.warning("LegendasDivx: rarfile not installed, cannot extract RAR archive")
         if extracted:
             filename, content = extracted
             result.filename = filename

--- a/backend/providers/legendasdivx.py
+++ b/backend/providers/legendasdivx.py
@@ -134,7 +134,6 @@ def _detect_format_from_filename(filename: str) -> SubtitleFormat:
     return _FORMAT_MAP.get(ext, SubtitleFormat.SRT)
 
 
-
 @register_provider
 class LegendasDivxProvider(SubtitleProvider):
     """LegendasDivx subtitle provider — Portuguese/Brazilian subtitles via HTML scraping with session auth."""

--- a/backend/providers/legendasdivx.py
+++ b/backend/providers/legendasdivx.py
@@ -16,7 +16,7 @@ import re
 from datetime import date
 from urllib.parse import urljoin
 
-from archive_utils import extract_subtitles_from_zip, extract_subtitles_from_rar
+from archive_utils import extract_subtitles_from_rar, extract_subtitles_from_zip
 from providers import register_provider
 from providers.base import (
     ProviderAuthError,

--- a/backend/providers/napisy24.py
+++ b/backend/providers/napisy24.py
@@ -10,11 +10,10 @@ License: GPL-3.0
 """
 
 import hashlib
-import io
 import logging
 import os
-import zipfile
 
+from archive_utils import extract_subtitles_from_zip
 from providers import register_provider
 from providers.base import (
     ProviderError,
@@ -273,31 +272,21 @@ class Napisy24Provider(SubtitleProvider):
 
         content = resp.content
 
-        # Handle ZIP archives: extract first .srt file
+        # Handle ZIP archives: prefer SRT then ASS/SSA
         if content[:4] == b"PK\x03\x04":
-            try:
-                with zipfile.ZipFile(io.BytesIO(content)) as zf:
-                    for name in zf.namelist():
-                        ext = os.path.splitext(name)[1].lower()
-                        if ext == ".srt":
-                            content = zf.read(name)
-                            result.filename = os.path.basename(name)
-                            result.format = SubtitleFormat.SRT
-                            break
-                    else:
-                        # No .srt found, try any subtitle file
-                        for name in zf.namelist():
-                            ext = os.path.splitext(name)[1].lower()
-                            if ext in {".ass", ".ssa", ".sub", ".txt"}:
-                                content = zf.read(name)
-                                result.filename = os.path.basename(name)
-                                if ext == ".ass":
-                                    result.format = SubtitleFormat.ASS
-                                elif ext == ".ssa":
-                                    result.format = SubtitleFormat.SSA
-                                break
-            except zipfile.BadZipFile:
-                logger.debug("Napisy24: content is not a valid ZIP, using as-is")
+            _PRIORITY = {".srt": 0, ".ass": 1, ".ssa": 2, ".vtt": 3}
+            entries = extract_subtitles_from_zip(content)
+            if entries:
+                entries.sort(key=lambda e: _PRIORITY.get(os.path.splitext(e[0])[1].lower(), 99))
+                best_name, content = entries[0]
+                result.filename = best_name
+                ext = os.path.splitext(best_name)[1].lower()
+                if ext == ".ass":
+                    result.format = SubtitleFormat.ASS
+                elif ext == ".ssa":
+                    result.format = SubtitleFormat.SSA
+                else:
+                    result.format = SubtitleFormat.SRT
 
         result.content = content
         logger.info("Napisy24: downloaded %s (%d bytes)", result.filename, len(content))

--- a/backend/providers/podnapisi.py
+++ b/backend/providers/podnapisi.py
@@ -10,11 +10,10 @@ Rate limit: Conservative 30 req/60s
 License: GPL-3.0
 """
 
-import io
 import logging
 import os
-import zipfile
 
+from archive_utils import extract_subtitles_from_zip
 from providers import register_provider
 from providers.base import (
     ProviderRateLimitError,
@@ -105,24 +104,6 @@ def _parse_xml(content: bytes):
 
         return ET.fromstring(content)
 
-
-def _extract_from_zip(archive_content: bytes) -> tuple[str, bytes] | None:
-    """Extract the first subtitle file from a ZIP archive.
-
-    Returns (filename, content) or None if no subtitle file found.
-    """
-    try:
-        with zipfile.ZipFile(io.BytesIO(archive_content)) as zf:
-            for name in zf.namelist():
-                if name.endswith("/"):
-                    continue
-                ext = os.path.splitext(name)[1].lower()
-                if ext in _SUBTITLE_EXTENSIONS:
-                    content = zf.read(name)
-                    return os.path.basename(name), content
-    except zipfile.BadZipFile:
-        logger.warning("Podnapisi: bad ZIP archive")
-    return None
 
 
 @register_provider
@@ -446,7 +427,8 @@ class PodnapisiProvider(SubtitleProvider):
 
         # Podnapisi returns ZIP archives -- extract the first subtitle file
         if content[:4] == b"PK\x03\x04":
-            extracted = _extract_from_zip(content)
+            entries = extract_subtitles_from_zip(content)
+            extracted = entries[0] if entries else None
             if extracted:
                 filename, sub_content = extracted
                 result.filename = filename

--- a/backend/providers/podnapisi.py
+++ b/backend/providers/podnapisi.py
@@ -105,7 +105,6 @@ def _parse_xml(content: bytes):
         return ET.fromstring(content)
 
 
-
 @register_provider
 class PodnapisiProvider(SubtitleProvider):
     """Podnapisi subtitle provider (XML API).

--- a/backend/providers/subdl.py
+++ b/backend/providers/subdl.py
@@ -8,12 +8,11 @@ Rate limit: 2000 downloads/day
 License: GPL-3.0
 """
 
-import io
 import logging
 import os
 import re
-import zipfile
 
+from archive_utils import extract_subtitles_from_zip
 from providers import register_provider
 from providers.base import (
     ProviderAuthError,
@@ -45,26 +44,6 @@ _RELEASE_GROUP_RE = re.compile(r"^\[([^\]]+)\]|[-.]([A-Za-z0-9]+)$")
 # Episode number extraction from release name
 _EPISODE_RE = re.compile(r"(?:S\d{1,2}E|E|EP|Episode[.\s_]?)(\d{1,3})\b", re.IGNORECASE)
 
-
-def _extract_from_zip(archive_content: bytes) -> list[tuple[str, bytes]]:
-    """Extract subtitle files from a ZIP archive.
-
-    Returns list of (filename, content) tuples.
-    """
-    results = []
-    try:
-        with zipfile.ZipFile(io.BytesIO(archive_content)) as zf:
-            for name in zf.namelist():
-                ext = os.path.splitext(name)[1].lower()
-                if ext not in _SUBTITLE_EXTENSIONS:
-                    continue
-                if name.endswith("/"):
-                    continue
-                content = zf.read(name)
-                results.append((os.path.basename(name), content))
-    except zipfile.BadZipFile:
-        logger.warning("SubDL: bad ZIP archive")
-    return results
 
 
 def _pick_best_subtitle(
@@ -398,7 +377,7 @@ class SubDLProvider(SubtitleProvider):
         archive_content = resp.content
 
         # Extract subtitle files from ZIP
-        extracted = _extract_from_zip(archive_content)
+        extracted = extract_subtitles_from_zip(archive_content)
         if not extracted:
             raise RuntimeError("No subtitle files found in SubDL ZIP archive")
 

--- a/backend/providers/subdl.py
+++ b/backend/providers/subdl.py
@@ -45,7 +45,6 @@ _RELEASE_GROUP_RE = re.compile(r"^\[([^\]]+)\]|[-.]([A-Za-z0-9]+)$")
 _EPISODE_RE = re.compile(r"(?:S\d{1,2}E|E|EP|Episode[.\s_]?)(\d{1,3})\b", re.IGNORECASE)
 
 
-
 def _pick_best_subtitle(
     files: list[tuple[str, bytes]], query: VideoQuery
 ) -> tuple[str, bytes] | None:

--- a/backend/providers/subscene.py
+++ b/backend/providers/subscene.py
@@ -9,9 +9,9 @@ Rate:     10 req / 60 s (conservative — site blocks aggressive scrapers)
 License:  GPL-3.0
 """
 
-import io
 import logging
-import zipfile
+
+from archive_utils import extract_subtitles_from_zip
 
 try:
     from bs4 import BeautifulSoup
@@ -299,22 +299,18 @@ class SubsceneProvider(SubtitleProvider):
         # Extract from ZIP if needed
         if content[:2] == b"PK":
             try:
-                with zipfile.ZipFile(io.BytesIO(content)) as zf:
-                    names = zf.namelist()
-                    # Pick first subtitle file
-                    for name in names:
-                        if name.lower().endswith((".srt", ".ass", ".ssa", ".vtt", ".sub")):
-                            content = zf.read(name)
-                            result.filename = name
-                            ext = name.rsplit(".", 1)[-1].lower()
-                            result.format = {
-                                "ass": SubtitleFormat.ASS,
-                                "ssa": SubtitleFormat.SSA,
-                                "vtt": SubtitleFormat.VTT,
-                            }.get(ext, SubtitleFormat.SRT)
-                            break
-            except Exception as e:
-                logger.warning("Subscene: ZIP extraction failed: %s", e)
+                entries = extract_subtitles_from_zip(content)
+                if entries:
+                    name, content = entries[0]
+                    result.filename = name
+                    ext = name.rsplit(".", 1)[-1].lower()
+                    result.format = {
+                        "ass": SubtitleFormat.ASS,
+                        "ssa": SubtitleFormat.SSA,
+                        "vtt": SubtitleFormat.VTT,
+                    }.get(ext, SubtitleFormat.SRT)
+            except ValueError as e:
+                raise RuntimeError(f"Subscene: archive security check failed: {e}") from e
 
         result.content = content
         logger.info("Subscene: downloaded %s (%d bytes)", result.filename, len(content))

--- a/backend/providers/titrari.py
+++ b/backend/providers/titrari.py
@@ -9,13 +9,12 @@ from RAR/ZIP archives.
 License: GPL-3.0
 """
 
-import io
 import logging
 import os
 import re
-import zipfile
 from urllib.parse import urljoin
 
+from archive_utils import extract_subtitles_from_zip, extract_subtitles_from_rar
 from providers import register_provider
 from providers.base import (
     ProviderError,
@@ -45,13 +44,6 @@ except ImportError:
     _HAS_GUESSIT = False
     logger.debug("Titrari: guessit not installed, using regex fallback for release parsing")
 
-try:
-    import rarfile
-
-    _HAS_RARFILE = True
-except ImportError:
-    _HAS_RARFILE = False
-    logger.debug("Titrari: rarfile not installed, RAR archives will not be extractable")
 
 BASE_URL = "https://www.titrari.ro"
 SEARCH_URL = f"{BASE_URL}/index.php"
@@ -122,41 +114,6 @@ def _detect_format_from_filename(filename: str) -> SubtitleFormat:
     ext = os.path.splitext(filename)[1].lower()
     return _FORMAT_MAP.get(ext, SubtitleFormat.SRT)
 
-
-def _extract_subtitle_from_archive(content: bytes) -> tuple[str, bytes] | None:
-    """Extract the first subtitle file from a ZIP or RAR archive.
-
-    Returns (filename, content) or None if no subtitle found.
-    """
-    # ZIP detection
-    if content[:4] == b"PK\x03\x04":
-        try:
-            with zipfile.ZipFile(io.BytesIO(content)) as zf:
-                for name in zf.namelist():
-                    ext = os.path.splitext(name)[1].lower()
-                    if ext in _SUBTITLE_EXTENSIONS:
-                        return (os.path.basename(name), zf.read(name))
-        except zipfile.BadZipFile:
-            logger.warning("Titrari: bad ZIP archive")
-        return None
-
-    # RAR detection
-    if content[:4] == b"Rar!":
-        if not _HAS_RARFILE:
-            logger.warning("Titrari: RAR archive detected but rarfile not installed")
-            return None
-        try:
-            with rarfile.RarFile(io.BytesIO(content)) as rf:
-                for name in rf.namelist():
-                    ext = os.path.splitext(name)[1].lower()
-                    if ext in _SUBTITLE_EXTENSIONS:
-                        return (os.path.basename(name), rf.read(name))
-        except Exception as e:
-            logger.warning("Titrari: RAR extraction failed: %s", e)
-        return None
-
-    # Not an archive — return None (caller will treat content as raw subtitle)
-    return None
 
 
 @register_provider
@@ -428,7 +385,16 @@ class TitrariProvider(SubtitleProvider):
         content = resp.content
 
         # Try to extract from archive
-        extracted = _extract_subtitle_from_archive(content)
+        extracted = None
+        if content[:4] == b"PK\x03\x04":
+            entries = extract_subtitles_from_zip(content)
+            extracted = entries[0] if entries else None
+        elif content[:4] == b"Rar!":
+            try:
+                entries = extract_subtitles_from_rar(content)
+                extracted = entries[0] if entries else None
+            except ImportError:
+                logger.warning("Titrari: rarfile not installed, cannot extract RAR archive")
         if extracted:
             filename, content = extracted
             result.filename = filename

--- a/backend/providers/titrari.py
+++ b/backend/providers/titrari.py
@@ -115,7 +115,6 @@ def _detect_format_from_filename(filename: str) -> SubtitleFormat:
     return _FORMAT_MAP.get(ext, SubtitleFormat.SRT)
 
 
-
 @register_provider
 class TitrariProvider(SubtitleProvider):
     """Titrari subtitle provider — Romanian subtitles via HTML scraping."""

--- a/backend/providers/titrari.py
+++ b/backend/providers/titrari.py
@@ -14,7 +14,7 @@ import os
 import re
 from urllib.parse import urljoin
 
-from archive_utils import extract_subtitles_from_zip, extract_subtitles_from_rar
+from archive_utils import extract_subtitles_from_rar, extract_subtitles_from_zip
 from providers import register_provider
 from providers.base import (
     ProviderError,

--- a/backend/providers/turkcealtyazi.py
+++ b/backend/providers/turkcealtyazi.py
@@ -9,9 +9,9 @@ Rate:     10 req / 60 s
 License:  GPL-3.0
 """
 
-import io
 import logging
-import zipfile
+
+from archive_utils import extract_subtitles_from_zip
 
 try:
     from bs4 import BeautifulSoup
@@ -236,17 +236,15 @@ class TurkcealtyaziProvider(SubtitleProvider):
 
         if content[:2] == b"PK":
             try:
-                with zipfile.ZipFile(io.BytesIO(content)) as zf:
-                    for name in zf.namelist():
-                        if name.lower().endswith((".srt", ".ass", ".ssa", ".vtt")):
-                            content = zf.read(name)
-                            result.filename = name
-                            ext = name.lower().rsplit(".", 1)[-1] if "." in name else ""
-                            if ext in _FORMAT_MAP:
-                                result.format = _FORMAT_MAP[ext]
-                            break
-            except Exception as e:
-                logger.warning("Turkcealtyazi: ZIP extraction failed: %s", e)
+                entries = extract_subtitles_from_zip(content)
+                if entries:
+                    name, content = entries[0]
+                    result.filename = name
+                    ext = name.lower().rsplit(".", 1)[-1] if "." in name else ""
+                    if ext in _FORMAT_MAP:
+                        result.format = _FORMAT_MAP[ext]
+            except ValueError as e:
+                raise RuntimeError(f"Turkcealtyazi: archive security check failed: {e}") from e
 
         result.content = content
         logger.info("Turkcealtyazi: downloaded %s (%d bytes)", result.filename, len(content))

--- a/backend/providers/tvsubtitles.py
+++ b/backend/providers/tvsubtitles.py
@@ -9,9 +9,9 @@ Rate:     15 req / 60 s
 License:  GPL-3.0
 """
 
-import io
 import logging
-import zipfile
+
+from archive_utils import extract_subtitles_from_zip
 
 try:
     from bs4 import BeautifulSoup
@@ -267,17 +267,15 @@ class TVSubtitlesProvider(SubtitleProvider):
         # Extract from ZIP if needed
         if content[:2] == b"PK":
             try:
-                with zipfile.ZipFile(io.BytesIO(content)) as zf:
-                    for name in zf.namelist():
-                        if name.lower().endswith((".srt", ".ass", ".ssa", ".vtt")):
-                            content = zf.read(name)
-                            result.filename = name
-                            ext = name.lower().rsplit(".", 1)[-1] if "." in name else ""
-                            if ext in _FORMAT_MAP:
-                                result.format = _FORMAT_MAP[ext]
-                            break
-            except Exception as e:
-                logger.warning("TVSubtitles: ZIP extraction failed: %s", e)
+                entries = extract_subtitles_from_zip(content)
+                if entries:
+                    name, content = entries[0]
+                    result.filename = name
+                    ext = name.lower().rsplit(".", 1)[-1] if "." in name else ""
+                    if ext in _FORMAT_MAP:
+                        result.format = _FORMAT_MAP[ext]
+            except ValueError as e:
+                raise RuntimeError(f"TVSubtitles: archive security check failed: {e}") from e
 
         result.content = content
         logger.info("TVSubtitles: downloaded %s (%d bytes)", result.filename, len(content))

--- a/backend/subtitle_sanitizer.py
+++ b/backend/subtitle_sanitizer.py
@@ -1,0 +1,179 @@
+"""Subtitle content sanitizer — strip malicious content before writing to disk.
+
+Subtitle files from untrusted providers can contain content that exploits parser
+bugs in media players (VLC CVE-2019-19721, Kodi, Jellyfin). This module sanitizes
+subtitle content before it reaches the media library.
+
+Threats addressed:
+- ASS: Lua script extensions, drawing-mode overlays ({\\p1}...{\\p0})
+- SRT/VTT: XSS-style HTML injection (<script>, event handlers, data: URIs)
+- All: oversized files, binary content disguised as subtitles
+"""
+
+import logging
+import re
+
+logger = logging.getLogger(__name__)
+
+_MAX_SUBTITLE_BYTES = 5 * 1024 * 1024  # 5 MB per subtitle file
+
+# Drawing-mode blocks: {\p1}...{\p0} — can render full-screen overlays
+# Matches any override tag containing \pN (N=1-9) up to the matching \p0 block.
+_DRAWING_BLOCK_RE = re.compile(
+    r"\{[^}]*\\p[1-9][^}]*\}.*?\{[^}]*\\p0[^}]*\}",
+    re.DOTALL | re.IGNORECASE,
+)
+
+# HTML tags allowed in SRT/VTT subtitle text
+_ALLOWED_HTML_TAGS = frozenset({"i", "b", "u", "font"})
+# Attributes allowed per tag (all others stripped)
+_ALLOWED_ATTRS: dict[str, frozenset[str]] = {"font": frozenset({"color"})}
+
+
+def sanitize_ass_content(content: bytes) -> bytes:
+    """Sanitize ASS/SSA subtitle content.
+
+    Uses pysubs2 to parse and re-serialize (strips non-standard Script Info
+    sections, Lua extensions, @import directives). Additionally strips dangerous
+    drawing-mode tag blocks via regex.
+
+    Args:
+        content: Raw ASS/SSA file bytes.
+
+    Returns:
+        Sanitized ASS bytes.
+    """
+    try:
+        import pysubs2
+
+        text = content.decode("utf-8", errors="replace")
+        subs = pysubs2.SSAFile.from_string(text)
+        serialized = subs.to_string("ass")
+        # Strip drawing-mode blocks from the re-serialized output
+        serialized = _DRAWING_BLOCK_RE.sub("", serialized)
+        return serialized.encode("utf-8")
+    except Exception as e:
+        logger.warning("ASS sanitization failed, returning original: %s", e)
+        return content
+
+
+def sanitize_srt_vtt_content(content: bytes) -> bytes:
+    """Sanitize SRT/VTT subtitle content.
+
+    Strips dangerous HTML (script, img, event handlers, javascript:/data: URIs)
+    while preserving allowed inline formatting tags (<i>, <b>, <u>, <font color>).
+
+    Args:
+        content: Raw SRT/VTT file bytes.
+
+    Returns:
+        Sanitized bytes with dangerous HTML removed.
+    """
+    try:
+        from bs4 import BeautifulSoup
+
+        text = content.decode("utf-8", errors="replace")
+        soup = BeautifulSoup(text, "html.parser")
+
+        # Process all tags — iterate over a frozen copy to avoid mutation issues
+        for tag in list(soup.find_all(True)):
+            tag_name = getattr(tag, "name", "").lower()
+
+            # Completely remove script/style and their contents
+            if tag_name in ("script", "style"):
+                tag.decompose()
+                continue
+
+            if tag_name in _ALLOWED_HTML_TAGS:
+                # Strip disallowed attributes
+                allowed = _ALLOWED_ATTRS.get(tag_name, frozenset())
+                for attr in list(tag.attrs.keys()):
+                    # Remove event handlers and any attr not in the allowlist
+                    if attr.lower().startswith("on") or attr not in allowed:
+                        del tag[attr]
+                # Strip javascript: and data: URIs from surviving attributes
+                for attr in list(tag.attrs.keys()):
+                    val = tag.get(attr, "")
+                    if isinstance(val, str) and val.lower().lstrip().startswith(
+                        ("javascript:", "data:")
+                    ):
+                        del tag[attr]
+            else:
+                # Not an allowed tag — keep text content, remove the tag wrapper
+                tag.unwrap()
+
+        return str(soup).encode("utf-8")
+    except Exception as e:
+        logger.warning("SRT/VTT sanitization failed, returning original: %s", e)
+        return content
+
+
+def validate_content_type(content: bytes, fmt) -> bool:
+    """Check that content matches the declared subtitle format.
+
+    Args:
+        content: Raw file bytes (may include UTF-8 BOM).
+        fmt: SubtitleFormat instance (checked via .value attribute).
+
+    Returns:
+        True if the content structure matches the expected format, False otherwise.
+    """
+    stripped = content.lstrip(b"\xef\xbb\xbf")  # strip UTF-8 BOM
+    fmt_value = fmt.value if hasattr(fmt, "value") else str(fmt)
+
+    if fmt_value in ("ass", "ssa"):
+        return stripped.lstrip().startswith(b"[Script Info]")
+
+    if fmt_value == "srt":
+        # First non-empty line must be a sequence number (digit only)
+        for line in stripped.decode("utf-8", errors="replace").splitlines():
+            line = line.strip()
+            if line:
+                return line.isdigit()
+        return False
+
+    if fmt_value == "vtt":
+        return stripped.startswith(b"WEBVTT")
+
+    # For unknown formats: reject binary content (high non-text byte ratio)
+    sample = stripped[:1000]
+    if sample:
+        non_text = sum(1 for b in sample if b < 0x09 or (0x0E <= b <= 0x1F) or b == 0x7F)
+        if non_text / len(sample) > 0.1:
+            return False
+
+    return True
+
+
+def sanitize_subtitle(content: bytes, fmt) -> bytes:
+    """Main sanitization gate — validates and sanitizes subtitle content.
+
+    Args:
+        content: Raw subtitle file bytes.
+        fmt: SubtitleFormat instance indicating the file type.
+
+    Returns:
+        Sanitized subtitle bytes.
+
+    Raises:
+        ValueError: If content exceeds size limit or fails content-type check.
+    """
+    if len(content) > _MAX_SUBTITLE_BYTES:
+        raise ValueError(
+            f"Subtitle too large: {len(content) // 1024} KB > "
+            f"{_MAX_SUBTITLE_BYTES // 1024} KB limit"
+        )
+
+    fmt_value = fmt.value if hasattr(fmt, "value") else str(fmt)
+
+    if fmt_value != "unknown" and not validate_content_type(content, fmt):
+        raise ValueError(f"Content does not match expected format {fmt_value!r}")
+
+    if fmt_value in ("ass", "ssa"):
+        return sanitize_ass_content(content)
+
+    if fmt_value in ("srt", "vtt"):
+        return sanitize_srt_vtt_content(content)
+
+    # Unknown or other formats: pass through unchanged
+    return content

--- a/backend/tests/test_security.py
+++ b/backend/tests/test_security.py
@@ -1,0 +1,363 @@
+"""Security regression tests for download security and subtitle sanitization.
+
+Tests three areas:
+- TestArchiveUtils: ZIP bomb, oversized archives, ZIP Slip, RAR, filtering
+- TestSubtitleSanitizer: size limits, ASS sanitization, SRT/VTT HTML stripping
+- TestProviderArchiveConsolidation: inline extraction removed from providers
+"""
+
+import io
+import os
+import sys
+import zipfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Ensure backend root is importable
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from archive_utils import (
+    _MAX_ARCHIVE_BYTES,
+    _MAX_COMPRESSION_RATIO,
+    _MAX_EXTRACTED_BYTES,
+    extract_subtitles_from_rar,
+    extract_subtitles_from_zip,
+)
+from providers.base import SubtitleFormat
+from subtitle_sanitizer import (
+    _MAX_SUBTITLE_BYTES,
+    sanitize_ass_content,
+    sanitize_srt_vtt_content,
+    sanitize_subtitle,
+    validate_content_type,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_zip(*entries: tuple[str, bytes]) -> bytes:
+    """Create an in-memory ZIP containing the given (name, content) entries."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name, content in entries:
+            zf.writestr(name, content)
+    return buf.getvalue()
+
+
+def _mock_zip_infolist(file_size: int, compress_size: int, filename: str = "test.srt"):
+    """Return a mock ZipFile context manager with custom infolist values."""
+    info = MagicMock()
+    info.filename = filename
+    info.file_size = file_size
+    info.compress_size = compress_size
+
+    mock_zf = MagicMock()
+    mock_zf.__enter__ = MagicMock(return_value=mock_zf)
+    mock_zf.__exit__ = MagicMock(return_value=False)
+    mock_zf.infolist.return_value = [info]
+    return mock_zf
+
+
+_VALID_SRT = b"1\n00:00:01,000 --> 00:00:02,000\nHello World\n\n"
+
+_VALID_ASS = (
+    b"[Script Info]\n"
+    b"ScriptType: v4.00+\n"
+    b"Title: Test\n\n"
+    b"[V4+ Styles]\n"
+    b"Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour,"
+    b" OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut,"
+    b" ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow,"
+    b" Alignment, MarginL, MarginR, MarginV, Encoding\n"
+    b"Style: Default,Arial,20,&H00FFFFFF,&H000000FF,&H00000000,"
+    b"&H00000000,0,0,0,0,100,100,0,0,1,2,2,2,10,10,10,1\n\n"
+    b"[Events]\n"
+    b"Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text\n"
+    b"Dialogue: 0,0:00:01.00,0:00:05.00,Default,,0,0,0,,Hello World!\n"
+)
+
+
+# ---------------------------------------------------------------------------
+# TestArchiveUtils
+# ---------------------------------------------------------------------------
+
+
+class TestArchiveUtils:
+    def test_zip_bomb_rejected(self):
+        """ZIP claiming uncompressed size > _MAX_EXTRACTED_BYTES should raise ValueError."""
+        zip_bytes = _make_zip(("test.srt", _VALID_SRT))
+
+        with patch("archive_utils.zipfile.ZipFile") as mock_zip_cls:
+            mock_zip_cls.return_value = _mock_zip_infolist(
+                file_size=_MAX_EXTRACTED_BYTES + 1_000_000,
+                compress_size=200,
+            )
+            with pytest.raises(ValueError, match="too large"):
+                extract_subtitles_from_zip(zip_bytes)
+
+    def test_zip_bomb_ratio_rejected(self):
+        """ZIP with compression ratio exceeding _MAX_COMPRESSION_RATIO should raise ValueError."""
+        zip_bytes = _make_zip(("test.srt", _VALID_SRT))
+
+        with patch("archive_utils.zipfile.ZipFile") as mock_zip_cls:
+            # compress_size=1, file_size=(_MAX_COMPRESSION_RATIO+100) → ratio > limit
+            mock_zip_cls.return_value = _mock_zip_infolist(
+                file_size=_MAX_COMPRESSION_RATIO + 100,
+                compress_size=1,
+            )
+            with pytest.raises(ValueError, match="bomb|ratio"):
+                extract_subtitles_from_zip(zip_bytes)
+
+    def test_oversized_archive_rejected(self):
+        """Archive raw bytes > _MAX_ARCHIVE_BYTES should raise ValueError before opening."""
+        oversized = b"PK\x03\x04" + b"\x00" * (_MAX_ARCHIVE_BYTES + 1)
+        with pytest.raises(ValueError, match="too large"):
+            extract_subtitles_from_zip(oversized)
+
+    def test_zip_slip_member_stripped(self):
+        """Members with ../../ path traversal are basename-stripped, not path-traversed."""
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            info = zipfile.ZipInfo("../../evil.srt")
+            zf.writestr(info, _VALID_SRT)
+        entries = extract_subtitles_from_zip(buf.getvalue())
+        assert len(entries) == 1
+        assert entries[0][0] == "evil.srt"
+
+    def test_rar_extraction_basic(self):
+        """extract_subtitles_from_rar returns (name, bytes) tuples for subtitle files."""
+        mock_info = MagicMock()
+        mock_info.filename = "show.srt"
+
+        mock_rf = MagicMock()
+        mock_rf.__enter__ = lambda s: s
+        mock_rf.__exit__ = MagicMock(return_value=False)
+        mock_rf.infolist.return_value = [mock_info]
+        mock_rf.read.return_value = _VALID_SRT
+
+        mock_rarfile = MagicMock()
+        mock_rarfile.RarFile.return_value = mock_rf
+
+        with patch.dict("sys.modules", {"rarfile": mock_rarfile}):
+            entries = extract_subtitles_from_rar(b"\x00" * 100)
+
+        assert entries == [("show.srt", _VALID_SRT)]
+
+    def test_non_subtitle_filtered(self):
+        """Files with non-subtitle extensions are excluded from extraction results."""
+        zip_bytes = _make_zip(
+            ("malware.exe", b"\x4d\x5a\x90\x00"),  # PE header
+            ("subtitles.srt", _VALID_SRT),
+        )
+        entries = extract_subtitles_from_zip(zip_bytes)
+        assert len(entries) == 1
+        assert entries[0][0] == "subtitles.srt"
+
+    def test_bad_zip_returns_empty(self):
+        """Corrupted ZIP data should be caught and return an empty list."""
+        result = extract_subtitles_from_zip(b"Not a ZIP at all!!")
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# TestSubtitleSanitizer
+# ---------------------------------------------------------------------------
+
+
+class TestSubtitleSanitizer:
+    def test_size_limit_enforced(self):
+        """Content larger than _MAX_SUBTITLE_BYTES should raise ValueError."""
+        big = b"\x00" * (_MAX_SUBTITLE_BYTES + 1)
+        with pytest.raises(ValueError, match="too large"):
+            sanitize_subtitle(big, SubtitleFormat.SRT)
+
+    def test_ass_lua_stripped(self):
+        """pysubs2 re-serialization strips non-standard ASS sections."""
+        ass_with_extras = _VALID_ASS.decode() + "\n[Custom Script]\nsome_lua_here()\n"
+        result = sanitize_ass_content(ass_with_extras.encode())
+        assert b"Custom Script" not in result
+        assert b"some_lua_here" not in result
+        assert b"Hello World" in result
+
+    def test_ass_drawing_mode_stripped(self):
+        """ASS drawing-mode blocks ({\\p1}...{\\p0}) should be removed."""
+        drawing_ass = (
+            _VALID_ASS.decode()
+            .replace(
+                "Hello World!",
+                r"{\p1}m 0 0 l 100 0 100 100 0 100{\p0}",
+            )
+            .encode()
+        )
+        result = sanitize_ass_content(drawing_ass)
+        assert b"\\p1" not in result
+        assert b"\\p0" not in result
+        assert b"m 0 0 l 100" not in result
+
+    def test_ass_valid_content_preserved(self):
+        """Normal ASS dialogue, formatting, and positions should be preserved."""
+        formatted = (
+            _VALID_ASS.decode()
+            .replace("Hello World!", r"{\i1}Hello{\i0} {\b1}World{\b0}!")
+            .encode()
+        )
+        result = sanitize_ass_content(formatted)
+        assert b"Hello" in result
+        assert b"World" in result
+        assert b"[Script Info]" in result
+        assert b"[Events]" in result
+
+    def test_srt_html_stripped(self):
+        """<script> tags and their content should be stripped from SRT."""
+        xss_srt = (
+            b"1\n00:00:01,000 --> 00:00:02,000\n"
+            b"<script>alert('xss')</script>Hello<script>alert(2)</script>\n\n"
+        )
+        result = sanitize_srt_vtt_content(xss_srt)
+        assert b"<script>" not in result
+        assert b"alert" not in result
+        assert b"Hello" in result
+
+    def test_srt_allowed_tags_preserved(self):
+        """<i>, <b>, <u> tags should survive SRT sanitization."""
+        formatted_srt = (
+            b"1\n00:00:01,000 --> 00:00:02,000\n"
+            b"<i>Italic</i> and <b>Bold</b> and <u>Underlined</u>\n\n"
+        )
+        result = sanitize_srt_vtt_content(formatted_srt)
+        assert b"<i>" in result
+        assert b"<b>" in result
+        assert b"<u>" in result
+
+    def test_srt_event_handlers_stripped(self):
+        """Event handler attributes should be removed but the tag itself survives."""
+        srt_with_handler = (
+            b'1\n00:00:01,000 --> 00:00:02,000\n<b onmouseover="malicious()">Click me</b>\n\n'
+        )
+        result = sanitize_srt_vtt_content(srt_with_handler)
+        assert b"onmouseover" not in result
+        assert b"<b>" in result
+        assert b"Click me" in result
+
+    def test_content_type_ass_validated(self):
+        """Content not starting with [Script Info] fails ASS content-type check."""
+        assert validate_content_type(b"Not ASS content", SubtitleFormat.ASS) is False
+        assert (
+            validate_content_type(b"[Script Info]\nScriptType: v4.00+", SubtitleFormat.ASS) is True
+        )
+
+    def test_content_type_srt_validated(self):
+        """Content not starting with a sequence digit fails SRT content-type check."""
+        assert validate_content_type(b"Not SRT", SubtitleFormat.SRT) is False
+        assert validate_content_type(_VALID_SRT, SubtitleFormat.SRT) is True
+
+    def test_unknown_format_passthrough(self):
+        """UNKNOWN format should pass through sanitize_subtitle unchanged."""
+        content = b"arbitrary content"
+        result = sanitize_subtitle(content, SubtitleFormat.UNKNOWN)
+        assert result == content
+
+
+# ---------------------------------------------------------------------------
+# TestProviderArchiveConsolidation
+# ---------------------------------------------------------------------------
+
+_PROVIDERS_WITH_INLINE_ZIP = [
+    "providers.jimaku",
+    "providers.subdl",
+    "providers.podnapisi",
+    "providers.titrari",
+    "providers.legendasdivx",
+    "providers.tvsubtitles",
+    "providers.animetosho",
+    "providers.kitsunekko",
+    "providers.napisy24",
+    "providers.subscene",
+    "providers.turkcealtyazi",
+]
+
+
+class TestProviderArchiveConsolidation:
+    """Verify providers use archive_utils instead of inline ZIP extraction."""
+
+    @pytest.mark.parametrize("module_name", _PROVIDERS_WITH_INLINE_ZIP)
+    def test_no_inline_extract_from_zip(self, module_name):
+        """Each provider should not have a module-level _extract_from_zip function."""
+        import importlib
+
+        module = importlib.import_module(module_name)
+        assert not hasattr(module, "_extract_from_zip"), (
+            f"{module_name} still has an inline _extract_from_zip — "
+            "consolidation to archive_utils may be incomplete"
+        )
+
+    @pytest.mark.parametrize("module_name", ["providers.titrari", "providers.legendasdivx"])
+    def test_no_inline_extract_from_archive(self, module_name):
+        """Titrari and LegendasDivx should not have _extract_subtitle_from_archive."""
+        import importlib
+
+        module = importlib.import_module(module_name)
+        assert not hasattr(module, "_extract_subtitle_from_archive"), (
+            f"{module_name} still has inline _extract_subtitle_from_archive"
+        )
+
+    def test_subdl_calls_archive_utils(self):
+        """SubDL download() should delegate ZIP extraction to extract_subtitles_from_zip."""
+        from providers.base import SubtitleFormat, SubtitleResult
+        from providers.subdl import SubDLProvider
+
+        zip_bytes = _make_zip(("test.srt", _VALID_SRT))
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.content = zip_bytes
+
+        provider = SubDLProvider(api_key="test")
+        provider.session = MagicMock()
+        provider.session.get.return_value = mock_resp
+
+        result = SubtitleResult(
+            provider_name="subdl",
+            subtitle_id="123",
+            language="en",
+            format=SubtitleFormat.SRT,
+            filename="test.srt",
+            download_url="http://test.com/123.zip",
+            provider_data={"sd_id": "123", "query_episode": 1, "query_season": 1},
+        )
+
+        with patch("providers.subdl.extract_subtitles_from_zip") as mock_extract:
+            mock_extract.return_value = [("test.srt", _VALID_SRT)]
+            provider.download(result)
+            mock_extract.assert_called_once()
+
+    def test_podnapisi_calls_archive_utils(self):
+        """Podnapisi download() should delegate ZIP extraction to extract_subtitles_from_zip."""
+        from providers.base import SubtitleFormat, SubtitleResult
+        from providers.podnapisi import PodnapisiProvider
+
+        zip_bytes = _make_zip(("test.srt", _VALID_SRT))
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.content = zip_bytes
+
+        provider = PodnapisiProvider()
+        provider.session = MagicMock()
+        provider.session.get.return_value = mock_resp
+
+        result = SubtitleResult(
+            provider_name="podnapisi",
+            subtitle_id="pid-42",
+            language="en",
+            format=SubtitleFormat.SRT,
+            filename="test.srt",
+            download_url="https://www.podnapisi.net/subtitles/pid-42/download",
+            provider_data={"pid": "pid-42"},
+        )
+
+        with patch("providers.podnapisi.extract_subtitles_from_zip") as mock_extract:
+            mock_extract.return_value = [("test.srt", _VALID_SRT)]
+            provider.download(result)
+            mock_extract.assert_called_once()


### PR DESCRIPTION
## Summary

- **ZIP bomb protection** — archive_utils.py enforces: 20 MB raw archive limit, 50 MB extraction limit, 100:1 compression ratio check; ZIP Slip prevented via `os.path.basename()` on all members
- **Subtitle sanitization** — subtitle_sanitizer.py: ASS via pysubs2 re-serialization (strips Lua/non-standard sections) + drawing-mode regex; SRT/VTT via BeautifulSoup (allowlist `<i>/<b>/<u>/<font color>`, strips `<script>`, event handlers, `data:`/`javascript:` URIs); content-type validation; 5 MB per-file limit
- **Provider consolidation** — 11 providers replaced inline ZIP/RAR code with `archive_utils` calls, removing ~170 lines of duplicated, unsecured extraction logic
- **Save gate** — `save_subtitle()` in `providers/__init__.py` now sanitizes content before every disk write; `ValueError` = hard fail, unexpected exceptions = non-fatal log (availability preserved)
- **32 security regression tests** — all passing; covers ZIP bomb, ZIP Slip, oversized archives, RAR, HTML injection, ASS drawing-mode, content-type validation, provider consolidation

Addresses threats: VLC CVE-2019-19721-style parser exploitation, XSS-style injection in SRT/VTT against media player renderers, ZIP bomb DoS.

## Test plan

- [x] `python -m pytest tests/test_security.py -v` — 32/32 passed
- [x] Full suite (excl. integration/performance): 182 passed, 28.4% coverage (above 25% threshold)
- [x] `ruff check` — 0 errors on new/modified files
- [ ] Manual: start dev server, trigger a wanted search, confirm subtitle saved without sanitizer errors in logs
- [ ] Manual: verify all provider health checks pass on Providers page

🤖 Generated with [Claude Code](https://claude.com/claude-code)