### PR TITLE
feat: SHA-256 duplicate detection at download time

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -65,6 +65,7 @@ class Settings(BaseSettings):
     provider_cache_ttl_minutes: int = 5  # Cache TTL for provider search results
     provider_auto_prioritize: bool = True  # Auto-prioritize providers based on success rate
     provider_rate_limit_enabled: bool = True  # Enable rate limiting per provider
+    dedup_on_download: bool = True  # Skip download if identical content already exists (SHA-256)
 
     # Dynamic Provider Timeouts (Phase 3)
     provider_dynamic_timeout_enabled: bool = True

--- a/backend/db/repositories/cleanup.py
+++ b/backend/db/repositories/cleanup.py
@@ -121,6 +121,21 @@ class CleanupRepository(BaseRepository):
 
         return groups
 
+    def find_by_content_hash(self, content_hash: str) -> list[dict]:
+        """Find all subtitle hash records matching the given SHA-256 hash.
+
+        Args:
+            content_hash: SHA-256 hex digest to look up.
+
+        Returns:
+            List of dicts with file_path, format, language for each match.
+        """
+        stmt = select(SubtitleHash).where(SubtitleHash.content_hash == content_hash)
+        rows = self.session.execute(stmt).scalars().all()
+        return [
+            {"file_path": r.file_path, "format": r.format, "language": r.language} for r in rows
+        ]
+
     def delete_hashes_by_paths(self, file_paths: list[str]) -> int:
         """Delete hash records for the given file paths.
 

--- a/backend/dedup_engine.py
+++ b/backend/dedup_engine.py
@@ -81,6 +81,23 @@ def compute_subtitle_hash(file_path: str) -> dict:
     }
 
 
+def compute_content_hash_from_bytes(content: bytes) -> str:
+    """Compute SHA-256 content hash from in-memory subtitle bytes.
+
+    Applies the same normalization as compute_subtitle_hash() (strip whitespace,
+    normalize line endings) so hashes are comparable between the two functions.
+
+    Args:
+        content: Raw subtitle file bytes.
+
+    Returns:
+        SHA-256 hex digest string.
+    """
+    text = content.decode("utf-8", errors="replace")
+    normalized = text.strip().replace("\r\n", "\n")
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
 def scan_for_duplicates(media_path: str, socketio=None) -> dict:
     """Scan a media path recursively for duplicate subtitles.
 

--- a/backend/error_handler.py
+++ b/backend/error_handler.py
@@ -82,6 +82,26 @@ class OllamaModelError(TranslationError):
         )
 
 
+class DuplicateSubtitleError(SublarrError):
+    """Subtitle content already exists on disk (duplicate detected by SHA-256 hash)."""
+
+    code = "PROV_002"
+    http_status = 409
+
+    def __init__(self, content_hash: str, existing_path: str, attempted_path: str) -> None:
+        super().__init__(
+            f"Duplicate subtitle: content already exists at {existing_path!r}",
+            context={
+                "content_hash": content_hash,
+                "existing_path": existing_path,
+                "attempted_path": attempted_path,
+            },
+        )
+        self.content_hash = content_hash
+        self.existing_path = existing_path
+        self.attempted_path = attempted_path
+
+
 class DatabaseError(SublarrError):
     """Database operation errors."""
 

--- a/backend/providers/__init__.py
+++ b/backend/providers/__init__.py
@@ -1156,6 +1156,48 @@ class ProviderManager:
             logger.warning("Subtitle sanitization failed (skipping): %s", e)
             # Non-fatal: log and continue on unexpected errors to preserve availability
 
+        # Duplicate detection: skip write if identical content already exists on disk
+        try:
+            from config import get_settings as _get_settings_dedup
+            from db.repositories.cleanup import CleanupRepository
+            from dedup_engine import compute_content_hash_from_bytes
+            from error_handler import DuplicateSubtitleError
+
+            _dedup_settings = _get_settings_dedup()
+            if getattr(_dedup_settings, "dedup_on_download", True):
+                content_hash = compute_content_hash_from_bytes(result.content)
+                _output_dir = os.path.dirname(os.path.abspath(output_path))
+
+                repo = CleanupRepository()
+                matches = repo.find_by_content_hash(content_hash)
+                stale_paths = []
+                duplicate_path = None
+
+                for match in matches:
+                    match_path = match["file_path"]
+                    if not os.path.isfile(match_path):
+                        stale_paths.append(match_path)
+                        continue
+                    if os.path.dirname(os.path.abspath(match_path)) == _output_dir:
+                        duplicate_path = match_path
+                        break
+
+                if stale_paths:
+                    repo.delete_hashes_by_paths(stale_paths)
+                    logger.debug("Cleaned %d stale hash entries", len(stale_paths))
+
+                if duplicate_path:
+                    logger.info(
+                        "Duplicate subtitle skipped: hash %s already at %s",
+                        content_hash[:12],
+                        duplicate_path,
+                    )
+                    raise DuplicateSubtitleError(content_hash, duplicate_path, output_path)
+        except DuplicateSubtitleError:
+            raise
+        except Exception as e:
+            logger.debug("Dedup check skipped: %s", e)
+
         # Create directory with error handling
         try:
             dir_path = os.path.dirname(output_path)
@@ -1172,6 +1214,23 @@ class ProviderManager:
         except OSError as e:
             logger.error("Failed to write subtitle to %s: %s", output_path, e)
             raise RuntimeError(f"Cannot write subtitle file: {e}") from e
+
+        # Register hash in dedup DB after successful write
+        try:
+            from db.repositories.cleanup import CleanupRepository as CleanupRepo
+            from dedup_engine import compute_content_hash_from_bytes as _chfb
+
+            _hash = _chfb(result.content)
+            _ext = result.format.value if result.format.value != "unknown" else "srt"
+            CleanupRepo().upsert_hash(
+                file_path=output_path,
+                content_hash=_hash,
+                file_size=len(result.content),
+                format=_ext,
+                language=result.language,
+            )
+        except Exception as e:
+            logger.debug("Failed to register subtitle hash after write: %s", e)
 
         logger.info(
             "Saved subtitle: %s (%s, %s, score=%d)",

--- a/backend/tests/test_dedup_detection.py
+++ b/backend/tests/test_dedup_detection.py
@@ -1,0 +1,233 @@
+"""Duplicate detection tests: SHA-256 hash-based dedup at download time.
+
+Tests:
+- TestComputeContentHash: normalization, CRLF/LF, BOM, empty content
+- TestDuplicateSubtitleError: error attributes and hierarchy
+- TestSaveSubtitleDedup: first save, duplicate skip, stale hash cleanup,
+                         cross-directory (not a duplicate), disabled via config
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from dedup_engine import compute_content_hash_from_bytes
+from error_handler import DuplicateSubtitleError, SublarrError
+
+# ── TestComputeContentHash ────────────────────────────────────────────────────
+
+
+class TestComputeContentHash:
+    def test_returns_sha256_hex(self):
+        result = compute_content_hash_from_bytes(b"hello")
+        assert len(result) == 64
+        assert all(c in "0123456789abcdef" for c in result)
+
+    def test_deterministic(self):
+        assert compute_content_hash_from_bytes(b"abc") == compute_content_hash_from_bytes(b"abc")
+
+    def test_crlf_equals_lf(self):
+        crlf = compute_content_hash_from_bytes(b"line1\r\nline2\r\n")
+        lf = compute_content_hash_from_bytes(b"line1\nline2\n")
+        assert crlf == lf
+
+    def test_leading_trailing_whitespace_stripped(self):
+        stripped = compute_content_hash_from_bytes(b"content")
+        padded = compute_content_hash_from_bytes(b"  content  ")
+        assert stripped == padded
+
+    def test_different_content_different_hash(self):
+        assert compute_content_hash_from_bytes(b"aaa") != compute_content_hash_from_bytes(b"bbb")
+
+    def test_utf8_bom_handled(self):
+        # BOM is decoded as part of the string — normalization still applies
+        with_bom = compute_content_hash_from_bytes(b"\xef\xbb\xbfcontent")
+        assert len(with_bom) == 64  # just ensure it doesn't crash
+
+    def test_empty_bytes(self):
+        result = compute_content_hash_from_bytes(b"")
+        assert len(result) == 64
+
+
+# ── TestDuplicateSubtitleError ────────────────────────────────────────────────
+
+
+class TestDuplicateSubtitleError:
+    def test_is_sublarr_error(self):
+        err = DuplicateSubtitleError("abc123", "/existing.srt", "/new.srt")
+        assert isinstance(err, SublarrError)
+
+    def test_http_status_409(self):
+        err = DuplicateSubtitleError("abc123", "/existing.srt", "/new.srt")
+        assert err.http_status == 409
+
+    def test_attributes(self):
+        err = DuplicateSubtitleError("deadbeef", "/old/path.srt", "/new/path.srt")
+        assert err.content_hash == "deadbeef"
+        assert err.existing_path == "/old/path.srt"
+        assert err.attempted_path == "/new/path.srt"
+
+    def test_context_populated(self):
+        err = DuplicateSubtitleError("hash1", "/a.srt", "/b.srt")
+        assert err.context["content_hash"] == "hash1"
+        assert err.context["existing_path"] == "/a.srt"
+
+
+# ── TestSaveSubtitleDedup ─────────────────────────────────────────────────────
+
+
+def _make_result(content: bytes = b"1\n00:00:01,000 --> 00:00:02,000\nHello\n"):
+    from providers.base import SubtitleFormat, SubtitleResult
+
+    r = SubtitleResult.__new__(SubtitleResult)
+    r.content = content
+    r.format = SubtitleFormat.SRT
+    r.provider_name = "test_provider"
+    r.language = "de"
+    r.score = 100
+    r.subtitle_id = "sub123"
+    return r
+
+
+def _make_manager():
+    from providers import ProviderManager
+
+    mgr = ProviderManager.__new__(ProviderManager)
+    mgr._providers = {}
+    return mgr
+
+
+class TestSaveSubtitleDedup:
+    """Tests for dedup logic inside ProviderManager.save_subtitle()."""
+
+    def _patch_save(self, tmp_path, dedup_enabled=True, repo_matches=None):
+        """Return a context manager that patches all save_subtitle dependencies."""
+        mock_settings = MagicMock(media_path=str(tmp_path), dedup_on_download=dedup_enabled)
+        mock_repo = MagicMock()
+        mock_repo.find_by_content_hash.return_value = repo_matches or []
+
+        return (
+            patch("config.get_settings", return_value=mock_settings),
+            patch("security_utils.is_safe_path", return_value=True),
+            patch("db.repositories.cleanup.CleanupRepository", return_value=mock_repo),
+            mock_repo,
+        )
+
+    def test_first_save_writes_file(self, tmp_path):
+        """First download should write the file normally."""
+        mgr = _make_manager()
+        result = _make_result()
+        output = str(tmp_path / "episode.de.srt")
+
+        mock_settings = MagicMock(media_path=str(tmp_path), dedup_on_download=True)
+        mock_repo = MagicMock()
+        mock_repo.find_by_content_hash.return_value = []
+
+        with (
+            patch("config.get_settings", return_value=mock_settings),
+            patch("security_utils.is_safe_path", return_value=True),
+            patch("db.repositories.cleanup.CleanupRepository", return_value=mock_repo),
+        ):
+            saved = mgr.save_subtitle(result, output)
+
+        assert os.path.isfile(saved)
+        assert open(saved, "rb").read() == result.content
+
+    def test_duplicate_raises_error(self, tmp_path):
+        """Identical content in the same directory raises DuplicateSubtitleError."""
+        mgr = _make_manager()
+        result = _make_result()
+        existing = str(tmp_path / "episode.de.srt")
+        open(existing, "wb").write(result.content)
+
+        mock_settings = MagicMock(media_path=str(tmp_path), dedup_on_download=True)
+        mock_repo = MagicMock()
+        mock_repo.find_by_content_hash.return_value = [
+            {"file_path": existing, "format": "srt", "language": "de"}
+        ]
+
+        with (
+            patch("config.get_settings", return_value=mock_settings),
+            patch("security_utils.is_safe_path", return_value=True),
+            patch("db.repositories.cleanup.CleanupRepository", return_value=mock_repo),
+            pytest.raises(DuplicateSubtitleError) as exc_info,
+        ):
+            mgr.save_subtitle(result, str(tmp_path / "episode2.de.srt"))
+
+        assert exc_info.value.existing_path == existing
+
+    def test_cross_directory_not_duplicate(self, tmp_path):
+        """Same hash in a different directory is not a duplicate."""
+        mgr = _make_manager()
+        result = _make_result()
+        other_dir = tmp_path / "other_series"
+        other_dir.mkdir()
+        existing = str(other_dir / "episode.de.srt")
+        open(existing, "wb").write(result.content)
+        output = str(tmp_path / "episode.de.srt")
+
+        mock_settings = MagicMock(media_path=str(tmp_path), dedup_on_download=True)
+        mock_repo = MagicMock()
+        mock_repo.find_by_content_hash.return_value = [
+            {"file_path": existing, "format": "srt", "language": "de"}
+        ]
+
+        with (
+            patch("config.get_settings", return_value=mock_settings),
+            patch("security_utils.is_safe_path", return_value=True),
+            patch("db.repositories.cleanup.CleanupRepository", return_value=mock_repo),
+        ):
+            saved = mgr.save_subtitle(result, output)
+
+        assert os.path.isfile(saved)
+
+    def test_stale_hash_cleaned_and_write_proceeds(self, tmp_path):
+        """Stale hash entries (file deleted) are cleaned up and write proceeds."""
+        mgr = _make_manager()
+        result = _make_result()
+        stale_path = str(tmp_path / "deleted.de.srt")  # does NOT exist on disk
+        output = str(tmp_path / "episode.de.srt")
+
+        mock_settings = MagicMock(media_path=str(tmp_path), dedup_on_download=True)
+        mock_repo = MagicMock()
+        mock_repo.find_by_content_hash.return_value = [
+            {"file_path": stale_path, "format": "srt", "language": "de"}
+        ]
+
+        with (
+            patch("config.get_settings", return_value=mock_settings),
+            patch("security_utils.is_safe_path", return_value=True),
+            patch("db.repositories.cleanup.CleanupRepository", return_value=mock_repo),
+        ):
+            saved = mgr.save_subtitle(result, output)
+            mock_repo.delete_hashes_by_paths.assert_called_once_with([stale_path])
+
+        assert os.path.isfile(saved)
+
+    def test_dedup_disabled_always_writes(self, tmp_path):
+        """When dedup_on_download=False, no duplicate check is performed."""
+        mgr = _make_manager()
+        result = _make_result()
+        existing = str(tmp_path / "episode.de.srt")
+        open(existing, "wb").write(result.content)
+        output = str(tmp_path / "episode2.de.srt")
+
+        mock_settings = MagicMock(media_path=str(tmp_path), dedup_on_download=False)
+        mock_repo = MagicMock()
+        mock_repo.find_by_content_hash.return_value = [
+            {"file_path": existing, "format": "srt", "language": "de"}
+        ]
+
+        with (
+            patch("config.get_settings", return_value=mock_settings),
+            patch("security_utils.is_safe_path", return_value=True),
+            patch("db.repositories.cleanup.CleanupRepository", return_value=mock_repo),
+        ):
+            saved = mgr.save_subtitle(result, output)
+
+        assert os.path.isfile(saved)
+        mock_repo.find_by_content_hash.assert_not_called()

--- a/backend/wanted_search.py
+++ b/backend/wanted_search.py
@@ -24,6 +24,7 @@ from db.wanted import (
     update_wanted_search,
     update_wanted_status,
 )
+from error_handler import DuplicateSubtitleError
 from providers import get_provider_manager
 from providers.base import SubtitleFormat, VideoQuery
 from translator import get_forced_output_path
@@ -591,6 +592,20 @@ def process_wanted_item(item_id: int) -> dict:
                     "provider": result.provider_name,
                     "upgraded": is_upgrade,
                 }
+            except DuplicateSubtitleError as dup_err:
+                logger.info(
+                    "Wanted %d: Duplicate subtitle skipped, already at %s",
+                    item_id,
+                    dup_err.existing_path,
+                )
+                update_wanted_status(item_id, "found")
+                return {
+                    "wanted_id": item_id,
+                    "status": "duplicate_skipped",
+                    "output_path": dup_err.existing_path,
+                    "provider": result.provider_name,
+                    "upgraded": False,
+                }
             except (OSError, RuntimeError) as save_error:
                 logger.error(
                     "Wanted %d: Failed to save subtitle from %s: %s",
@@ -629,6 +644,13 @@ def process_wanted_item(item_id: int) -> dict:
                         file_path,
                         result.score,
                     )
+                except DuplicateSubtitleError as dup_err:
+                    logger.info(
+                        "Wanted %d: Duplicate source ASS skipped, using existing %s",
+                        item_id,
+                        dup_err.existing_path,
+                    )
+                    actual_source_path = dup_err.existing_path
                 except (OSError, RuntimeError) as save_error:
                     logger.error(
                         "Wanted %d: Failed to save source ASS from %s: %s",
@@ -760,6 +782,19 @@ def process_wanted_item(item_id: int) -> dict:
                         "output_path": output_path,
                         "provider": result.provider_name,
                     }
+                except DuplicateSubtitleError as dup_err:
+                    logger.info(
+                        "Wanted %d: Duplicate target SRT skipped, already at %s",
+                        item_id,
+                        dup_err.existing_path,
+                    )
+                    update_wanted_status(item_id, "found")
+                    return {
+                        "wanted_id": item_id,
+                        "status": "duplicate_skipped",
+                        "output_path": dup_err.existing_path,
+                        "provider": result.provider_name,
+                    }
                 except (OSError, RuntimeError) as save_error:
                     logger.error(
                         "Wanted %d: Failed to save target SRT from %s: %s",
@@ -795,6 +830,13 @@ def process_wanted_item(item_id: int) -> dict:
                         file_path,
                         result.score,
                     )
+                except DuplicateSubtitleError as dup_err:
+                    logger.info(
+                        "Wanted %d: Duplicate source SRT skipped, using existing %s",
+                        item_id,
+                        dup_err.existing_path,
+                    )
+                    actual_source_path = dup_err.existing_path
                 except (OSError, RuntimeError) as save_error:
                     logger.error(
                         "Wanted %d: Failed to save source SRT from %s: %s",
@@ -1019,6 +1061,20 @@ def _process_forced_wanted_item(item, item_id, item_lang, manager):
                         "provider": result.provider_name,
                         "forced": True,
                     }
+                except DuplicateSubtitleError as dup_err:
+                    logger.info(
+                        "Wanted %d: Duplicate forced subtitle skipped, already at %s",
+                        item_id,
+                        dup_err.existing_path,
+                    )
+                    update_wanted_status(item_id, "found")
+                    return {
+                        "wanted_id": item_id,
+                        "status": "duplicate_skipped",
+                        "output_path": dup_err.existing_path,
+                        "provider": result.provider_name,
+                        "forced": True,
+                    }
                 except (OSError, RuntimeError) as save_error:
                     logger.error(
                         "Wanted %d: Failed to save forced subtitle from %s: %s",
@@ -1068,6 +1124,20 @@ def _process_forced_wanted_item(item, item_id, item_lang, manager):
                         "wanted_id": item_id,
                         "status": "found",
                         "output_path": output_path,
+                        "provider": result.provider_name,
+                        "forced": True,
+                    }
+                except DuplicateSubtitleError as dup_err:
+                    logger.info(
+                        "Wanted %d: Duplicate forced subtitle (source) skipped, already at %s",
+                        item_id,
+                        dup_err.existing_path,
+                    )
+                    update_wanted_status(item_id, "found")
+                    return {
+                        "wanted_id": item_id,
+                        "status": "duplicate_skipped",
+                        "output_path": dup_err.existing_path,
                         "provider": result.provider_name,
                         "forced": True,
                     }
@@ -1328,6 +1398,8 @@ def download_specific_for_item(
                 file_path,
                 target_result.score,
             )
+        except DuplicateSubtitleError as dup_err:
+            actual_source_path = dup_err.existing_path
         except (OSError, RuntimeError) as e:
             return {"success": False, "error": f"Failed to save subtitle: {e}"}
 
@@ -1424,6 +1496,16 @@ def download_specific_for_item(
             file_path,
             target_result.score,
         )
+    except DuplicateSubtitleError as dup_err:
+        update_wanted_status(item_id, "found")
+        _try_auto_sync(dup_err.existing_path, file_path, settings)
+        return {
+            "success": True,
+            "path": dup_err.existing_path,
+            "format": fmt_ext,
+            "translated": False,
+            "duplicate_skipped": True,
+        }
     except (OSError, RuntimeError) as e:
         return {"success": False, "error": f"Failed to save subtitle: {e}"}
 


### PR DESCRIPTION
## Summary

- **`compute_content_hash_from_bytes()`** in `dedup_engine` — in-memory SHA-256 hashing with same CRLF/whitespace normalization as the file-based variant; comparable hashes
- **`DuplicateSubtitleError`** (HTTP 409) added to the `SublarrError` hierarchy — carries `content_hash`, `existing_path`, `attempted_path`
- **`CleanupRepository.find_by_content_hash()`** — targeted single-hash lookup against the indexed `subtitle_hashes` table (sub-millisecond on SQLite)
- **`dedup_on_download` config setting** (`SUBLARR_DEDUP_ON_DOWNLOAD`, default `True`) — allows disabling without code changes
- **`save_subtitle()` gate** — after sanitization, before disk write: compute hash → query DB → if identical content in same directory → raise `DuplicateSubtitleError`; stale DB entries (file deleted) are auto-cleaned before the decision; hash upserted into `subtitle_hashes` on every successful write (auto-populates dedup DB without explicit scan)
- **`wanted_search` handlers** — `DuplicateSubtitleError` at direct target callsites → `status: "duplicate_skipped"` + `update_wanted_status("found")`; at source-file callsites → reuse `existing_path` for translation (subtitle already on disk, translate it)

## Test plan

- [x] `python -m pytest tests/test_dedup_detection.py -v` — 16/16 passed
  - Hash normalization: CRLF=LF, whitespace strip, BOM, empty, deterministic
  - `DuplicateSubtitleError`: hierarchy, HTTP 409, attributes, context
  - `save_subtitle()` scenarios: first write, duplicate (raises), cross-directory (not duplicate), stale hash (cleaned + write), disabled (no check)
- [x] `ruff check . && ruff format --check .` — 0 errors
- [ ] Manual: trigger wanted search, re-download same sub, verify INFO log + `duplicate_skipped` status

🤖 Generated with [Claude Code](https://claude.com/claude-code)