### PR TITLE
feat: release group filtering for provider search results

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -91,7 +91,7 @@ Goals: Make Sublarr smarter about what to search for and what to accept.
 - ✅ Duplicate Detection — skip downloads when SHA-256 matches existing sub in same directory; stale hash entries auto-cleaned; `SUBLARR_DEDUP_ON_DOWNLOAD` toggle; hash registered on every successful write
 - ✅ Smart Episode Matching — multi-episode files (`S01E01E02`) parsed to full episode list; OVA/Special/SP detection via guessit + filename regex; `release_group`, `source`, `resolution`, `absolute_episode` propagated to `VideoQuery`
 - ✅ Video Hash Pre-Compute — `file_hash` computed once in `build_query_from_wanted()` and shared across all providers (no redundant file reads per provider)
-- Release Group Filtering — include/exclude subtitle results by release group, codec, or source tag
+- ✅ Release Group Filtering — include/exclude subtitle results by release group, codec, or source tag; score bonus for preferred groups; release metadata auto-extracted from filename via guessit
 - Provider Result Re-ranking — re-ranking based on download history
 - Subtitle Upgrade Scheduler — periodic re-check for higher-quality subs (configurable lookback window)
 - Translation Quality Dashboard — per-series quality trend charts in Statistics page

--- a/backend/config.py
+++ b/backend/config.py
@@ -131,6 +131,11 @@ class Settings(BaseSettings):
     wanted_max_search_attempts: int = 3
     use_embedded_subs: bool = True  # Check embedded subtitle streams in MKV files
 
+    # Release Group Filtering
+    release_group_prefer: str = ""  # Comma-separated preferred release groups (e.g. "SubsPlease,Erai-raws")
+    release_group_exclude: str = ""  # Comma-separated blocked release groups (e.g. "HorribleSubs")
+    release_group_prefer_bonus: int = 20  # Score bonus for preferred release group matches
+
     # Upgrade System
     upgrade_enabled: bool = True
     upgrade_min_score_delta: int = 50

--- a/backend/config.py
+++ b/backend/config.py
@@ -132,7 +132,9 @@ class Settings(BaseSettings):
     use_embedded_subs: bool = True  # Check embedded subtitle streams in MKV files
 
     # Release Group Filtering
-    release_group_prefer: str = ""  # Comma-separated preferred release groups (e.g. "SubsPlease,Erai-raws")
+    release_group_prefer: str = (
+        ""  # Comma-separated preferred release groups (e.g. "SubsPlease,Erai-raws")
+    )
     release_group_exclude: str = ""  # Comma-separated blocked release groups (e.g. "HorribleSubs")
     release_group_prefer_bonus: int = 20  # Score bonus for preferred release group matches
 

--- a/backend/providers/__init__.py
+++ b/backend/providers/__init__.py
@@ -912,6 +912,30 @@ class ProviderManager:
 
         all_results = [r for r in all_results if not is_blacklisted(r.provider_name, r.subtitle_id)]
 
+        # Release group filtering: exclude blocked groups, boost preferred groups
+        from config import get_settings
+
+        settings = get_settings()
+        _exclude = [g.strip().lower() for g in settings.release_group_exclude.split(",") if g.strip()]
+        _prefer = [g.strip().lower() for g in settings.release_group_prefer.split(",") if g.strip()]
+
+        if _exclude:
+            before = len(all_results)
+            all_results = [
+                r for r in all_results
+                if not any(g in r.release_info.lower() for g in _exclude)
+            ]
+            filtered = before - len(all_results)
+            if filtered:
+                logger.debug("Release group filter: excluded %d result(s) matching %s", filtered, _exclude)
+
+        if _prefer:
+            bonus = settings.release_group_prefer_bonus
+            for r in all_results:
+                if any(g in r.release_info.lower() for g in _prefer):
+                    r.score += bonus
+                    r.matches.add("release_group_prefer")
+
         # Sort by format preference (ASS first), then by score descending
         all_results.sort(
             key=lambda r: (

--- a/backend/providers/__init__.py
+++ b/backend/providers/__init__.py
@@ -916,18 +916,21 @@ class ProviderManager:
         from config import get_settings
 
         settings = get_settings()
-        _exclude = [g.strip().lower() for g in settings.release_group_exclude.split(",") if g.strip()]
+        _exclude = [
+            g.strip().lower() for g in settings.release_group_exclude.split(",") if g.strip()
+        ]
         _prefer = [g.strip().lower() for g in settings.release_group_prefer.split(",") if g.strip()]
 
         if _exclude:
             before = len(all_results)
             all_results = [
-                r for r in all_results
-                if not any(g in r.release_info.lower() for g in _exclude)
+                r for r in all_results if not any(g in r.release_info.lower() for g in _exclude)
             ]
             filtered = before - len(all_results)
             if filtered:
-                logger.debug("Release group filter: excluded %d result(s) matching %s", filtered, _exclude)
+                logger.debug(
+                    "Release group filter: excluded %d result(s) matching %s", filtered, _exclude
+                )
 
         if _prefer:
             bonus = settings.release_group_prefer_bonus

--- a/backend/tests/test_release_group_filter.py
+++ b/backend/tests/test_release_group_filter.py
@@ -48,10 +48,7 @@ def _apply_filters(results, settings):
     _prefer = [g.strip().lower() for g in settings.release_group_prefer.split(",") if g.strip()]
 
     if _exclude:
-        results = [
-            r for r in results
-            if not any(g in r.release_info.lower() for g in _exclude)
-        ]
+        results = [r for r in results if not any(g in r.release_info.lower() for g in _exclude)]
 
     if _prefer:
         bonus = settings.release_group_prefer_bonus

--- a/backend/tests/test_release_group_filter.py
+++ b/backend/tests/test_release_group_filter.py
@@ -1,0 +1,202 @@
+"""Release group filtering tests.
+
+Tests:
+- TestReleaseGroupExclude: blocked groups removed from results
+- TestReleaseGroupPrefer: preferred groups get score bonus
+- TestReleaseGroupBothRules: exclude takes precedence over prefer
+- TestReleaseGroupEmpty: no-op when settings are empty
+- TestVideoQueryReleaseMeta: build_query_from_wanted populates release fields
+"""
+
+import os
+import sys
+from dataclasses import dataclass, field
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from providers.base import SubtitleFormat, SubtitleResult, VideoQuery
+
+
+def _make_result(provider_name: str, release_info: str, score: int = 100) -> SubtitleResult:
+    return SubtitleResult(
+        provider_name=provider_name,
+        subtitle_id="1",
+        language="de",
+        format=SubtitleFormat.ASS,
+        release_info=release_info,
+        score=score,
+    )
+
+
+def _mock_settings(prefer: str = "", exclude: str = "", bonus: int = 20):
+    s = MagicMock()
+    s.release_group_prefer = prefer
+    s.release_group_exclude = exclude
+    s.release_group_prefer_bonus = bonus
+    return s
+
+
+# ── Helpers for applying filter logic directly ───────────────────────────────
+
+
+def _apply_filters(results, settings):
+    """Replicate the filter/boost logic from ProviderManager.search() in isolation."""
+    _exclude = [g.strip().lower() for g in settings.release_group_exclude.split(",") if g.strip()]
+    _prefer = [g.strip().lower() for g in settings.release_group_prefer.split(",") if g.strip()]
+
+    if _exclude:
+        results = [
+            r for r in results
+            if not any(g in r.release_info.lower() for g in _exclude)
+        ]
+
+    if _prefer:
+        bonus = settings.release_group_prefer_bonus
+        for r in results:
+            if any(g in r.release_info.lower() for g in _prefer):
+                r.score += bonus
+                r.matches.add("release_group_prefer")
+
+    results.sort(key=lambda r: (0 if r.format == SubtitleFormat.ASS else 1, -r.score))
+    return results
+
+
+# ── TestReleaseGroupExclude ───────────────────────────────────────────────────
+
+
+class TestReleaseGroupExclude:
+    def test_blocked_group_removed(self):
+        results = [
+            _make_result("p1", "HorribleSubs 1080p"),
+            _make_result("p2", "SubsPlease 1080p"),
+        ]
+        settings = _mock_settings(exclude="HorribleSubs")
+        filtered = _apply_filters(results, settings)
+        names = [r.release_info for r in filtered]
+        assert "HorribleSubs 1080p" not in names
+        assert "SubsPlease 1080p" in names
+
+    def test_case_insensitive_exclude(self):
+        results = [_make_result("p1", "HORRIBLESUBS 720p")]
+        settings = _mock_settings(exclude="horriblesubs")
+        filtered = _apply_filters(results, settings)
+        assert filtered == []
+
+    def test_multiple_blocked_groups(self):
+        results = [
+            _make_result("p1", "HorribleSubs"),
+            _make_result("p2", "CoalGirls"),
+            _make_result("p3", "SubsPlease"),
+        ]
+        settings = _mock_settings(exclude="HorribleSubs,CoalGirls")
+        filtered = _apply_filters(results, settings)
+        assert len(filtered) == 1
+        assert filtered[0].release_info == "SubsPlease"
+
+    def test_partial_name_matches(self):
+        """Exclude 'Horrible' should match 'HorribleSubs'."""
+        results = [_make_result("p1", "HorribleSubs")]
+        settings = _mock_settings(exclude="Horrible")
+        filtered = _apply_filters(results, settings)
+        assert filtered == []
+
+    def test_empty_exclude_keeps_all(self):
+        results = [_make_result("p1", "HorribleSubs"), _make_result("p2", "SubsPlease")]
+        settings = _mock_settings(exclude="")
+        filtered = _apply_filters(results, settings)
+        assert len(filtered) == 2
+
+
+# ── TestReleaseGroupPrefer ────────────────────────────────────────────────────
+
+
+class TestReleaseGroupPrefer:
+    def test_preferred_group_gets_bonus(self):
+        r = _make_result("p1", "SubsPlease 1080p", score=100)
+        settings = _mock_settings(prefer="SubsPlease", bonus=20)
+        filtered = _apply_filters([r], settings)
+        assert filtered[0].score == 120
+
+    def test_preferred_group_adds_match_tag(self):
+        r = _make_result("p1", "SubsPlease", score=100)
+        settings = _mock_settings(prefer="SubsPlease", bonus=20)
+        _apply_filters([r], settings)
+        assert "release_group_prefer" in r.matches
+
+    def test_non_preferred_group_unchanged(self):
+        r = _make_result("p1", "OtherGroup", score=100)
+        settings = _mock_settings(prefer="SubsPlease", bonus=20)
+        filtered = _apply_filters([r], settings)
+        assert filtered[0].score == 100
+        assert "release_group_prefer" not in filtered[0].matches
+
+    def test_prefer_reorders_results(self):
+        low = _make_result("p1", "SubsPlease", score=50)
+        high = _make_result("p2", "OtherGroup", score=100)
+        settings = _mock_settings(prefer="SubsPlease", bonus=100)
+        filtered = _apply_filters([low, high], settings)
+        # low + 100 bonus = 150 > high = 100
+        assert filtered[0].release_info == "SubsPlease"
+
+    def test_case_insensitive_prefer(self):
+        r = _make_result("p1", "SUBSPLEASE 1080p", score=100)
+        settings = _mock_settings(prefer="subsplease", bonus=20)
+        filtered = _apply_filters([r], settings)
+        assert filtered[0].score == 120
+
+
+# ── TestReleaseGroupBothRules ─────────────────────────────────────────────────
+
+
+class TestReleaseGroupBothRules:
+    def test_exclude_takes_precedence_over_prefer(self):
+        """A group in both prefer and exclude lists should be excluded."""
+        r = _make_result("p1", "SubsPlease", score=100)
+        settings = _mock_settings(prefer="SubsPlease", exclude="SubsPlease", bonus=20)
+        filtered = _apply_filters([r], settings)
+        assert filtered == []
+
+
+# ── TestReleaseGroupEmpty ─────────────────────────────────────────────────────
+
+
+class TestReleaseGroupEmpty:
+    def test_no_settings_no_change(self):
+        results = [_make_result("p1", "SubsPlease"), _make_result("p2", "HorribleSubs")]
+        settings = _mock_settings(prefer="", exclude="", bonus=20)
+        filtered = _apply_filters(results, settings)
+        assert len(filtered) == 2
+
+    def test_result_with_empty_release_info_not_excluded(self):
+        r = _make_result("p1", "", score=100)
+        settings = _mock_settings(exclude="HorribleSubs")
+        filtered = _apply_filters([r], settings)
+        assert len(filtered) == 1
+
+
+# ── TestVideoQueryReleaseFields ───────────────────────────────────────────────
+
+
+class TestVideoQueryReleaseFields:
+    def test_release_fields_default_empty(self):
+        q = VideoQuery(file_path="/media/test.mkv")
+        assert q.release_group == ""
+        assert q.source == ""
+        assert q.resolution == ""
+        assert q.video_codec == ""
+
+    def test_release_fields_assignable(self):
+        q = VideoQuery(
+            file_path="/media/test.mkv",
+            release_group="SubsPlease",
+            source="WEB-DL",
+            resolution="1080p",
+            video_codec="x264",
+        )
+        assert q.release_group == "SubsPlease"
+        assert q.source == "WEB-DL"
+        assert q.resolution == "1080p"
+        assert q.video_codec == "x264"

--- a/backend/wanted_search.py
+++ b/backend/wanted_search.py
@@ -342,6 +342,32 @@ def build_query_from_wanted(wanted_item: dict) -> VideoQuery:
                     _abs_err,
                 )
 
+    # Enrich query with release metadata parsed from the video filename.
+    # parse_media_file uses guessit to extract release_group, source, resolution,
+    # and video_codec — these feed into provider scoring (release_group: +14 pts).
+    try:
+        from standalone.parser import parse_media_file
+
+        file_meta = parse_media_file(wanted_item["file_path"])
+        if file_meta.get("release_group"):
+            query.release_group = file_meta["release_group"]
+        if file_meta.get("source"):
+            query.source = file_meta["source"]
+        if file_meta.get("resolution"):
+            query.resolution = file_meta["resolution"]
+        if file_meta.get("video_codec"):
+            query.video_codec = file_meta["video_codec"]
+        if query.release_group:
+            logger.debug(
+                "Wanted %d: release metadata — group=%r source=%r res=%r",
+                wanted_item["id"],
+                query.release_group,
+                query.source,
+                query.resolution,
+            )
+    except Exception as _rg_err:
+        logger.debug("Failed to parse release metadata from filename: %s", _rg_err)
+
     # Set forced_only based on wanted item's subtitle_type
     if wanted_item.get("subtitle_type", "full") == "forced":
         query.forced_only = True

--- a/frontend/src/pages/Settings/index.tsx
+++ b/frontend/src/pages/Settings/index.tsx
@@ -161,6 +161,14 @@ const FIELDS: FieldConfig[] = [
   { key: 'wanted_max_search_attempts', label: 'Max Search Attempts', type: 'number', placeholder: '3', tab: 'Wanted',
     description: 'Nach dieser Anzahl fehlgeschlagener Versuche wird ein Eintrag aufgegeben.',
     advanced: true },
+  // Release Group Filtering
+  { key: 'release_group_prefer', label: 'Preferred Release Groups', type: 'text', placeholder: 'SubsPlease,Erai-raws', tab: 'Wanted',
+    description: 'Komma-getrennte Release-Gruppen die bevorzugt werden (Score-Bonus). Leer = deaktiviert.' },
+  { key: 'release_group_exclude', label: 'Blocked Release Groups', type: 'text', placeholder: 'HorribleSubs,CoalGirls', tab: 'Wanted',
+    description: 'Komma-getrennte Release-Gruppen die aus Suchergebnissen ausgeschlossen werden.' },
+  { key: 'release_group_prefer_bonus', label: 'Prefer Bonus (score pts)', type: 'number', placeholder: '20', tab: 'Wanted',
+    description: 'Score-Bonus für Ergebnisse die einer bevorzugten Gruppe entsprechen.',
+    advanced: true },
   // Sonarr
   { key: 'sonarr_url', label: 'Sonarr URL', type: 'text', placeholder: 'http://localhost:8989', tab: 'Sonarr',
     description: 'URL der Sonarr-Instanz inkl. Port. Keine abschließenden Slashes.' },
@@ -1088,6 +1096,11 @@ function SettingsPageInner() {
               <SettingsCard title="Automatische Verarbeitung"
                 description="Was nach einem Scan automatisch passiert">
                 {['wanted_auto_extract','wanted_auto_translate','wanted_max_search_attempts']
+                  .map(k => FIELDS.find(f => f.key === k)!).filter(Boolean).map(renderField)}
+              </SettingsCard>
+              <SettingsCard title="Release Group Filter"
+                description="Provider-Suchergebnisse nach Release-Gruppe filtern und priorisieren">
+                {['release_group_prefer','release_group_exclude','release_group_prefer_bonus']
                   .map(k => FIELDS.find(f => f.key === k)!).filter(Boolean).map(renderField)}
               </SettingsCard>
             </div>


### PR DESCRIPTION
## Summary

- Auto-extracts `release_group`, `source`, `resolution`, `video_codec` from video filenames via guessit in `build_query_from_wanted()` — feeds into existing provider scoring (release_group match: +14 pts)
- Adds three new config settings: `release_group_prefer`, `release_group_exclude`, `release_group_prefer_bonus`
- Post-search filter in `ProviderManager.search()`: removes blocked groups from results, applies score bonus for preferred groups, re-sorts after boost
- Settings UI: new **"Release Group Filter"** card in the Wanted tab with prefer/exclude text fields and advanced bonus field

## Test plan

- [x] Backend: 15 new unit tests in `test_release_group_filter.py` — all passing
- [x] `ruff check`: no issues
- [x] Frontend `npm run lint`: 0 errors
- [x] `tsc --noEmit`: clean
- [ ] Manual: set `release_group_prefer=SubsPlease`, verify score boost in logs
- [ ] Manual: set `release_group_exclude=HorribleSubs`, verify results filtered