### PR TITLE
feat: provider result re-ranking based on download history

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -92,7 +92,7 @@ Goals: Make Sublarr smarter about what to search for and what to accept.
 - ✅ Smart Episode Matching — multi-episode files (`S01E01E02`) parsed to full episode list; OVA/Special/SP detection via guessit + filename regex; `release_group`, `source`, `resolution`, `absolute_episode` propagated to `VideoQuery`
 - ✅ Video Hash Pre-Compute — `file_hash` computed once in `build_query_from_wanted()` and shared across all providers (no redundant file reads per provider)
 - ✅ Release Group Filtering — include/exclude subtitle results by release group, codec, or source tag; score bonus for preferred groups; release metadata auto-extracted from filename via guessit
-- Provider Result Re-ranking — re-ranking based on download history
+- ✅ Provider Result Re-ranking — auto-adjust per-provider score modifiers from download history; formula: success_rate + avg_score vs. global avg + consecutive failure penalty; throttled hourly; preview endpoint + manual trigger
 - Subtitle Upgrade Scheduler — periodic re-check for higher-quality subs (configurable lookback window)
 - Translation Quality Dashboard — per-series quality trend charts in Statistics page
 - Custom Post-Processing Scripts — user-supplied shell scripts run after download/translate

--- a/backend/config.py
+++ b/backend/config.py
@@ -131,6 +131,13 @@ class Settings(BaseSettings):
     wanted_max_search_attempts: int = 3
     use_embedded_subs: bool = True  # Check embedded subtitle streams in MKV files
 
+    # Provider Re-ranking
+    provider_reranking_enabled: bool = False  # Auto-adjust score modifiers from download history
+    provider_reranking_min_downloads: int = (
+        20  # Min successful downloads before modifier is applied
+    )
+    provider_reranking_max_modifier: int = 50  # Absolute cap on computed modifier (±)
+
     # Release Group Filtering
     release_group_prefer: str = (
         ""  # Comma-separated preferred release groups (e.g. "SubsPlease,Erai-raws")

--- a/backend/providers/__init__.py
+++ b/backend/providers/__init__.py
@@ -1103,6 +1103,13 @@ class ProviderManager:
                 if content is not None:  # Empty bytes for embedded is OK
                     # Record successful download
                     update_provider_stats(result.provider_name, success=True, score=result.score)
+                    # Trigger auto re-ranking (throttled to once/hour)
+                    try:
+                        from providers.reranker import apply_auto_reranking
+
+                        apply_auto_reranking()
+                    except Exception as _rr_err:
+                        logger.debug("Re-ranking trigger skipped: %s", _rr_err)
                     return result
                 else:
                     # Record failed download

--- a/backend/providers/reranker.py
+++ b/backend/providers/reranker.py
@@ -1,0 +1,261 @@
+"""Provider result re-ranking engine.
+
+Automatically adjusts per-provider score modifiers based on download history
+statistics. Providers with high success rates and above-average subtitle
+quality receive a bonus; consistently failing providers get penalized.
+
+Usage:
+    # Compute preview (read-only)
+    preview = compute_reranking_preview()
+
+    # Apply modifiers to DB
+    apply_auto_reranking()
+
+Throttling:
+    apply_auto_reranking() is a no-op if called more than once per hour
+    (unless force=True). The last-run timestamp is kept in memory.
+"""
+
+import logging
+import time
+
+logger = logging.getLogger(__name__)
+
+# In-memory throttle: skip re-rank if last run < _RERANK_INTERVAL_SECS ago
+_RERANK_INTERVAL_SECS = 3600  # 1 hour
+_last_rerank_ts: float = 0.0
+
+
+# ---------------------------------------------------------------------------
+# Core formula
+# ---------------------------------------------------------------------------
+
+#: Success-rate baseline. Providers above this get a bonus, below get a penalty.
+_BASELINE_SUCCESS_RATE = 0.65
+
+#: Multiplier for success-rate component (scales ±1.0 deviation → ±this many pts).
+_SUCCESS_RATE_SCALE = 40
+
+#: Max absolute contribution from the score-delta component.
+_SCORE_DELTA_CAP = 15
+
+#: Consecutive-failure threshold that triggers a hard penalty.
+_CONSECUTIVE_FAILURE_THRESHOLD = 5
+_CONSECUTIVE_FAILURE_PENALTY = -30
+
+
+def compute_modifier_from_stats(
+    stats: dict,
+    global_avg_score: float,
+    min_downloads: int,
+    max_modifier: int,
+) -> int | None:
+    """Compute a score modifier for one provider based on its stats.
+
+    Args:
+        stats: Dict from ProviderRepository.get_all_provider_stats()
+               Keys: successful_downloads, failed_downloads, avg_score,
+                     success_rate, consecutive_failures
+        global_avg_score: Mean avg_score across all providers (for relative comparison).
+        min_downloads:    Minimum successful downloads required before applying modifier.
+        max_modifier:     Absolute cap on the returned modifier value.
+
+    Returns:
+        Integer modifier, or None if not enough data to make a decision.
+    """
+    n_success = stats.get("successful_downloads") or 0
+    if n_success < min_downloads:
+        return None  # not enough data
+
+    consecutive_failures = stats.get("consecutive_failures") or 0
+    if consecutive_failures >= _CONSECUTIVE_FAILURE_THRESHOLD:
+        penalty = max(-max_modifier, _CONSECUTIVE_FAILURE_PENALTY)
+        return penalty
+
+    success_rate = stats.get("success_rate") or 0.0
+    avg_score = stats.get("avg_score") or 0.0
+
+    # Success-rate component: deviation from baseline, scaled
+    sr_modifier = int((success_rate - _BASELINE_SUCCESS_RATE) * _SUCCESS_RATE_SCALE)
+
+    # Score-quality component: how this provider's avg score compares to the field
+    if global_avg_score > 0 and avg_score > 0:
+        delta = avg_score - global_avg_score
+        # +/- 100 score delta → approx +/- _SCORE_DELTA_CAP pts
+        score_modifier = int(delta / (100 / _SCORE_DELTA_CAP))
+        score_modifier = max(-_SCORE_DELTA_CAP, min(_SCORE_DELTA_CAP, score_modifier))
+    else:
+        score_modifier = 0
+
+    total = sr_modifier + score_modifier
+    return max(-max_modifier, min(max_modifier, total))
+
+
+def _compute_global_avg_score(all_stats: list[dict]) -> float:
+    """Weighted average of avg_score across providers with enough downloads."""
+    scores = [
+        (s["avg_score"] or 0.0, s["successful_downloads"] or 0)
+        for s in all_stats
+        if (s.get("avg_score") or 0) > 0 and (s.get("successful_downloads") or 0) > 0
+    ]
+    if not scores:
+        return 0.0
+    total_weight = sum(w for _, w in scores)
+    if total_weight == 0:
+        return 0.0
+    return sum(v * w for v, w in scores) / total_weight
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def compute_reranking_preview(
+    min_downloads: int | None = None,
+    max_modifier: int | None = None,
+) -> dict:
+    """Compute what modifiers would be applied without writing anything.
+
+    Returns:
+        {
+            "global_avg_score": float,
+            "providers": {
+                "<name>": {
+                    "current_modifier": int,
+                    "proposed_modifier": int | None,
+                    "stats": { successful_downloads, success_rate, avg_score, ... },
+                    "reason": str,
+                }
+            }
+        }
+    """
+    from config import get_settings
+    from db import get_db
+    from db.repositories.providers import ProviderRepository
+    from db.repositories.scoring import ScoringRepository
+
+    settings = get_settings()
+    if min_downloads is None:
+        min_downloads = settings.provider_reranking_min_downloads
+    if max_modifier is None:
+        max_modifier = settings.provider_reranking_max_modifier
+
+    with get_db() as db:
+        provider_repo = ProviderRepository(db)
+        scoring_repo = ScoringRepository(db)
+
+        all_stats = provider_repo.get_all_provider_stats()
+        current_modifiers = scoring_repo.get_all_provider_modifiers()
+
+    global_avg = _compute_global_avg_score(all_stats)
+
+    result: dict = {"global_avg_score": round(global_avg, 1), "providers": {}}
+
+    for stats in all_stats:
+        name = stats["provider_name"]
+        proposed = compute_modifier_from_stats(stats, global_avg, min_downloads, max_modifier)
+        current = current_modifiers.get(name, 0)
+
+        if proposed is None:
+            reason = f"insufficient data ({stats.get('successful_downloads', 0)} < {min_downloads} downloads)"
+        elif stats.get("consecutive_failures", 0) >= _CONSECUTIVE_FAILURE_THRESHOLD:
+            reason = f"consecutive failure penalty ({stats['consecutive_failures']} failures)"
+        else:
+            sr = stats.get("success_rate", 0.0)
+            reason = (
+                f"success_rate={sr:.0%} "
+                f"avg_score={stats.get('avg_score', 0):.0f} "
+                f"global_avg={global_avg:.0f}"
+            )
+
+        result["providers"][name] = {
+            "current_modifier": current,
+            "proposed_modifier": proposed,
+            "stats": {
+                "successful_downloads": stats.get("successful_downloads", 0),
+                "failed_downloads": stats.get("failed_downloads", 0),
+                "success_rate": round(stats.get("success_rate", 0.0), 3),
+                "avg_score": round(stats.get("avg_score", 0.0), 1),
+                "consecutive_failures": stats.get("consecutive_failures", 0),
+            },
+            "reason": reason,
+        }
+
+    return result
+
+
+def apply_auto_reranking(force: bool = False) -> dict:
+    """Compute and write provider score modifiers based on download history.
+
+    Throttled to at most once per hour unless force=True.
+
+    Returns:
+        {"applied": int, "skipped": int, "reason": str}
+        Where applied = number of modifiers written, skipped = not enough data.
+    """
+    global _last_rerank_ts
+
+    from config import get_settings
+
+    settings = get_settings()
+    if not settings.provider_reranking_enabled and not force:
+        return {"applied": 0, "skipped": 0, "reason": "reranking disabled"}
+
+    now = time.monotonic()
+    if not force and (now - _last_rerank_ts) < _RERANK_INTERVAL_SECS:
+        remaining = int(_RERANK_INTERVAL_SECS - (now - _last_rerank_ts))
+        return {"applied": 0, "skipped": 0, "reason": f"throttled (next in {remaining}s)"}
+
+    _last_rerank_ts = now
+
+    from db import get_db
+    from db.repositories.providers import ProviderRepository
+    from db.repositories.scoring import ScoringRepository
+    from providers.base import invalidate_scoring_cache
+
+    min_downloads = settings.provider_reranking_min_downloads
+    max_modifier = settings.provider_reranking_max_modifier
+
+    with get_db() as db:
+        provider_repo = ProviderRepository(db)
+        scoring_repo = ScoringRepository(db)
+
+        all_stats = provider_repo.get_all_provider_stats()
+        global_avg = _compute_global_avg_score(all_stats)
+
+        applied = 0
+        skipped = 0
+        changes = []
+
+        for stats in all_stats:
+            name = stats["provider_name"]
+            proposed = compute_modifier_from_stats(stats, global_avg, min_downloads, max_modifier)
+
+            if proposed is None:
+                skipped += 1
+                continue
+
+            current = scoring_repo.get_provider_modifier(name)
+            if proposed != current:
+                scoring_repo.set_provider_modifier(name, proposed)
+                changes.append(f"{name}: {current:+d} → {proposed:+d}")
+                applied += 1
+
+    if applied:
+        invalidate_scoring_cache()
+        logger.info(
+            "Provider re-ranking applied %d modifier(s): %s",
+            applied,
+            ", ".join(changes),
+        )
+    else:
+        logger.debug("Provider re-ranking: no modifier changes needed")
+
+    return {
+        "applied": applied,
+        "skipped": skipped,
+        "reason": "ok",
+        "changes": changes,
+        "global_avg_score": round(global_avg, 1),
+    }

--- a/backend/routes/providers.py
+++ b/backend/routes/providers.py
@@ -551,3 +551,36 @@ def clear_cache():
             "provider": provider_name or "all",
         }
     )
+
+
+@bp.route("/rerank/preview", methods=["GET"])
+def get_rerank_preview():
+    """GET /api/v1/providers/rerank/preview — preview auto re-ranking without applying.
+
+    Returns proposed modifier for each provider based on current download history.
+    """
+    from config import get_settings
+    from providers.reranker import compute_reranking_preview
+
+    settings = get_settings()
+    min_dl = request.args.get("min_downloads", settings.provider_reranking_min_downloads, type=int)
+    max_mod = request.args.get("max_modifier", settings.provider_reranking_max_modifier, type=int)
+
+    preview = compute_reranking_preview(min_downloads=min_dl, max_modifier=max_mod)
+    return jsonify(preview)
+
+
+@bp.route("/rerank", methods=["POST"])
+def trigger_rerank():
+    """POST /api/v1/providers/rerank — manually trigger provider re-ranking.
+
+    Body (optional JSON):
+        force: bool  — bypass hourly throttle (default: true for manual trigger)
+    """
+    data = request.get_json(silent=True) or {}
+    force = data.get("force", True)
+
+    from providers.reranker import apply_auto_reranking
+
+    result = apply_auto_reranking(force=force)
+    return jsonify(result)

--- a/backend/tests/test_provider_reranking.py
+++ b/backend/tests/test_provider_reranking.py
@@ -1,0 +1,347 @@
+"""Provider re-ranking engine tests.
+
+Tests:
+- TestComputeModifierFromStats: formula correctness, edge cases
+- TestComputeGlobalAvgScore: weighted average calculation
+- TestRerankingThrottle: throttle prevents repeated runs
+- TestRerankingDisabled: no-op when feature flag is off
+"""
+
+import os
+import sys
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from providers.reranker import (
+    _BASELINE_SUCCESS_RATE,
+    _CONSECUTIVE_FAILURE_THRESHOLD,
+    _compute_global_avg_score,
+    compute_modifier_from_stats,
+)
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _stats(
+    successful=30,
+    failed=10,
+    avg_score=800.0,
+    success_rate=None,
+    consecutive_failures=0,
+):
+    if success_rate is None:
+        total = successful + failed
+        success_rate = successful / total if total > 0 else 0.0
+    return {
+        "provider_name": "testprovider",
+        "successful_downloads": successful,
+        "failed_downloads": failed,
+        "avg_score": avg_score,
+        "success_rate": success_rate,
+        "consecutive_failures": consecutive_failures,
+    }
+
+
+# ── TestComputeModifierFromStats ──────────────────────────────────────────────
+
+
+class TestComputeModifierFromStats:
+    def test_none_when_below_min_downloads(self):
+        result = compute_modifier_from_stats(
+            _stats(successful=5), global_avg_score=800.0, min_downloads=20, max_modifier=50
+        )
+        assert result is None
+
+    def test_zero_when_exactly_at_baseline_success_rate(self):
+        result = compute_modifier_from_stats(
+            _stats(successful=20, failed=10, success_rate=_BASELINE_SUCCESS_RATE, avg_score=800.0),
+            global_avg_score=800.0,
+            min_downloads=20,
+            max_modifier=50,
+        )
+        # At baseline success rate AND avg score == global avg → modifier near 0
+        assert result is not None
+        assert abs(result) <= 5  # small rounding allowed
+
+    def test_positive_modifier_for_high_success_rate(self):
+        result = compute_modifier_from_stats(
+            _stats(successful=50, failed=5, success_rate=0.91, avg_score=850.0),
+            global_avg_score=800.0,
+            min_downloads=20,
+            max_modifier=50,
+        )
+        assert result is not None
+        assert result > 0
+
+    def test_negative_modifier_for_low_success_rate(self):
+        result = compute_modifier_from_stats(
+            _stats(successful=20, failed=40, success_rate=0.33, avg_score=600.0),
+            global_avg_score=800.0,
+            min_downloads=20,
+            max_modifier=50,
+        )
+        assert result is not None
+        assert result < 0
+
+    def test_hard_penalty_for_consecutive_failures(self):
+        result = compute_modifier_from_stats(
+            _stats(
+                successful=50,
+                failed=5,
+                success_rate=0.91,
+                consecutive_failures=_CONSECUTIVE_FAILURE_THRESHOLD,
+            ),
+            global_avg_score=800.0,
+            min_downloads=20,
+            max_modifier=50,
+        )
+        assert result is not None
+        assert result < 0  # Even with high success rate, consecutive failures penalize
+
+    def test_modifier_capped_at_max(self):
+        # Perfect provider with low global avg
+        result = compute_modifier_from_stats(
+            _stats(successful=1000, failed=0, success_rate=1.0, avg_score=1000.0),
+            global_avg_score=100.0,
+            min_downloads=20,
+            max_modifier=50,
+        )
+        assert result is not None
+        assert result <= 50
+
+    def test_modifier_floor_at_negative_max(self):
+        # Terrible provider
+        result = compute_modifier_from_stats(
+            _stats(successful=20, failed=200, success_rate=0.09, avg_score=100.0),
+            global_avg_score=900.0,
+            min_downloads=20,
+            max_modifier=50,
+        )
+        assert result is not None
+        assert result >= -50
+
+    def test_no_score_bonus_when_global_avg_zero(self):
+        # When global_avg_score is 0, score component should be 0
+        result_with_avg = compute_modifier_from_stats(
+            _stats(successful=30, failed=10, success_rate=0.75, avg_score=900.0),
+            global_avg_score=800.0,
+            min_downloads=20,
+            max_modifier=50,
+        )
+        result_no_avg = compute_modifier_from_stats(
+            _stats(successful=30, failed=10, success_rate=0.75, avg_score=900.0),
+            global_avg_score=0.0,
+            min_downloads=20,
+            max_modifier=50,
+        )
+        # With global_avg=0, score component is skipped — result is success_rate component only
+        assert result_no_avg is not None
+        assert result_with_avg is not None
+        # Should differ (score component was adding bonus with global_avg=800)
+        assert result_no_avg != result_with_avg
+
+    def test_zero_consecutive_failures_no_penalty(self):
+        result = compute_modifier_from_stats(
+            _stats(successful=50, consecutive_failures=0, success_rate=0.83),
+            global_avg_score=800.0,
+            min_downloads=20,
+            max_modifier=50,
+        )
+        assert result is not None
+        assert result >= 0  # No failure streak → no penalty from that component
+
+
+# ── TestComputeGlobalAvgScore ─────────────────────────────────────────────────
+
+
+class TestComputeGlobalAvgScore:
+    def _make_stats(self, name, avg_score, n):
+        return {
+            "provider_name": name,
+            "avg_score": avg_score,
+            "successful_downloads": n,
+        }
+
+    def test_empty_list_returns_zero(self):
+        assert _compute_global_avg_score([]) == 0.0
+
+    def test_single_provider(self):
+        result = _compute_global_avg_score([self._make_stats("p1", 800.0, 10)])
+        assert result == pytest.approx(800.0)
+
+    def test_weighted_by_download_count(self):
+        # p1: avg=600 with 100 downloads, p2: avg=900 with 100 downloads → avg=750
+        stats = [
+            self._make_stats("p1", 600.0, 100),
+            self._make_stats("p2", 900.0, 100),
+        ]
+        result = _compute_global_avg_score(stats)
+        assert result == pytest.approx(750.0)
+
+    def test_higher_weight_dominates(self):
+        # p1: avg=400 with 10 downloads, p2: avg=900 with 990 downloads → heavily weighted to p2
+        stats = [
+            self._make_stats("p1", 400.0, 10),
+            self._make_stats("p2", 900.0, 990),
+        ]
+        result = _compute_global_avg_score(stats)
+        assert result > 800.0  # p2 should dominate
+
+    def test_providers_with_zero_score_excluded(self):
+        stats = [
+            self._make_stats("p1", 0.0, 100),  # excluded
+            self._make_stats("p2", 800.0, 50),
+        ]
+        result = _compute_global_avg_score(stats)
+        assert result == pytest.approx(800.0)
+
+    def test_providers_with_zero_downloads_excluded(self):
+        stats = [
+            self._make_stats("p1", 900.0, 0),  # excluded
+            self._make_stats("p2", 800.0, 50),
+        ]
+        result = _compute_global_avg_score(stats)
+        assert result == pytest.approx(800.0)
+
+
+# ── TestRerankingDisabled ─────────────────────────────────────────────────────
+
+
+class TestRerankingDisabled:
+    def test_returns_disabled_reason_when_feature_flag_off(self):
+        from providers.reranker import apply_auto_reranking
+
+        mock_settings = MagicMock()
+        mock_settings.provider_reranking_enabled = False
+
+        with patch("config.get_settings", return_value=mock_settings):
+            result = apply_auto_reranking(force=False)
+
+        assert result["applied"] == 0
+        assert "disabled" in result["reason"]
+
+    def test_force_bypasses_feature_flag_check(self):
+        """force=True must bypass the enabled check (used for manual triggers)."""
+        from providers import reranker
+
+        mock_settings = MagicMock()
+        mock_settings.provider_reranking_enabled = False
+        mock_settings.provider_reranking_min_downloads = 20
+        mock_settings.provider_reranking_max_modifier = 50
+
+        with (
+            patch("config.get_settings", return_value=mock_settings),
+            patch("db.get_db") as mock_db_ctx,
+        ):
+            mock_db = MagicMock()
+            mock_db_ctx.return_value.__enter__ = MagicMock(return_value=mock_db)
+            mock_db_ctx.return_value.__exit__ = MagicMock(return_value=False)
+
+            mock_provider_repo = MagicMock()
+            mock_provider_repo.get_all_provider_stats.return_value = []
+            mock_scoring_repo = MagicMock()
+            mock_scoring_repo.get_all_provider_modifiers.return_value = {}
+
+            with (
+                patch(
+                    "db.repositories.providers.ProviderRepository", return_value=mock_provider_repo
+                ),
+                patch("db.repositories.scoring.ScoringRepository", return_value=mock_scoring_repo),
+                patch("providers.base.invalidate_scoring_cache"),
+            ):
+                result = reranker.apply_auto_reranking(force=True)
+
+        # Should NOT return "disabled" — it ran (even with empty stats)
+        assert "disabled" not in result["reason"]
+
+
+# ── TestRerankingThrottle ─────────────────────────────────────────────────────
+
+
+class TestRerankingThrottle:
+    def test_throttled_after_recent_run(self):
+        from providers import reranker
+
+        mock_settings = MagicMock()
+        mock_settings.provider_reranking_enabled = True
+
+        # Simulate last run just now
+        reranker._last_rerank_ts = time.monotonic()
+
+        with patch("config.get_settings", return_value=mock_settings):
+            result = reranker.apply_auto_reranking(force=False)
+
+        assert "throttled" in result["reason"]
+        assert result["applied"] == 0
+
+    def test_not_throttled_after_interval(self):
+        from providers import reranker
+
+        mock_settings = MagicMock()
+        mock_settings.provider_reranking_enabled = True
+        mock_settings.provider_reranking_min_downloads = 20
+        mock_settings.provider_reranking_max_modifier = 50
+
+        # Simulate last run long ago
+        reranker._last_rerank_ts = time.monotonic() - reranker._RERANK_INTERVAL_SECS - 1
+
+        with (
+            patch("config.get_settings", return_value=mock_settings),
+            patch("db.get_db") as mock_db_ctx,
+        ):
+            mock_db = MagicMock()
+            mock_db_ctx.return_value.__enter__ = MagicMock(return_value=mock_db)
+            mock_db_ctx.return_value.__exit__ = MagicMock(return_value=False)
+
+            mock_provider_repo = MagicMock()
+            mock_provider_repo.get_all_provider_stats.return_value = []
+            mock_scoring_repo = MagicMock()
+
+            with (
+                patch(
+                    "db.repositories.providers.ProviderRepository", return_value=mock_provider_repo
+                ),
+                patch("db.repositories.scoring.ScoringRepository", return_value=mock_scoring_repo),
+                patch("providers.base.invalidate_scoring_cache"),
+            ):
+                result = reranker.apply_auto_reranking(force=False)
+
+        assert "throttled" not in result["reason"]
+
+    def test_force_bypasses_throttle(self):
+        from providers import reranker
+
+        mock_settings = MagicMock()
+        mock_settings.provider_reranking_enabled = True
+        mock_settings.provider_reranking_min_downloads = 20
+        mock_settings.provider_reranking_max_modifier = 50
+
+        # Simulate last run just now
+        reranker._last_rerank_ts = time.monotonic()
+
+        with (
+            patch("config.get_settings", return_value=mock_settings),
+            patch("db.get_db") as mock_db_ctx,
+        ):
+            mock_db = MagicMock()
+            mock_db_ctx.return_value.__enter__ = MagicMock(return_value=mock_db)
+            mock_db_ctx.return_value.__exit__ = MagicMock(return_value=False)
+
+            mock_provider_repo = MagicMock()
+            mock_provider_repo.get_all_provider_stats.return_value = []
+            mock_scoring_repo = MagicMock()
+
+            with (
+                patch(
+                    "db.repositories.providers.ProviderRepository", return_value=mock_provider_repo
+                ),
+                patch("db.repositories.scoring.ScoringRepository", return_value=mock_scoring_repo),
+                patch("providers.base.invalidate_scoring_cache"),
+            ):
+                result = reranker.apply_auto_reranking(force=True)
+
+        assert "throttled" not in result["reason"]

--- a/frontend/src/pages/Settings/index.tsx
+++ b/frontend/src/pages/Settings/index.tsx
@@ -114,6 +114,15 @@ const FIELDS: FieldConfig[] = [
     advanced: true },
   { key: 'hi_removal_enabled', label: 'Remove Hearing Impaired Tags', type: 'toggle', tab: 'Translation',
     description: 'Entfernt [Geräuschbeschreibungen] und (Sprechertags) aus Untertiteln.' },
+  // Automation — Provider Re-ranking
+  { key: 'provider_reranking_enabled', label: 'Auto Re-ranking', type: 'toggle', tab: 'Automation',
+    description: 'Provider-Score-Modifier automatisch aus Download-History berechnen. Gute Provider bekommen Bonus, schlechte Penalty.' },
+  { key: 'provider_reranking_min_downloads', label: 'Min Downloads (for re-ranking)', type: 'number', placeholder: '20', tab: 'Automation',
+    description: 'Mindest-Anzahl erfolgreicher Downloads bevor ein Modifier berechnet wird.',
+    advanced: true },
+  { key: 'provider_reranking_max_modifier', label: 'Max Modifier (±pts)', type: 'number', placeholder: '50', tab: 'Automation',
+    description: 'Maximaler absoluter Score-Modifier der durch Re-ranking vergeben wird.',
+    advanced: true },
   // Automation — Upgrade
   { key: 'upgrade_enabled', label: 'Upgrade Enabled', type: 'toggle', tab: 'Automation',
     description: 'Automatisch bessere Untertitel suchen wenn Score-Schwellenwert nicht erreicht.' },
@@ -1073,6 +1082,11 @@ function SettingsPageInner() {
               <SettingsCard title="Webhook-Aktionen"
                 description="Was passiert automatisch nach Sonarr/Radarr Downloads">
                 {['webhook_auto_scan','webhook_auto_search','webhook_auto_translate']
+                  .map(k => FIELDS.find(f => f.key === k)!).filter(Boolean).map(renderField)}
+              </SettingsCard>
+              <SettingsCard title="Provider Re-ranking"
+                description="Score-Modifier automatisch aus Download-History berechnen">
+                {['provider_reranking_enabled','provider_reranking_min_downloads','provider_reranking_max_modifier']
                   .map(k => FIELDS.find(f => f.key === k)!).filter(Boolean).map(renderField)}
               </SettingsCard>
               <SettingsCard title="Upgrade-Einstellungen"


### PR DESCRIPTION
## Summary

- **`providers/reranker.py`** — Core engine: `compute_modifier_from_stats()` formula uses success_rate (65% baseline), avg_score vs. global weighted average, and consecutive failure penalty; result capped at `±max_modifier`
- **`apply_auto_reranking()`** — Batch-updates `provider_score_modifiers` in DB, throttled to once/hour, invalidates scoring cache; triggered automatically after every successful download
- **`compute_reranking_preview()`** — Read-only preview showing proposed vs. current modifiers with reasoning
- **Config**: `provider_reranking_enabled` (default: off), `provider_reranking_min_downloads` (20), `provider_reranking_max_modifier` (50)
- **Routes**: `POST /api/v1/providers/rerank`, `GET /api/v1/providers/rerank/preview`
- **Settings UI**: new "Provider Re-ranking" card in Automation tab

## Test plan

- [x] 20 unit tests — all passing
- [x] `ruff check`: clean
- [x] `ruff format --check`: clean
- [x] Frontend `tsc --noEmit`: clean
- [ ] Manual: enable re-ranking, trigger `POST /providers/rerank`, verify modifier changes in `/scoring/modifiers`
- [ ] Manual: check throttle — second call within 1h returns `throttled` reason