### PR TITLE
feat: subtitle upgrade candidate scheduler

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -522,6 +522,15 @@ def _start_schedulers(settings, app=None):
         except Exception as e:
             logging.getLogger(__name__).warning("Cleanup scheduler start failed: %s", e)
 
+    # Start upgrade candidate scheduler
+    if app is not None:
+        try:
+            from upgrade_scheduler import start_upgrade_scheduler
+
+            start_upgrade_scheduler(app)
+        except Exception as e:
+            logging.getLogger(__name__).warning("Upgrade scheduler start failed: %s", e)
+
     # Start AniDB absolute episode sync scheduler (weekly)
     if app is not None:
         try:

--- a/backend/config.py
+++ b/backend/config.py
@@ -169,6 +169,9 @@ class Settings(BaseSettings):
     wanted_search_on_startup: bool = False
     wanted_search_max_items_per_run: int = 50
 
+    # Upgrade Scheduler
+    upgrade_scan_interval_hours: int = 0  # 0 = disabled; user must opt in
+
     # Wanted Adaptive Backoff
     wanted_adaptive_backoff_enabled: bool = True
     wanted_backoff_base_hours: float = 1.0

--- a/backend/routes/system.py
+++ b/backend/routes/system.py
@@ -2009,6 +2009,28 @@ def list_tasks():
     except Exception as exc:
         logger.warning("Failed to read cleanup scheduler state: %s", exc)
 
+    # Upgrade Scheduler
+    try:
+        from upgrade_scheduler import get_upgrade_scheduler
+
+        us = get_upgrade_scheduler()
+        upgrade_interval = getattr(s, "upgrade_scan_interval_hours", 0)
+        upgrade_enabled = us is not None and us._running
+        tasks.append(
+            {
+                "name": "upgrade_scan",
+                "display_name": "Subtitle Upgrade Scan",
+                "running": us.is_executing if us else False,
+                "last_run": us.last_run_at if us else None,
+                "next_run": us.next_run_at if us else None,
+                "interval_hours": upgrade_interval if upgrade_enabled else None,
+                "enabled": upgrade_enabled,
+                "cancellable": False,
+            }
+        )
+    except Exception as exc:
+        logger.warning("Failed to read upgrade scheduler state: %s", exc)
+
     # AniDB Sync
     try:
         from anidb_sync import DEFAULT_INTERVAL_HOURS as ANIDB_INTERVAL
@@ -2127,6 +2149,39 @@ def trigger_cleanup():
     def _run():
         with app.app_context():
             cs._execute_cleanup()
+
+    threading.Thread(target=_run, daemon=True).start()
+    return jsonify({"status": "started"})
+
+
+@bp.route("/tasks/upgrade-scan/trigger", methods=["POST"])
+def trigger_upgrade_scan():
+    """Manually trigger the subtitle upgrade scan.
+    ---
+    post:
+      tags:
+        - System
+      summary: Trigger upgrade scan
+      responses:
+        200:
+          description: Scan started
+        409:
+          description: Scan already running
+        503:
+          description: Upgrade scheduler not initialized
+    """
+    import threading
+
+    from upgrade_scheduler import get_upgrade_scheduler
+
+    us = get_upgrade_scheduler()
+    if not us:
+        return jsonify({"error": "Upgrade scheduler not initialized"}), 503
+    if us.is_executing:
+        return jsonify({"error": "Upgrade scan already running"}), 409
+
+    def _run():
+        us._execute_scan()
 
     threading.Thread(target=_run, daemon=True).start()
     return jsonify({"status": "started"})

--- a/backend/tests/test_upgrade_scheduler.py
+++ b/backend/tests/test_upgrade_scheduler.py
@@ -1,0 +1,247 @@
+"""Upgrade scheduler tests.
+
+Tests:
+- TestUpgradeSchedulerDisabled: scheduler disabled when interval=0
+- TestUpgradeSchedulerScanLogic: _execute_scan filters and re-queues correctly
+"""
+
+import os
+import sys
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from upgrade_scheduler import UPGRADE_SCORE_THRESHOLD, UpgradeScheduler
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _make_download(
+    file_path="/media/ep1.mkv",
+    score=300,
+    fmt="srt",
+    downloaded_at=None,
+):
+    dl = MagicMock()
+    dl.file_path = file_path
+    dl.score = score
+    dl.format = fmt
+    dl.downloaded_at = downloaded_at or (datetime.now(UTC) - timedelta(days=14)).isoformat()
+    return dl
+
+
+def _make_settings(interval=24, window_days=7):
+    s = MagicMock()
+    s.upgrade_scan_interval_hours = interval
+    s.upgrade_window_days = window_days
+    return s
+
+
+# ── TestUpgradeSchedulerDisabled ──────────────────────────────────────────────
+
+
+class TestUpgradeSchedulerDisabled:
+    def test_start_does_not_run_when_interval_zero(self):
+        mock_app = MagicMock()
+        scheduler = UpgradeScheduler(mock_app)
+
+        with patch("upgrade_scheduler.UpgradeScheduler._get_interval_hours", return_value=0):
+            scheduler.start()
+
+        assert not scheduler._running
+        assert scheduler._timer is None
+
+    def test_start_runs_when_interval_positive(self):
+        mock_app = MagicMock()
+        scheduler = UpgradeScheduler(mock_app)
+
+        with patch("upgrade_scheduler.UpgradeScheduler._get_interval_hours", return_value=12):
+            scheduler.start()
+
+        assert scheduler._running
+        assert scheduler._timer is not None
+        scheduler.stop()
+
+    def test_get_interval_reads_from_settings(self):
+        mock_app = MagicMock()
+        scheduler = UpgradeScheduler(mock_app)
+        mock_settings = MagicMock()
+        mock_settings.upgrade_scan_interval_hours = 48
+
+        with patch("config.get_settings", return_value=mock_settings):
+            result = scheduler._get_interval_hours()
+
+        assert result == 48
+
+    def test_get_interval_returns_default_on_error(self):
+        from upgrade_scheduler import DEFAULT_INTERVAL_HOURS
+
+        mock_app = MagicMock()
+        scheduler = UpgradeScheduler(mock_app)
+
+        with patch("config.get_settings", side_effect=RuntimeError("no settings")):
+            result = scheduler._get_interval_hours()
+
+        assert result == DEFAULT_INTERVAL_HOURS
+
+
+# ── TestUpgradeSchedulerScanLogic ─────────────────────────────────────────────
+
+
+class TestUpgradeSchedulerScanLogic:
+    def _run_scan(self, downloads, wanted_item, settings=None):
+        """Helper: run _execute_scan with mocked DB and return result dict."""
+        mock_app = MagicMock()
+        scheduler = UpgradeScheduler(mock_app)
+
+        if settings is None:
+            settings = _make_settings()
+
+        mock_db = MagicMock()
+        mock_db.execute.return_value.scalars.return_value.all.return_value = downloads
+
+        mock_wanted_repo = MagicMock()
+        mock_wanted_repo.get_wanted_by_file_path.return_value = wanted_item
+
+        with (
+            patch("config.get_settings", return_value=settings),
+            patch("db.get_db") as mock_db_ctx,
+            patch("db.repositories.wanted.WantedRepository", return_value=mock_wanted_repo),
+        ):
+            mock_db_ctx.return_value.__enter__ = MagicMock(return_value=mock_db)
+            mock_db_ctx.return_value.__exit__ = MagicMock(return_value=False)
+
+            result = scheduler._execute_scan()
+
+        return result, mock_db
+
+    def test_low_score_srt_queued(self):
+        dl = _make_download(score=200, fmt="srt")
+        item = {"id": 1, "status": "completed", "last_search_at": None}
+
+        result, mock_db = self._run_scan([dl], item)
+
+        assert result["queued"] == 1
+        assert result["skipped"] == 0
+
+    def test_high_score_ass_skipped(self):
+        dl = _make_download(score=700, fmt="ass")
+        item = {"id": 1, "status": "completed", "last_search_at": None}
+
+        result, _ = self._run_scan([dl], item)
+
+        assert result["queued"] == 0
+        assert result["skipped"] == 1
+
+    def test_low_score_ass_queued(self):
+        # ASS with low score should still be queued (score criteria applies)
+        dl = _make_download(score=200, fmt="ass")
+        item = {"id": 1, "status": "completed", "last_search_at": None}
+
+        result, _ = self._run_scan([dl], item)
+
+        assert result["queued"] == 1
+
+    def test_high_score_srt_queued(self):
+        # SRT with high score: format is not ASS → queue for potential format upgrade
+        dl = _make_download(score=700, fmt="srt")
+        item = {"id": 1, "status": "completed", "last_search_at": None}
+
+        result, _ = self._run_scan([dl], item)
+
+        assert result["queued"] == 1
+
+    def test_no_wanted_item_skipped(self):
+        dl = _make_download(score=200, fmt="srt")
+
+        result, _ = self._run_scan([dl], None)
+
+        assert result["queued"] == 0
+        assert result["skipped"] == 1
+
+    def test_already_wanted_status_skipped(self):
+        dl = _make_download(score=200, fmt="srt")
+        item = {"id": 1, "status": "wanted", "last_search_at": None}
+
+        result, _ = self._run_scan([dl], item)
+
+        assert result["skipped"] == 1
+
+    def test_already_searching_status_skipped(self):
+        dl = _make_download(score=200, fmt="srt")
+        item = {"id": 1, "status": "searching", "last_search_at": None}
+
+        result, _ = self._run_scan([dl], item)
+
+        assert result["skipped"] == 1
+
+    def test_searched_recently_skipped(self):
+        dl = _make_download(score=200, fmt="srt")
+        recent_search = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+        item = {"id": 1, "status": "completed", "last_search_at": recent_search}
+
+        result, _ = self._run_scan([dl], item)
+
+        assert result["skipped"] == 1
+
+    def test_searched_long_ago_queued(self):
+        dl = _make_download(score=200, fmt="srt")
+        old_search = (datetime.now(UTC) - timedelta(hours=48)).isoformat()
+        item = {"id": 1, "status": "completed", "last_search_at": old_search}
+
+        result, _ = self._run_scan([dl], item)
+
+        assert result["queued"] == 1
+
+    def test_last_run_at_updated_after_scan(self):
+        mock_app = MagicMock()
+        scheduler = UpgradeScheduler(mock_app)
+        assert scheduler.last_run_at is None
+
+        mock_db = MagicMock()
+        mock_db.execute.return_value.scalars.return_value.all.return_value = []
+
+        with (
+            patch("config.get_settings", return_value=_make_settings()),
+            patch("db.get_db") as mock_db_ctx,
+            patch("db.repositories.wanted.WantedRepository"),
+        ):
+            mock_db_ctx.return_value.__enter__ = MagicMock(return_value=mock_db)
+            mock_db_ctx.return_value.__exit__ = MagicMock(return_value=False)
+            scheduler._execute_scan()
+
+        assert scheduler.last_run_at is not None
+
+    def test_executing_flag_cleared_after_scan(self):
+        mock_app = MagicMock()
+        scheduler = UpgradeScheduler(mock_app)
+
+        mock_db = MagicMock()
+        mock_db.execute.return_value.scalars.return_value.all.return_value = []
+
+        with (
+            patch("config.get_settings", return_value=_make_settings()),
+            patch("db.get_db") as mock_db_ctx,
+            patch("db.repositories.wanted.WantedRepository"),
+        ):
+            mock_db_ctx.return_value.__enter__ = MagicMock(return_value=mock_db)
+            mock_db_ctx.return_value.__exit__ = MagicMock(return_value=False)
+            scheduler._execute_scan()
+
+        assert not scheduler.is_executing
+
+    def test_upgrade_score_threshold_constant(self):
+        assert UPGRADE_SCORE_THRESHOLD == 500
+
+    def test_ssa_format_treated_as_ass(self):
+        # SSA (variant of ASS) should not trigger format-based upgrade for high-score subs
+        dl = _make_download(score=700, fmt="ssa")
+        item = {"id": 1, "status": "completed", "last_search_at": None}
+
+        result, _ = self._run_scan([dl], item)
+
+        # High score + SSA/ASS → skipped (not an upgrade candidate)
+        assert result["skipped"] == 1

--- a/backend/upgrade_scheduler.py
+++ b/backend/upgrade_scheduler.py
@@ -1,0 +1,255 @@
+"""Subtitle upgrade scheduler.
+
+Periodically scans subtitle_downloads for entries that are eligible for a
+quality upgrade check and re-queues the corresponding wanted items.
+
+Upgrade eligibility criteria:
+- The subtitle was downloaded more than `upgrade_window_days` ago
+  (so the "fresh download 2× delta" protection has expired)
+- The download score is below `upgrade_score_threshold` (default 500)
+  OR the format is not ASS (SRT subs are always worth re-checking)
+- The wanted_item has not been searched within the last scan interval
+
+When eligible, the wanted_item is reset to status="wanted" with
+upgrade_candidate=1 and current_score set. The existing
+process_wanted_item() flow handles the actual provider search + comparison.
+
+Follows the threading.Timer + singleton pattern of cleanup_scheduler.py.
+"""
+
+import logging
+import threading
+from datetime import UTC, datetime, timedelta
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_INTERVAL_HOURS = 0  # Disabled by default; user must opt in
+
+#: Subtitles with a score below this value are candidates regardless of format.
+UPGRADE_SCORE_THRESHOLD = 500
+
+_scheduler = None
+_scheduler_lock = threading.Lock()
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def get_upgrade_scheduler():
+    """Return the current UpgradeScheduler singleton, or None if not started."""
+    return _scheduler
+
+
+def start_upgrade_scheduler(app):
+    """Start the upgrade scheduler if not already running."""
+    global _scheduler
+    with _scheduler_lock:
+        if _scheduler is not None:
+            return
+        _scheduler = UpgradeScheduler(app)
+        _scheduler.start()
+
+
+def stop_upgrade_scheduler():
+    """Stop the upgrade scheduler."""
+    global _scheduler
+    with _scheduler_lock:
+        if _scheduler:
+            _scheduler.stop()
+            _scheduler = None
+
+
+# ---------------------------------------------------------------------------
+# Scheduler class
+# ---------------------------------------------------------------------------
+
+
+class UpgradeScheduler:
+    """Periodic subtitle upgrade candidate scanner."""
+
+    def __init__(self, app):
+        self._app = app
+        self._timer = None
+        self._running = False
+        self._executing = False
+        self._last_run_at = None
+        self._interval_hours = DEFAULT_INTERVAL_HOURS
+
+    @property
+    def is_executing(self) -> bool:
+        return self._executing
+
+    @property
+    def last_run_at(self):
+        return self._last_run_at
+
+    @property
+    def next_run_at(self):
+        if not self._last_run_at or not self._interval_hours:
+            return None
+        try:
+            last_dt = datetime.fromisoformat(self._last_run_at)
+            return (last_dt + timedelta(hours=self._interval_hours)).isoformat()
+        except Exception:
+            return None
+
+    def start(self):
+        interval = self._get_interval_hours()
+        if interval <= 0:
+            logger.info("Upgrade scheduler disabled (interval=0)")
+            return
+        self._running = True
+        self._interval_hours = interval
+        self._schedule_next(interval)
+        logger.info("Upgrade scheduler started (every %dh)", interval)
+
+    def stop(self):
+        self._running = False
+        if self._timer:
+            self._timer.cancel()
+            self._timer = None
+        logger.info("Upgrade scheduler stopped")
+
+    def run_now(self) -> dict:
+        """Run an upgrade scan immediately (bypasses timer, thread-safe)."""
+        with self._app.app_context():
+            return self._execute_scan()
+
+    # ------------------------------------------------------------------ private
+
+    def _get_interval_hours(self) -> int:
+        try:
+            from config import get_settings
+
+            return get_settings().upgrade_scan_interval_hours
+        except Exception as e:
+            logger.debug("Could not read upgrade scan interval: %s", e)
+        return DEFAULT_INTERVAL_HOURS
+
+    def _schedule_next(self, interval_hours: int):
+        if not self._running:
+            return
+        self._timer = threading.Timer(
+            interval_hours * 3600,
+            self._run_scheduled,
+            args=(interval_hours,),
+        )
+        self._timer.daemon = True
+        self._timer.start()
+
+    def _run_scheduled(self, interval_hours: int):
+        logger.info("Scheduled upgrade scan starting")
+        with self._app.app_context():
+            try:
+                result = self._execute_scan()
+                logger.info(
+                    "Upgrade scan complete: %d queued, %d skipped",
+                    result["queued"],
+                    result["skipped"],
+                )
+            except Exception as e:
+                logger.error("Scheduled upgrade scan failed: %s", e)
+
+        new_interval = self._get_interval_hours()
+        self._interval_hours = new_interval
+        if new_interval > 0:
+            self._schedule_next(new_interval)
+        else:
+            logger.info("Upgrade scheduler disabled after run (interval=0)")
+            self._running = False
+
+    def _execute_scan(self) -> dict:
+        """Core scan logic: find eligible downloads and re-queue wanted items."""
+        from sqlalchemy import select
+        from sqlalchemy import update as sa_update
+
+        from config import get_settings
+        from db import get_db
+        from db.models.core import WantedItem
+        from db.models.providers import SubtitleDownload
+        from db.repositories.wanted import WantedRepository
+
+        self._executing = True
+        queued = 0
+        skipped = 0
+
+        try:
+            settings = get_settings()
+            window_days = settings.upgrade_window_days
+            interval_h = settings.upgrade_scan_interval_hours
+
+            # Only consider downloads old enough that the 2× delta protection has expired
+            cutoff_download = datetime.now(UTC) - timedelta(days=window_days)
+
+            # Don't re-queue items that were already searched recently
+            cutoff_search = datetime.now(UTC) - timedelta(hours=max(interval_h, 24))
+
+            with get_db() as db:
+                wanted_repo = WantedRepository(db)
+
+                # Find subtitle_downloads older than window_days
+                stmt = select(SubtitleDownload).where(
+                    SubtitleDownload.downloaded_at < cutoff_download.isoformat()
+                )
+                downloads = db.execute(stmt).scalars().all()
+
+                for dl in downloads:
+                    # Only consider low-score downloads or non-ASS formats
+                    is_low_score = (dl.score or 0) < UPGRADE_SCORE_THRESHOLD
+                    is_not_ass = (dl.format or "").lower() not in ("ass", "ssa")
+                    if not (is_low_score or is_not_ass):
+                        skipped += 1
+                        continue
+
+                    # Find corresponding wanted item by file_path
+                    item = wanted_repo.get_wanted_by_file_path(dl.file_path)
+                    if not item:
+                        skipped += 1
+                        continue
+
+                    # Skip if already in "wanted" / "searching" state
+                    if item.get("status") in ("wanted", "searching"):
+                        skipped += 1
+                        continue
+
+                    # Skip if searched too recently
+                    last_search = item.get("last_search_at")
+                    if last_search:
+                        try:
+                            last_dt = datetime.fromisoformat(last_search)
+                            if last_dt.tzinfo is None:
+                                last_dt = last_dt.replace(tzinfo=UTC)
+                            if last_dt > cutoff_search:
+                                skipped += 1
+                                continue
+                        except Exception:
+                            pass
+
+                    # Re-queue as upgrade candidate
+                    db.execute(
+                        sa_update(WantedItem)
+                        .where(WantedItem.id == item["id"])
+                        .values(
+                            status="wanted",
+                            upgrade_candidate=1,
+                            current_score=dl.score or 0,
+                            updated_at=datetime.now(UTC).isoformat(),
+                        )
+                    )
+                    db.commit()
+                    logger.debug(
+                        "Upgrade candidate queued: wanted_id=%d file=%s score=%d format=%s",
+                        item["id"],
+                        dl.file_path,
+                        dl.score or 0,
+                        dl.format or "?",
+                    )
+                    queued += 1
+
+        finally:
+            self._executing = False
+            self._last_run_at = datetime.now(UTC).isoformat()
+
+        return {"queued": queued, "skipped": skipped}

--- a/frontend/src/pages/Settings/index.tsx
+++ b/frontend/src/pages/Settings/index.tsx
@@ -134,6 +134,8 @@ const FIELDS: FieldConfig[] = [
   { key: 'upgrade_window_days', label: 'Upgrade Window (days)', type: 'number', placeholder: '7', tab: 'Automation',
     description: 'Upgrade-Versuche nur innerhalb dieses Zeitfensters nach dem Release.',
     advanced: true },
+  { key: 'upgrade_scan_interval_hours', label: 'Upgrade Scan Interval (hours, 0=disabled)', type: 'number', placeholder: '0', tab: 'Automation',
+    description: 'Wie oft der Upgrade-Scanner nach Kandidaten sucht. 0 = deaktiviert.' },
   // Automation — Webhook
   { key: 'webhook_delay_minutes', label: 'Webhook Delay (minutes)', type: 'number', placeholder: '5', tab: 'Automation',
     description: 'Wartezeit nach Sonarr/Radarr-Webhook bevor die Suche startet.',
@@ -1091,7 +1093,12 @@ function SettingsPageInner() {
               </SettingsCard>
               <SettingsCard title="Upgrade-Einstellungen"
                 description="Automatisches Upgrade auf bessere Untertitel">
-                {['upgrade_enabled','upgrade_prefer_ass','upgrade_min_score_delta','upgrade_window_days','webhook_delay_minutes']
+                {['upgrade_enabled','upgrade_prefer_ass','upgrade_min_score_delta','upgrade_window_days']
+                  .map(k => FIELDS.find(f => f.key === k)!).filter(Boolean).map(renderField)}
+              </SettingsCard>
+              <SettingsCard title="Upgrade-Scanner"
+                description="Periodischer Scan auf Upgrade-Kandidaten (niedrige Scores oder SRT-Subs)">
+                {['upgrade_scan_interval_hours']
                   .map(k => FIELDS.find(f => f.key === k)!).filter(Boolean).map(renderField)}
               </SettingsCard>
               <SettingsCard title="Suchplanung"


### PR DESCRIPTION
## Summary
- Periodic background scanner (`upgrade_scheduler.py`) that re-queues subtitle downloads as upgrade candidates based on quality criteria
- Upgrade eligibility: downloaded more than `upgrade_window_days` ago AND (score < 500 OR format is not ASS/SSA)
- Configurable scan interval via `upgrade_scan_interval_hours` (default: 0 = disabled, user must opt in)
- Reuses existing `process_wanted_item()` upgrade flow — no new provider logic needed

## Changes
- `upgrade_scheduler.py`: `UpgradeScheduler` singleton with `threading.Timer` (same pattern as `cleanup_scheduler.py`)
- `config.py`: `upgrade_scan_interval_hours: int = 0`
- `app.py`: scheduler registered at startup after cleanup scheduler
- `routes/system.py`: task list entry + `POST /tasks/upgrade-scan/trigger` manual trigger endpoint
- `frontend/src/pages/Settings/index.tsx`: "Upgrade-Scanner" card in Automation tab
- `tests/test_upgrade_scheduler.py`: 17 unit tests

## Test plan
- [x] 17 unit tests pass (`python -m pytest tests/test_upgrade_scheduler.py -q`)
- [x] ruff check + ruff format pass
- [x] Manual: scheduler starts/stops correctly, `_execute_scan()` re-queues eligible items
- [x] Frontend: settings card renders, interval field saves