### PR TITLE
feat: HI and forced subtitle preference scoring

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -153,6 +153,10 @@ class Settings(BaseSettings):
 
     # Hearing Impaired
     hi_removal_enabled: bool = False
+    hi_preference: str = "include"  # include | prefer | exclude | only
+
+    # Forced Subtitles
+    forced_preference: str = "include"  # include | prefer | exclude | only
 
     # Webhook Automation
     webhook_delay_minutes: int = 5  # Wait time after Sonarr/Radarr webhook

--- a/backend/providers/base.py
+++ b/backend/providers/base.py
@@ -293,22 +293,24 @@ def compute_score(result: SubtitleResult, query: VideoQuery) -> int:
 
     # HI preference modifier
     from config import get_settings  # local import to avoid circular deps
+
     settings = get_settings()
     hi_pref = getattr(settings, "hi_preference", "include")
     if hi_pref == "prefer" and result.hearing_impaired:
         score += 30
-    elif hi_pref == "exclude" and result.hearing_impaired:
-        score -= 999
-    elif hi_pref == "only" and not result.hearing_impaired:
+    elif (
+        hi_pref == "exclude"
+        and result.hearing_impaired
+        or hi_pref == "only"
+        and not result.hearing_impaired
+    ):
         score -= 999
 
     # Forced subtitle preference modifier
     forced_pref = getattr(settings, "forced_preference", "include")
     if forced_pref == "prefer" and result.forced:
         score += 30
-    elif forced_pref == "exclude" and result.forced:
-        score -= 999
-    elif forced_pref == "only" and not result.forced:
+    elif forced_pref == "exclude" and result.forced or forced_pref == "only" and not result.forced:
         score -= 999
 
     result.score = score

--- a/backend/providers/base.py
+++ b/backend/providers/base.py
@@ -291,6 +291,26 @@ def compute_score(result: SubtitleResult, query: VideoQuery) -> int:
     if result.provider_name == "opensubtitles" and result.uploader_trust > 0:
         score += int(result.uploader_trust)
 
+    # HI preference modifier
+    from config import get_settings  # local import to avoid circular deps
+    settings = get_settings()
+    hi_pref = getattr(settings, "hi_preference", "include")
+    if hi_pref == "prefer" and result.hearing_impaired:
+        score += 30
+    elif hi_pref == "exclude" and result.hearing_impaired:
+        score -= 999
+    elif hi_pref == "only" and not result.hearing_impaired:
+        score -= 999
+
+    # Forced subtitle preference modifier
+    forced_pref = getattr(settings, "forced_preference", "include")
+    if forced_pref == "prefer" and result.forced:
+        score += 30
+    elif forced_pref == "exclude" and result.forced:
+        score -= 999
+    elif forced_pref == "only" and not result.forced:
+        score -= 999
+
     result.score = score
     return score
 

--- a/backend/tests/test_hi_forced_scoring.py
+++ b/backend/tests/test_hi_forced_scoring.py
@@ -1,0 +1,157 @@
+"""Tests for HI and Forced subtitle preference scoring modifiers."""
+
+import os
+import pytest
+from unittest.mock import patch
+
+
+def _make_result(hearing_impaired=False, forced=False, provider="opensubtitles"):
+    from providers.base import SubtitleResult, SubtitleFormat
+    return SubtitleResult(
+        provider_name=provider,
+        subtitle_id="test-1",
+        language="de",
+        format=SubtitleFormat.SRT,
+        hearing_impaired=hearing_impaired,
+        forced=forced,
+        matches={"series", "season", "episode"},
+    )
+
+
+def _make_query(is_episode=True):
+    from providers.base import VideoQuery
+    return VideoQuery(
+        series_title="Test Show",
+        season=1,
+        episode=1,
+        languages=["de"],
+    )
+
+
+@pytest.fixture(autouse=True)
+def reset_settings(monkeypatch):
+    """Ensure clean settings state for each test."""
+    monkeypatch.setenv("SUBLARR_MEDIA_PATH", "/tmp/test_media")
+    from config import reload_settings
+    reload_settings()
+    yield
+    reload_settings()
+
+
+class TestHIPreferenceScoring:
+    def _score(self, hi_preference, hearing_impaired):
+        from providers.base import compute_score, invalidate_scoring_cache
+        from config import reload_settings
+        invalidate_scoring_cache()
+        reload_settings({"hi_preference": hi_preference})
+        result = _make_result(hearing_impaired=hearing_impaired)
+        query = _make_query()
+        return compute_score(result, query)
+
+    def test_include_hi_no_change(self):
+        """include: HI subtitle gets no bonus or penalty."""
+        score_hi = self._score("include", hearing_impaired=True)
+        score_non_hi = self._score("include", hearing_impaired=False)
+        assert score_hi == score_non_hi
+
+    def test_prefer_hi_gets_bonus(self):
+        """prefer: HI subtitle scores +30 over non-HI."""
+        score_hi = self._score("prefer", hearing_impaired=True)
+        score_non_hi = self._score("prefer", hearing_impaired=False)
+        assert score_hi == score_non_hi + 30
+
+    def test_prefer_non_hi_no_bonus(self):
+        """prefer: non-HI subtitle gets no bonus."""
+        score_include = self._score("include", hearing_impaired=False)
+        score_prefer = self._score("prefer", hearing_impaired=False)
+        assert score_prefer == score_include
+
+    def test_exclude_hi_gets_penalty(self):
+        """exclude: HI subtitle is heavily penalized."""
+        score_hi = self._score("exclude", hearing_impaired=True)
+        score_non_hi = self._score("exclude", hearing_impaired=False)
+        assert score_hi == score_non_hi - 999
+
+    def test_exclude_non_hi_no_penalty(self):
+        """exclude: non-HI subtitle is not penalized."""
+        score_include = self._score("include", hearing_impaired=False)
+        score_exclude = self._score("exclude", hearing_impaired=False)
+        assert score_exclude == score_include
+
+    def test_only_non_hi_gets_penalty(self):
+        """only: non-HI subtitle is heavily penalized."""
+        score_non_hi = self._score("only", hearing_impaired=False)
+        score_hi = self._score("only", hearing_impaired=True)
+        assert score_non_hi == score_hi - 999
+
+    def test_only_hi_no_penalty(self):
+        """only: HI subtitle is not penalized."""
+        score_include = self._score("include", hearing_impaired=True)
+        score_only = self._score("only", hearing_impaired=True)
+        assert score_only == score_include
+
+    def test_unknown_preference_treated_as_include(self):
+        """Unknown preference value falls back to include (no modifier)."""
+        score_unknown = self._score("bogus", hearing_impaired=True)
+        score_include = self._score("include", hearing_impaired=True)
+        assert score_unknown == score_include
+
+
+class TestForcedPreferenceScoring:
+    def _score(self, forced_preference, forced):
+        from providers.base import compute_score, invalidate_scoring_cache
+        from config import reload_settings
+        invalidate_scoring_cache()
+        reload_settings({"forced_preference": forced_preference})
+        result = _make_result(forced=forced)
+        query = _make_query()
+        return compute_score(result, query)
+
+    def test_include_forced_no_change(self):
+        score_forced = self._score("include", forced=True)
+        score_normal = self._score("include", forced=False)
+        assert score_forced == score_normal
+
+    def test_prefer_forced_gets_bonus(self):
+        score_forced = self._score("prefer", forced=True)
+        score_normal = self._score("prefer", forced=False)
+        assert score_forced == score_normal + 30
+
+    def test_exclude_forced_gets_penalty(self):
+        score_forced = self._score("exclude", forced=True)
+        score_normal = self._score("exclude", forced=False)
+        assert score_forced == score_normal - 999
+
+    def test_only_non_forced_gets_penalty(self):
+        score_normal = self._score("only", forced=False)
+        score_forced = self._score("only", forced=True)
+        assert score_normal == score_forced - 999
+
+    def test_only_forced_no_penalty(self):
+        score_include = self._score("include", forced=True)
+        score_only = self._score("only", forced=True)
+        assert score_only == score_include
+
+
+class TestHIAndForcedCombined:
+    def test_both_prefer_additive(self):
+        """When both HI and forced are preferred and result matches both, bonuses stack."""
+        from providers.base import compute_score, invalidate_scoring_cache
+        from config import reload_settings
+        invalidate_scoring_cache()
+        reload_settings({"hi_preference": "prefer", "forced_preference": "prefer"})
+        result_both = _make_result(hearing_impaired=True, forced=True)
+        result_neither = _make_result(hearing_impaired=False, forced=False)
+        query = _make_query()
+        assert compute_score(result_both, query) == compute_score(result_neither, query) + 60
+
+    def test_exclude_hi_independent_of_forced(self):
+        """Excluding HI does not affect forced subtitle scoring."""
+        from providers.base import compute_score, invalidate_scoring_cache
+        from config import reload_settings
+        invalidate_scoring_cache()
+        reload_settings({"hi_preference": "exclude", "forced_preference": "include"})
+        result_forced_only = _make_result(hearing_impaired=False, forced=True)
+        result_neither = _make_result(hearing_impaired=False, forced=False)
+        query = _make_query()
+        assert compute_score(result_forced_only, query) == compute_score(result_neither, query)

--- a/backend/tests/test_hi_forced_scoring.py
+++ b/backend/tests/test_hi_forced_scoring.py
@@ -1,12 +1,14 @@
 """Tests for HI and Forced subtitle preference scoring modifiers."""
 
 import os
-import pytest
 from unittest.mock import patch
+
+import pytest
 
 
 def _make_result(hearing_impaired=False, forced=False, provider="opensubtitles"):
-    from providers.base import SubtitleResult, SubtitleFormat
+    from providers.base import SubtitleFormat, SubtitleResult
+
     return SubtitleResult(
         provider_name=provider,
         subtitle_id="test-1",
@@ -20,6 +22,7 @@ def _make_result(hearing_impaired=False, forced=False, provider="opensubtitles")
 
 def _make_query(is_episode=True):
     from providers.base import VideoQuery
+
     return VideoQuery(
         series_title="Test Show",
         season=1,
@@ -33,6 +36,7 @@ def reset_settings(monkeypatch):
     """Ensure clean settings state for each test."""
     monkeypatch.setenv("SUBLARR_MEDIA_PATH", "/tmp/test_media")
     from config import reload_settings
+
     reload_settings()
     yield
     reload_settings()
@@ -40,8 +44,9 @@ def reset_settings(monkeypatch):
 
 class TestHIPreferenceScoring:
     def _score(self, hi_preference, hearing_impaired):
-        from providers.base import compute_score, invalidate_scoring_cache
         from config import reload_settings
+        from providers.base import compute_score, invalidate_scoring_cache
+
         invalidate_scoring_cache()
         reload_settings({"hi_preference": hi_preference})
         result = _make_result(hearing_impaired=hearing_impaired)
@@ -99,8 +104,9 @@ class TestHIPreferenceScoring:
 
 class TestForcedPreferenceScoring:
     def _score(self, forced_preference, forced):
-        from providers.base import compute_score, invalidate_scoring_cache
         from config import reload_settings
+        from providers.base import compute_score, invalidate_scoring_cache
+
         invalidate_scoring_cache()
         reload_settings({"forced_preference": forced_preference})
         result = _make_result(forced=forced)
@@ -136,8 +142,9 @@ class TestForcedPreferenceScoring:
 class TestHIAndForcedCombined:
     def test_both_prefer_additive(self):
         """When both HI and forced are preferred and result matches both, bonuses stack."""
-        from providers.base import compute_score, invalidate_scoring_cache
         from config import reload_settings
+        from providers.base import compute_score, invalidate_scoring_cache
+
         invalidate_scoring_cache()
         reload_settings({"hi_preference": "prefer", "forced_preference": "prefer"})
         result_both = _make_result(hearing_impaired=True, forced=True)
@@ -147,8 +154,9 @@ class TestHIAndForcedCombined:
 
     def test_exclude_hi_independent_of_forced(self):
         """Excluding HI does not affect forced subtitle scoring."""
-        from providers.base import compute_score, invalidate_scoring_cache
         from config import reload_settings
+        from providers.base import compute_score, invalidate_scoring_cache
+
         invalidate_scoring_cache()
         reload_settings({"hi_preference": "exclude", "forced_preference": "include"})
         result_forced_only = _make_result(hearing_impaired=False, forced=True)

--- a/frontend/src/pages/Settings/index.tsx
+++ b/frontend/src/pages/Settings/index.tsx
@@ -81,8 +81,9 @@ const TABS = NAV_GROUPS.flatMap((g) => g.items)
 export interface FieldConfig {
   key: string
   label: string
-  type: 'text' | 'number' | 'password' | 'toggle' | 'language-select'
+  type: 'text' | 'number' | 'password' | 'toggle' | 'language-select' | 'select'
   placeholder?: string
+  options?: { value: string; label: string }[]
   tab: string
   description?: string
   advanced?: boolean
@@ -114,6 +115,22 @@ const FIELDS: FieldConfig[] = [
     advanced: true },
   { key: 'hi_removal_enabled', label: 'Remove Hearing Impaired Tags', type: 'toggle', tab: 'Translation',
     description: 'Entfernt [Geräuschbeschreibungen] und (Sprechertags) aus Untertiteln.' },
+  { key: 'hi_preference', label: 'Hearing Impaired Preference', type: 'select', tab: 'Translation',
+    description: 'Wie Untertitel mit HI-Tags bei der Provider-Suche behandelt werden.',
+    options: [
+      { value: 'include', label: 'Include (no preference)' },
+      { value: 'prefer', label: 'Prefer HI (+30 score)' },
+      { value: 'exclude', label: 'Exclude HI (−999 penalty)' },
+      { value: 'only', label: 'Only HI (non-HI excluded)' },
+    ] },
+  { key: 'forced_preference', label: 'Forced Subtitle Preference', type: 'select', tab: 'Translation',
+    description: 'Wie Forced-Untertitel (für Fremdsprachen-Szenen) bei der Provider-Suche behandelt werden.',
+    options: [
+      { value: 'include', label: 'Include (no preference)' },
+      { value: 'prefer', label: 'Prefer forced (+30 score)' },
+      { value: 'exclude', label: 'Exclude forced (−999 penalty)' },
+      { value: 'only', label: 'Only forced (non-forced excluded)' },
+    ] },
   // Automation — Provider Re-ranking
   { key: 'provider_reranking_enabled', label: 'Auto Re-ranking', type: 'toggle', tab: 'Automation',
     description: 'Provider-Score-Modifier automatisch aus Download-History berechnen. Gute Provider bekommen Bonus, schlechte Penalty.' },
@@ -693,6 +710,23 @@ function SettingsPageInner() {
             setValues((prev) => ({ ...prev, [field.key]: code, [nameKey]: name }))
           }}
         />
+      ) : field.type === 'select' ? (
+        <select
+          value={values[field.key] ?? field.options?.[0]?.value ?? ''}
+          onChange={(e) => setValues((v) => ({ ...v, [field.key]: e.target.value }))}
+          className="px-3 py-2 rounded-md text-sm focus:outline-none"
+          style={{
+            backgroundColor: 'var(--bg-primary)',
+            border: '1px solid var(--border)',
+            color: 'var(--text-primary)',
+            fontSize: '13px',
+            minWidth: '200px',
+          }}
+        >
+          {(field.options ?? []).map((opt) => (
+            <option key={opt.value} value={opt.value}>{opt.label}</option>
+          ))}
+        </select>
       ) : (
         <input
           type={field.type}


### PR DESCRIPTION
## Summary
- Add `hi_preference` config field (`include` / `prefer` / `exclude` / `only`) — controls score modifier for hearing-impaired subtitles during provider search
- Add `forced_preference` config field (same options) — controls score modifier for forced/signs subtitles
- Both apply in `compute_score()`: `prefer` → +30, `exclude` → −999 on match, `only` → −999 on non-match
- Extend Settings `FieldConfig` with `'select'` type + `options` array — renders a native `<select>` element
- Add `hi_preference` and `forced_preference` dropdowns to Settings → Translation tab
- 15 unit tests covering all four preference values for both fields, combined interactions, and unknown value fallback

## Test plan
- [x] Backend: `pytest tests/test_hi_forced_scoring.py` — 15/15 passed
- [x] Frontend: `tsc --noEmit` — no errors; `eslint` — no new errors
- [x] Manual: Settings → Translation tab shows both dropdowns, values persist after save