### PR TITLE
feat: TRaSH-compatible scoring presets

### DIFF
--- a/backend/routes/hooks.py
+++ b/backend/routes/hooks.py
@@ -1025,7 +1025,7 @@ def import_preset():
         400:
           description: Invalid preset data
     """
-    from db.scoring import set_scoring_weights, set_provider_modifier
+    from db.scoring import set_provider_modifier, set_scoring_weights
     from providers.base import invalidate_scoring_cache
     from scoring_presets import validate_preset
 

--- a/backend/routes/hooks.py
+++ b/backend/routes/hooks.py
@@ -944,3 +944,108 @@ def delete_modifier(provider_name):
     delete_provider_modifier(provider_name)
     invalidate_scoring_cache()
     return "", 204
+
+
+# ---- Scoring preset endpoints ------------------------------------------------
+
+
+@bp.route("/scoring/presets", methods=["GET"])
+def list_presets():
+    """Return metadata for all bundled scoring presets.
+    ---
+    get:
+      tags:
+        - Events
+      summary: List scoring presets
+      description: Returns name, description, and type of all bundled scoring presets.
+      responses:
+        200:
+          description: List of preset metadata
+    """
+    from scoring_presets import load_bundled_presets
+
+    return jsonify(load_bundled_presets())
+
+
+@bp.route("/scoring/presets/<name>", methods=["GET"])
+def get_preset(name: str):
+    """Return a single bundled preset by name.
+    ---
+    get:
+      tags:
+        - Events
+      summary: Get scoring preset
+      parameters:
+        - in: path
+          name: name
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Full preset data
+        404:
+          description: Preset not found
+    """
+    from scoring_presets import get_bundled_preset
+
+    preset = get_bundled_preset(name)
+    if preset is None:
+        return jsonify({"error": f"Preset '{name}' not found"}), 404
+    return jsonify(preset)
+
+
+@bp.route("/scoring/presets/import", methods=["POST"])
+def import_preset():
+    """Import a scoring preset (bundled or custom JSON) and apply it.
+
+    Accepts a preset JSON body. Writes weights and provider modifiers to DB.
+    ---
+    post:
+      tags:
+        - Events
+      summary: Import scoring preset
+      description: Applies a preset's scoring weights and provider modifiers. Partial presets are supported.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                weights:
+                  type: object
+                provider_modifiers:
+                  type: object
+      responses:
+        200:
+          description: Preset applied
+        400:
+          description: Invalid preset data
+    """
+    from db.scoring import set_scoring_weights, set_provider_modifier
+    from providers.base import invalidate_scoring_cache
+    from scoring_presets import validate_preset
+
+    data = request.get_json(silent=True)
+    if not data or not validate_preset(data):
+        return jsonify({"error": "Invalid preset data"}), 400
+
+    applied: dict = {"weights": {}, "provider_modifiers": {}}
+
+    weights = data.get("weights", {})
+    for score_type, w in weights.items():
+        if w:
+            set_scoring_weights(score_type, w)
+            applied["weights"][score_type] = w
+
+    modifiers = data.get("provider_modifiers", {})
+    for provider_name, modifier in modifiers.items():
+        set_provider_modifier(provider_name, int(modifier))
+        applied["provider_modifiers"][provider_name] = modifier
+
+    invalidate_scoring_cache()
+
+    return jsonify({"status": "ok", "preset": data.get("name", "custom"), "applied": applied})

--- a/backend/scoring_presets/__init__.py
+++ b/backend/scoring_presets/__init__.py
@@ -23,9 +23,18 @@ logger = logging.getLogger(__name__)
 _PRESETS_DIR = Path(__file__).parent
 
 _VALID_WEIGHT_KEYS = {
-    "hash", "series", "year", "season", "episode",
-    "release_group", "source", "audio_codec", "resolution",
-    "hearing_impaired", "title", "format_bonus",
+    "hash",
+    "series",
+    "year",
+    "season",
+    "episode",
+    "release_group",
+    "source",
+    "audio_codec",
+    "resolution",
+    "hearing_impaired",
+    "title",
+    "format_bonus",
 }
 
 
@@ -37,11 +46,13 @@ def load_bundled_presets() -> list[dict]:
             with open(path, encoding="utf-8") as f:
                 data = json.load(f)
             if validate_preset(data):
-                presets.append({
-                    "name": data["name"],
-                    "description": data.get("description", ""),
-                    "type": data.get("type", "both"),
-                })
+                presets.append(
+                    {
+                        "name": data["name"],
+                        "description": data.get("description", ""),
+                        "type": data.get("type", "both"),
+                    }
+                )
         except Exception as exc:
             logger.warning("Failed to load preset %s: %s", path.name, exc)
     return presets

--- a/backend/scoring_presets/__init__.py
+++ b/backend/scoring_presets/__init__.py
@@ -1,0 +1,88 @@
+"""Bundled scoring presets for TRaSH-compatible import.
+
+Presets define scoring weight overrides and optional provider modifiers.
+Schema:
+  {
+    "name": str,
+    "description": str,
+    "type": "episode" | "movie" | "both",
+    "weights": {
+      "episode"?: {weight_key: int, ...},
+      "movie"?: {weight_key: int, ...}
+    },
+    "provider_modifiers": {provider_name: int, ...}
+  }
+"""
+
+import json
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_PRESETS_DIR = Path(__file__).parent
+
+_VALID_WEIGHT_KEYS = {
+    "hash", "series", "year", "season", "episode",
+    "release_group", "source", "audio_codec", "resolution",
+    "hearing_impaired", "title", "format_bonus",
+}
+
+
+def load_bundled_presets() -> list[dict]:
+    """Load all bundled preset JSON files. Returns metadata only (no full weights)."""
+    presets = []
+    for path in sorted(_PRESETS_DIR.glob("*.json")):
+        try:
+            with open(path, encoding="utf-8") as f:
+                data = json.load(f)
+            if validate_preset(data):
+                presets.append({
+                    "name": data["name"],
+                    "description": data.get("description", ""),
+                    "type": data.get("type", "both"),
+                })
+        except Exception as exc:
+            logger.warning("Failed to load preset %s: %s", path.name, exc)
+    return presets
+
+
+def get_bundled_preset(name: str) -> dict | None:
+    """Get a full bundled preset by name. Returns None if not found."""
+    for path in _PRESETS_DIR.glob("*.json"):
+        try:
+            with open(path, encoding="utf-8") as f:
+                data = json.load(f)
+            if data.get("name") == name and validate_preset(data):
+                return data
+        except Exception:
+            continue
+    return None
+
+
+def validate_preset(data: dict) -> bool:
+    """Validate preset structure. Returns True if valid."""
+    if not isinstance(data, dict):
+        return False
+    if not data.get("name") or not isinstance(data["name"], str):
+        return False
+    weights = data.get("weights", {})
+    if not isinstance(weights, dict):
+        return False
+    for score_type, w in weights.items():
+        if score_type not in ("episode", "movie"):
+            return False
+        if not isinstance(w, dict):
+            return False
+        for key, val in w.items():
+            if key not in _VALID_WEIGHT_KEYS:
+                return False
+            if not isinstance(val, int):
+                return False
+    modifiers = data.get("provider_modifiers", {})
+    if not isinstance(modifiers, dict):
+        return False
+    for name, val in modifiers.items():
+        if not isinstance(name, str) or not isinstance(val, int):
+            return False
+    return True

--- a/backend/scoring_presets/anime.json
+++ b/backend/scoring_presets/anime.json
@@ -1,0 +1,21 @@
+{
+  "name": "Anime",
+  "description": "Optimised for anime: high series/episode match, strong ASS format preference, release group matters.",
+  "type": "episode",
+  "weights": {
+    "episode": {
+      "hash": 359,
+      "series": 180,
+      "year": 90,
+      "season": 30,
+      "episode": 30,
+      "release_group": 20,
+      "source": 5,
+      "audio_codec": 2,
+      "resolution": 2,
+      "hearing_impaired": 1,
+      "format_bonus": 80
+    }
+  },
+  "provider_modifiers": {}
+}

--- a/backend/scoring_presets/movies.json
+++ b/backend/scoring_presets/movies.json
@@ -1,0 +1,19 @@
+{
+  "name": "Movies",
+  "description": "Balanced for movies: hash match important, title/year weighted, format bonus moderate.",
+  "type": "movie",
+  "weights": {
+    "movie": {
+      "hash": 119,
+      "title": 60,
+      "year": 30,
+      "release_group": 15,
+      "source": 7,
+      "audio_codec": 3,
+      "resolution": 2,
+      "hearing_impaired": 1,
+      "format_bonus": 50
+    }
+  },
+  "provider_modifiers": {}
+}

--- a/backend/scoring_presets/tv.json
+++ b/backend/scoring_presets/tv.json
@@ -1,0 +1,32 @@
+{
+  "name": "TV",
+  "description": "Tuned for live-action TV: strong episode/season match, hash important, moderate release group.",
+  "type": "both",
+  "weights": {
+    "episode": {
+      "hash": 359,
+      "series": 180,
+      "year": 90,
+      "season": 30,
+      "episode": 30,
+      "release_group": 14,
+      "source": 7,
+      "audio_codec": 3,
+      "resolution": 2,
+      "hearing_impaired": 1,
+      "format_bonus": 50
+    },
+    "movie": {
+      "hash": 119,
+      "title": 60,
+      "year": 30,
+      "release_group": 13,
+      "source": 7,
+      "audio_codec": 3,
+      "resolution": 2,
+      "hearing_impaired": 1,
+      "format_bonus": 50
+    }
+  },
+  "provider_modifiers": {}
+}

--- a/backend/tests/test_scoring_presets.py
+++ b/backend/tests/test_scoring_presets.py
@@ -1,0 +1,167 @@
+"""Tests for scoring preset endpoints and validation."""
+
+import json
+import os
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def set_media_path(tmp_path, monkeypatch):
+    monkeypatch.setenv("SUBLARR_MEDIA_PATH", str(tmp_path))
+    from config import reload_settings
+    reload_settings()
+    yield
+    reload_settings()
+
+
+class TestPresetValidation:
+    def test_valid_episode_preset(self):
+        from scoring_presets import validate_preset
+        preset = {
+            "name": "Test",
+            "description": "Test preset",
+            "type": "episode",
+            "weights": {"episode": {"hash": 359, "series": 180}},
+            "provider_modifiers": {},
+        }
+        assert validate_preset(preset) is True
+
+    def test_valid_movie_preset(self):
+        from scoring_presets import validate_preset
+        preset = {
+            "name": "Movies",
+            "weights": {"movie": {"hash": 119, "title": 60}},
+            "provider_modifiers": {"opensubtitles": 10},
+        }
+        assert validate_preset(preset) is True
+
+    def test_valid_both_preset(self):
+        from scoring_presets import validate_preset
+        preset = {
+            "name": "Both",
+            "weights": {
+                "episode": {"hash": 359},
+                "movie": {"hash": 119},
+            },
+            "provider_modifiers": {},
+        }
+        assert validate_preset(preset) is True
+
+    def test_missing_name_invalid(self):
+        from scoring_presets import validate_preset
+        assert validate_preset({"weights": {}}) is False
+
+    def test_invalid_weight_key(self):
+        from scoring_presets import validate_preset
+        preset = {
+            "name": "Bad",
+            "weights": {"episode": {"nonexistent_key": 999}},
+            "provider_modifiers": {},
+        }
+        assert validate_preset(preset) is False
+
+    def test_invalid_score_type(self):
+        from scoring_presets import validate_preset
+        preset = {
+            "name": "Bad",
+            "weights": {"special": {"hash": 359}},
+            "provider_modifiers": {},
+        }
+        assert validate_preset(preset) is False
+
+    def test_empty_weights_valid(self):
+        from scoring_presets import validate_preset
+        assert validate_preset({"name": "Empty", "weights": {}, "provider_modifiers": {}}) is True
+
+    def test_not_dict_invalid(self):
+        from scoring_presets import validate_preset
+        assert validate_preset([]) is False
+        assert validate_preset("string") is False
+        assert validate_preset(None) is False
+
+
+class TestBundledPresets:
+    def test_load_bundled_presets_returns_list(self):
+        from scoring_presets import load_bundled_presets
+        presets = load_bundled_presets()
+        assert isinstance(presets, list)
+        assert len(presets) >= 3  # anime, movies, tv
+
+    def test_bundled_preset_names(self):
+        from scoring_presets import load_bundled_presets
+        names = {p["name"] for p in load_bundled_presets()}
+        assert "Anime" in names
+        assert "Movies" in names
+        assert "TV" in names
+
+    def test_get_bundled_preset_anime(self):
+        from scoring_presets import get_bundled_preset
+        preset = get_bundled_preset("Anime")
+        assert preset is not None
+        assert preset["name"] == "Anime"
+        assert "episode" in preset["weights"]
+
+    def test_get_bundled_preset_not_found(self):
+        from scoring_presets import get_bundled_preset
+        assert get_bundled_preset("DoesNotExist") is None
+
+
+class TestPresetEndpoints:
+    def test_list_presets(self, client):
+        resp = client.get("/api/v1/scoring/presets")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert isinstance(data, list)
+        names = [p["name"] for p in data]
+        assert "Anime" in names
+
+    def test_get_preset_by_name(self, client):
+        resp = client.get("/api/v1/scoring/presets/Anime")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["name"] == "Anime"
+        assert "weights" in data
+
+    def test_get_preset_not_found(self, client):
+        resp = client.get("/api/v1/scoring/presets/DoesNotExist")
+        assert resp.status_code == 404
+
+    def test_import_preset(self, client):
+        preset = {
+            "name": "TestImport",
+            "weights": {"episode": {"hash": 400, "series": 200}},
+            "provider_modifiers": {"opensubtitles": 15},
+        }
+        resp = client.post(
+            "/api/v1/scoring/presets/import",
+            json=preset,
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["status"] == "ok"
+        assert data["preset"] == "TestImport"
+
+    def test_import_invalid_preset(self, client):
+        resp = client.post(
+            "/api/v1/scoring/presets/import",
+            json={"bad": "data"},
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+
+    def test_import_preset_updates_weights(self, client):
+        """Import applies weights to the DB and invalidates cache."""
+        preset = {
+            "name": "CacheTest",
+            "weights": {"episode": {"hash": 500}},
+            "provider_modifiers": {},
+        }
+        resp = client.post("/api/v1/scoring/presets/import", json=preset)
+        assert resp.status_code == 200
+
+        # Verify weights are stored
+        weights_resp = client.get("/api/v1/scoring/weights")
+        assert weights_resp.status_code == 200
+        weights = weights_resp.get_json()
+        assert weights["episode"]["hash"] == 500

--- a/backend/tests/test_scoring_presets.py
+++ b/backend/tests/test_scoring_presets.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+
 import pytest
 
 
@@ -9,6 +10,7 @@ import pytest
 def set_media_path(tmp_path, monkeypatch):
     monkeypatch.setenv("SUBLARR_MEDIA_PATH", str(tmp_path))
     from config import reload_settings
+
     reload_settings()
     yield
     reload_settings()
@@ -17,6 +19,7 @@ def set_media_path(tmp_path, monkeypatch):
 class TestPresetValidation:
     def test_valid_episode_preset(self):
         from scoring_presets import validate_preset
+
         preset = {
             "name": "Test",
             "description": "Test preset",
@@ -28,6 +31,7 @@ class TestPresetValidation:
 
     def test_valid_movie_preset(self):
         from scoring_presets import validate_preset
+
         preset = {
             "name": "Movies",
             "weights": {"movie": {"hash": 119, "title": 60}},
@@ -37,6 +41,7 @@ class TestPresetValidation:
 
     def test_valid_both_preset(self):
         from scoring_presets import validate_preset
+
         preset = {
             "name": "Both",
             "weights": {
@@ -49,10 +54,12 @@ class TestPresetValidation:
 
     def test_missing_name_invalid(self):
         from scoring_presets import validate_preset
+
         assert validate_preset({"weights": {}}) is False
 
     def test_invalid_weight_key(self):
         from scoring_presets import validate_preset
+
         preset = {
             "name": "Bad",
             "weights": {"episode": {"nonexistent_key": 999}},
@@ -62,6 +69,7 @@ class TestPresetValidation:
 
     def test_invalid_score_type(self):
         from scoring_presets import validate_preset
+
         preset = {
             "name": "Bad",
             "weights": {"special": {"hash": 359}},
@@ -71,10 +79,12 @@ class TestPresetValidation:
 
     def test_empty_weights_valid(self):
         from scoring_presets import validate_preset
+
         assert validate_preset({"name": "Empty", "weights": {}, "provider_modifiers": {}}) is True
 
     def test_not_dict_invalid(self):
         from scoring_presets import validate_preset
+
         assert validate_preset([]) is False
         assert validate_preset("string") is False
         assert validate_preset(None) is False
@@ -83,12 +93,14 @@ class TestPresetValidation:
 class TestBundledPresets:
     def test_load_bundled_presets_returns_list(self):
         from scoring_presets import load_bundled_presets
+
         presets = load_bundled_presets()
         assert isinstance(presets, list)
         assert len(presets) >= 3  # anime, movies, tv
 
     def test_bundled_preset_names(self):
         from scoring_presets import load_bundled_presets
+
         names = {p["name"] for p in load_bundled_presets()}
         assert "Anime" in names
         assert "Movies" in names
@@ -96,6 +108,7 @@ class TestBundledPresets:
 
     def test_get_bundled_preset_anime(self):
         from scoring_presets import get_bundled_preset
+
         preset = get_bundled_preset("Anime")
         assert preset is not None
         assert preset["name"] == "Anime"
@@ -103,6 +116,7 @@ class TestBundledPresets:
 
     def test_get_bundled_preset_not_found(self):
         from scoring_presets import get_bundled_preset
+
         assert get_bundled_preset("DoesNotExist") is None
 
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -760,6 +760,9 @@ export const resetScoringWeights = () => api.delete('/scoring/weights')
 export const getProviderModifiers = () => api.get('/scoring/modifiers').then(r => r.data)
 export const updateProviderModifiers = (data: Record<string, number>) => api.put('/scoring/modifiers', data).then(r => r.data)
 export const deleteProviderModifier = (name: string) => api.delete(`/scoring/modifiers/${name}`)
+export const getScoringPresets = () => api.get('/scoring/presets').then(r => r.data)
+export const getScoringPreset = (name: string) => api.get(`/scoring/presets/${encodeURIComponent(name)}`).then(r => r.data)
+export const importScoringPreset = (data: Record<string, unknown>) => api.post('/scoring/presets/import', data).then(r => r.data)
 
 // ─── Statistics ──────────────────────────────────────────────────────────────
 

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -30,6 +30,7 @@ import {
   getHookLogs, clearHookLogs,
   getScoringWeights, updateScoringWeights, resetScoringWeights,
   getProviderModifiers, updateProviderModifiers,
+  getScoringPresets, getScoringPreset, importScoringPreset,
   getStatistics, exportStatistics,
   createFullBackup, listFullBackups, restoreFullBackup,
   getLogRotation, updateLogRotation,
@@ -1044,6 +1045,21 @@ export function useUpdateProviderModifiers() {
   return useMutation({
     mutationFn: updateProviderModifiers,
     onSuccess: () => { void qc.invalidateQueries({ queryKey: ['providerModifiers'] }) },
+  })
+}
+
+export function useScoringPresets() {
+  return useQuery({ queryKey: ['scoringPresets'], queryFn: getScoringPresets })
+}
+
+export function useImportScoringPreset() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: importScoringPreset,
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ['scoringWeights'] })
+      void qc.invalidateQueries({ queryKey: ['providerModifiers'] })
+    },
   })
 }
 

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -30,7 +30,7 @@ import {
   getHookLogs, clearHookLogs,
   getScoringWeights, updateScoringWeights, resetScoringWeights,
   getProviderModifiers, updateProviderModifiers,
-  getScoringPresets, getScoringPreset, importScoringPreset,
+  getScoringPresets, importScoringPreset,
   getStatistics, exportStatistics,
   createFullBackup, listFullBackups, restoreFullBackup,
   getLogRotation, updateLogRotation,

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -605,6 +605,20 @@ export interface ProviderModifiers {
   [provider_name: string]: number
 }
 
+export interface ScoringPresetMeta {
+  name: string
+  description: string
+  type: 'episode' | 'movie' | 'both'
+}
+
+export interface ScoringPreset extends ScoringPresetMeta {
+  weights: {
+    episode?: Record<string, number>
+    movie?: Record<string, number>
+  }
+  provider_modifiers: Record<string, number>
+}
+
 // ─── Subtitle Sidecar Management ─────────────────────────────────────────────
 
 export interface SidecarSubtitle {

--- a/frontend/src/pages/Settings/EventsTab.tsx
+++ b/frontend/src/pages/Settings/EventsTab.tsx
@@ -5,14 +5,15 @@ import {
   useHookLogs, useClearHookLogs,
   useScoringWeights, useUpdateScoringWeights, useResetScoringWeights,
   useProviderModifiers, useUpdateProviderModifiers,
+  useScoringPresets, useImportScoringPreset,
   useProviders,
   useConfig, useUpdateConfig,
 } from '@/hooks/useApi'
-import { Save, Loader2, TestTube, ChevronUp, ChevronDown, Trash2, Plus, Edit2, X, Check, Eye, EyeOff, CheckCircle, XCircle, RotateCcw } from 'lucide-react'
+import { Save, Loader2, TestTube, ChevronUp, ChevronDown, Trash2, Plus, Edit2, X, Check, Eye, EyeOff, CheckCircle, XCircle, RotateCcw, Download } from 'lucide-react'
 import { toast } from '@/components/shared/Toast'
 import { Toggle } from '@/components/shared/Toggle'
 import { SettingSection } from '@/components/shared/SettingSection'
-import type { EventCatalogItem, HookConfig, WebhookConfig, HookLog, ScoringWeights } from '@/lib/types'
+import type { EventCatalogItem, HookConfig, WebhookConfig, HookLog, ScoringWeights, ScoringPreset } from '@/lib/types'
 
 // ─── Events & Hooks Tab ──────────────────────────────────────────────────────
 
@@ -402,15 +403,20 @@ export function ScoringTab() {
   const { data: scoringData } = useScoringWeights()
   const { data: providers } = useProviders()
   const { data: modifiers } = useProviderModifiers()
+  const { data: presets } = useScoringPresets()
   const updateWeights = useUpdateScoringWeights()
   const resetWeights = useResetScoringWeights()
   const updateModifiers = useUpdateProviderModifiers()
+  const importPreset = useImportScoringPreset()
 
   const [episodeWeights, setEpisodeWeights] = useState<Record<string, number>>({})
   const [movieWeights, setMovieWeights] = useState<Record<string, number>>({})
   const [providerMods, setProviderMods] = useState<Record<string, number>>({})
   const [weightsInit, setWeightsInit] = useState(false)
   const [modsInit, setModsInit] = useState(false)
+  const [selectedPreset, setSelectedPreset] = useState('')
+  const [customPresetJson, setCustomPresetJson] = useState('')
+  const [showCustomImport, setShowCustomImport] = useState(false)
 
   const weights: ScoringWeights | undefined = scoringData
   const providerList = providers?.providers || []
@@ -463,6 +469,32 @@ export function ScoringTab() {
     })
   }
 
+  const handleApplyPreset = (preset: ScoringPreset) => {
+    if (!confirm(`Apply preset "${preset.name}"? This will overwrite the current scoring weights.`)) return
+    importPreset.mutate(preset as unknown as Record<string, unknown>, {
+      onSuccess: () => {
+        setWeightsInit(false)
+        setModsInit(false)
+        setSelectedPreset('')
+        toast(`Preset "${preset.name}" applied`)
+      },
+      onError: () => toast('Failed to apply preset', 'error'),
+    })
+  }
+
+  const handleImportCustom = () => {
+    let parsed: ScoringPreset
+    try {
+      parsed = JSON.parse(customPresetJson)
+    } catch {
+      toast('Invalid JSON', 'error')
+      return
+    }
+    handleApplyPreset(parsed)
+    setCustomPresetJson('')
+    setShowCustomImport(false)
+  }
+
   const formatWeightKey = (key: string) => {
     if (key === 'format_bonus') return 'ASS Format Bonus'
     if (key === 'hearing_impaired') return 'Hearing Impaired'
@@ -505,6 +537,72 @@ export function ScoringTab() {
 
   return (
     <div className="space-y-4">
+      {/* Scoring Presets */}
+      <SettingSection
+        title="Load Preset"
+        description="Apply a bundled scoring profile or import a custom JSON preset."
+      >
+        <div className="flex flex-wrap items-end gap-2">
+          <div className="flex-1 min-w-[160px]">
+            <select
+              value={selectedPreset}
+              onChange={(e) => setSelectedPreset(e.target.value)}
+              className="w-full px-3 py-2 rounded-md text-sm focus:outline-none"
+              style={{ backgroundColor: 'var(--bg-primary)', border: '1px solid var(--border)', color: 'var(--text-primary)', fontSize: '13px' }}
+            >
+              <option value="">Select preset…</option>
+              {(presets ?? []).map((p: { name: string; description: string }) => (
+                <option key={p.name} value={p.name}>{p.name} — {p.description}</option>
+              ))}
+            </select>
+          </div>
+          <button
+            disabled={!selectedPreset || importPreset.isPending}
+            onClick={() => {
+              const preset = (presets ?? []).find((p: { name: string }) => p.name === selectedPreset)
+              if (preset) {
+                import('@/api/client').then(({ getScoringPreset }) =>
+                  getScoringPreset(preset.name).then(handleApplyPreset)
+                )
+              }
+            }}
+            className="flex items-center gap-1 px-3 py-2 rounded text-xs font-medium text-white disabled:opacity-50"
+            style={{ backgroundColor: 'var(--accent)' }}
+          >
+            {importPreset.isPending ? <Loader2 size={12} className="animate-spin" /> : <Download size={12} />}
+            Apply
+          </button>
+          <button
+            onClick={() => setShowCustomImport((v) => !v)}
+            className="flex items-center gap-1 px-3 py-2 rounded text-xs font-medium"
+            style={{ border: '1px solid var(--border)', color: 'var(--text-muted)' }}
+          >
+            {showCustomImport ? <X size={12} /> : <Plus size={12} />}
+            Custom JSON
+          </button>
+        </div>
+        {showCustomImport && (
+          <div className="flex flex-col gap-2 mt-2">
+            <textarea
+              value={customPresetJson}
+              onChange={(e) => setCustomPresetJson(e.target.value)}
+              placeholder='{"name":"My Preset","weights":{"episode":{...},"movie":{...}},"provider_modifiers":{}}'
+              rows={5}
+              className="w-full px-3 py-2 rounded-md text-xs font-mono focus:outline-none"
+              style={{ backgroundColor: 'var(--bg-primary)', border: '1px solid var(--border)', color: 'var(--text-primary)', resize: 'vertical' }}
+            />
+            <button
+              onClick={handleImportCustom}
+              disabled={!customPresetJson.trim() || importPreset.isPending}
+              className="self-end flex items-center gap-1 px-3 py-1.5 rounded text-xs font-medium text-white disabled:opacity-50"
+              style={{ backgroundColor: 'var(--accent)' }}
+            >
+              <Download size={12} /> Import & Apply
+            </button>
+          </div>
+        )}
+      </SettingSection>
+
       {/* Scoring Weights */}
       <SettingSection
         title="Scoring Weights"


### PR DESCRIPTION
## Summary
- New \`scoring_presets/\` package: validator, loader, 3 bundled presets (Anime / Movies / TV)
- 3 new API endpoints: \`GET /scoring/presets\`, \`GET /scoring/presets/<name>\`, \`POST /scoring/presets/import\`
- Import applies weights + provider modifiers atomically, invalidates scoring cache
- Settings → Scoring tab: bundled preset dropdown + custom JSON import textarea
- Full TypeScript types, API client functions, and TanStack Query hooks

## Test plan
- [x] Backend: \`pytest tests/test_scoring_presets.py --no-cov\` — 18/18 passed
- [x] Frontend: \`tsc --noEmit\` — no errors
- [x] Manual: Scoring tab shows presets, applying Anime preset changes episode hash weight to 359 + format_bonus to 80