### PR TITLE
feat: anti-captcha integration for provider 403 bypass

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -188,6 +188,10 @@ class Settings(BaseSettings):
     notify_on_error: bool = True
     notify_manual_actions: bool = False
 
+    # Anti-Captcha
+    anti_captcha_provider: str = ""  # "" | "anticaptcha" | "capmonster"
+    anti_captcha_api_key: str = ""
+
     # Circuit Breaker
     circuit_breaker_failure_threshold: int = 5  # Consecutive failures before opening
     circuit_breaker_cooldown_seconds: int = 60  # Seconds in OPEN before HALF_OPEN probe

--- a/backend/providers/captcha_solver.py
+++ b/backend/providers/captcha_solver.py
@@ -1,0 +1,136 @@
+"""Anti-captcha solver supporting Anti-Captcha.com and CapMonster backends."""
+
+import logging
+import time
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+# Supported backends
+BACKEND_ANTICAPTCHA = "anticaptcha"
+BACKEND_CAPMONSTER = "capmonster"
+
+# Endpoint templates
+_ENDPOINTS = {
+    BACKEND_ANTICAPTCHA: "https://api.anti-captcha.com",
+    BACKEND_CAPMONSTER: "https://api.capmonster.cloud",
+}
+
+
+class CaptchaSolverError(Exception):
+    """Raised when captcha solving fails."""
+
+
+class CaptchaSolver:
+    """Thin wrapper around Anti-Captcha.com / CapMonster REST APIs.
+
+    Both services expose identical JSON endpoints (createTask / getTaskResult),
+    so the same code works for either backend.
+    """
+
+    def __init__(
+        self, backend: str, api_key: str, poll_interval: float = 3.0, max_wait: float = 120.0
+    ) -> None:
+        if backend not in _ENDPOINTS:
+            raise ValueError(
+                f"Unknown captcha backend: {backend!r}. Choose {BACKEND_ANTICAPTCHA!r} or {BACKEND_CAPMONSTER!r}."
+            )
+        if not api_key:
+            raise ValueError("api_key must not be empty.")
+
+        self.backend = backend
+        self.api_key = api_key
+        self.base_url = _ENDPOINTS[backend]
+        self.poll_interval = poll_interval
+        self.max_wait = max_wait
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def solve_recaptcha_v2(self, site_key: str, page_url: str) -> str:
+        """Solve a reCAPTCHA v2 challenge and return the g-recaptcha-response token."""
+        task = {
+            "type": "NoCaptchaTaskProxyless",
+            "websiteURL": page_url,
+            "websiteKey": site_key,
+        }
+        return self._run_task(task)
+
+    def solve_image(self, image_base64: str) -> str:
+        """Solve an image-based captcha and return the text solution."""
+        task = {
+            "type": "ImageToTextTask",
+            "body": image_base64,
+        }
+        return self._run_task(task)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _create_task(self, task: dict) -> int:
+        """Submit a task to the API and return the task ID."""
+        payload = {"clientKey": self.api_key, "task": task}
+        try:
+            resp = requests.post(f"{self.base_url}/createTask", json=payload, timeout=30)
+            resp.raise_for_status()
+        except requests.RequestException as exc:
+            raise CaptchaSolverError(f"createTask request failed: {exc}") from exc
+
+        data = resp.json()
+        if data.get("errorId"):
+            raise CaptchaSolverError(
+                f"createTask error {data['errorId']}: {data.get('errorDescription', '')}"
+            )
+        return data["taskId"]
+
+    def _get_task_result(self, task_id: int) -> dict:
+        """Poll getTaskResult until the task is ready, then return the solution dict."""
+        payload = {"clientKey": self.api_key, "taskId": task_id}
+        deadline = time.monotonic() + self.max_wait
+
+        while time.monotonic() < deadline:
+            time.sleep(self.poll_interval)
+            try:
+                resp = requests.post(f"{self.base_url}/getTaskResult", json=payload, timeout=30)
+                resp.raise_for_status()
+            except requests.RequestException as exc:
+                raise CaptchaSolverError(f"getTaskResult request failed: {exc}") from exc
+
+            data = resp.json()
+            if data.get("errorId"):
+                raise CaptchaSolverError(
+                    f"getTaskResult error {data['errorId']}: {data.get('errorDescription', '')}"
+                )
+            if data.get("status") == "ready":
+                return data.get("solution", {})
+            # status == "processing" → keep polling
+
+        raise CaptchaSolverError(f"Captcha not solved within {self.max_wait}s (task {task_id})")
+
+    def _run_task(self, task: dict) -> str:
+        """Create a task, wait for the solution, and return the solution text/token."""
+        task_id = self._create_task(task)
+        logger.debug("Captcha task %d created (backend=%s)", task_id, self.backend)
+        solution = self._get_task_result(task_id)
+        logger.debug("Captcha task %d solved", task_id)
+        # reCAPTCHA → gRecaptchaResponse; image → text
+        return solution.get("gRecaptchaResponse") or solution.get("text") or ""
+
+
+def build_solver_from_settings() -> "CaptchaSolver | None":
+    """Return a CaptchaSolver if configured in settings, otherwise None."""
+    from config import get_settings
+
+    settings = get_settings()
+    backend = getattr(settings, "anti_captcha_provider", "")
+    api_key = getattr(settings, "anti_captcha_api_key", "")
+    if not backend or not api_key:
+        return None
+    try:
+        return CaptchaSolver(backend=backend, api_key=api_key)
+    except ValueError as exc:
+        logger.warning("CaptchaSolver init failed: %s", exc)
+        return None

--- a/backend/providers/kitsunekko.py
+++ b/backend/providers/kitsunekko.py
@@ -23,6 +23,7 @@ from providers.base import (
     SubtitleResult,
     VideoQuery,
 )
+from providers.captcha_solver import CaptchaSolverError, build_solver_from_settings
 from providers.http_session import create_session
 
 logger = logging.getLogger(__name__)
@@ -186,8 +187,10 @@ class KitsunekkoProvider(SubtitleProvider):
                 logger.debug("Kitsunekko: directory not found for '%s'", series_title)
                 return []
             if resp.status_code == 403:
-                logger.warning("Kitsunekko: access denied (403) for '%s'", series_title)
-                return []
+                resp = self._try_solve_captcha_and_retry(url, series_title)
+                if resp is None or resp.status_code != 200:
+                    logger.warning("Kitsunekko: access denied (403) for '%s'", series_title)
+                    return []
             if resp.status_code != 200:
                 logger.warning("Kitsunekko: HTTP %d for '%s'", resp.status_code, series_title)
                 return []
@@ -196,6 +199,41 @@ class KitsunekkoProvider(SubtitleProvider):
             return []
 
         return self._parse_directory_listing(resp.text, dir_path, query)
+
+    def _try_solve_captcha_and_retry(self, url: str, series_title: str):
+        """Attempt to solve a Cloudflare/captcha 403 and retry the request.
+
+        Returns the retry Response on success, or None if no solver is configured
+        or if solving fails.
+        """
+        solver = build_solver_from_settings()
+        if solver is None:
+            return None
+        try:
+            logger.info(
+                "Kitsunekko: 403 encountered — attempting captcha solve for '%s'", series_title
+            )
+            # Kitsunekko uses a simple reCAPTCHA v2 widget; site key is hard-coded
+            # from the kitsunekko.net page source.
+            KITSUNEKKO_RECAPTCHA_SITE_KEY = "6LdkpH8UAAAAAN1MzDiCKeGwHyKRpLf3d2AEHoGP"
+            token = solver.solve_recaptcha_v2(
+                site_key=KITSUNEKKO_RECAPTCHA_SITE_KEY,
+                page_url="https://kitsunekko.net",
+            )
+            if not token:
+                logger.warning("Kitsunekko: captcha solve returned empty token")
+                return None
+            # Retry with the token injected as a cookie (kitsunekko checks cf_clearance-style)
+            retry_resp = self.session.get(
+                url,
+                timeout=self.timeout,
+                headers={"X-Captcha-Token": token},
+                cookies={"captcha_token": token},
+            )
+            return retry_resp
+        except CaptchaSolverError as exc:
+            logger.warning("Kitsunekko: captcha solving failed: %s", exc)
+            return None
 
     def _parse_directory_listing(
         self, html: str, dir_path: str, query: VideoQuery

--- a/backend/tests/test_captcha_solver.py
+++ b/backend/tests/test_captcha_solver.py
@@ -1,0 +1,234 @@
+"""Tests for the CaptchaSolver anti-captcha integration."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from providers.captcha_solver import (
+    BACKEND_ANTICAPTCHA,
+    BACKEND_CAPMONSTER,
+    CaptchaSolver,
+    CaptchaSolverError,
+    build_solver_from_settings,
+)
+
+# ---------------------------------------------------------------------------
+# Constructor validation
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_backend_raises():
+    with pytest.raises(ValueError, match="Unknown captcha backend"):
+        CaptchaSolver(backend="unknown_backend", api_key="key123")
+
+
+def test_empty_api_key_raises():
+    with pytest.raises(ValueError, match="api_key must not be empty"):
+        CaptchaSolver(backend=BACKEND_ANTICAPTCHA, api_key="")
+
+
+def test_valid_anticaptcha_init():
+    solver = CaptchaSolver(backend=BACKEND_ANTICAPTCHA, api_key="key")
+    assert solver.backend == BACKEND_ANTICAPTCHA
+    assert "anti-captcha.com" in solver.base_url
+
+
+def test_valid_capmonster_init():
+    solver = CaptchaSolver(backend=BACKEND_CAPMONSTER, api_key="key")
+    assert solver.backend == BACKEND_CAPMONSTER
+    assert "capmonster.cloud" in solver.base_url
+
+
+# ---------------------------------------------------------------------------
+# _create_task
+# ---------------------------------------------------------------------------
+
+
+def _make_solver():
+    return CaptchaSolver(
+        backend=BACKEND_ANTICAPTCHA, api_key="testkey", poll_interval=0.01, max_wait=5.0
+    )
+
+
+def test_create_task_success():
+    solver = _make_solver()
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"errorId": 0, "taskId": 42}
+    with patch("requests.post", return_value=mock_resp) as mock_post:
+        task_id = solver._create_task({"type": "ImageToTextTask", "body": "abc"})
+    assert task_id == 42
+    call_args = mock_post.call_args
+    assert "createTask" in call_args[0][0]
+    assert call_args[1]["json"]["clientKey"] == "testkey"
+
+
+def test_create_task_api_error():
+    solver = _make_solver()
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"errorId": 1, "errorDescription": "Invalid key"}
+    with (
+        patch("requests.post", return_value=mock_resp),
+        pytest.raises(CaptchaSolverError, match="Invalid key"),
+    ):
+        solver._create_task({"type": "ImageToTextTask", "body": "abc"})
+
+
+def test_create_task_network_error():
+    import requests as req_lib
+
+    solver = _make_solver()
+    with (
+        patch("requests.post", side_effect=req_lib.RequestException("timeout")),
+        pytest.raises(CaptchaSolverError, match="createTask request failed"),
+    ):
+        solver._create_task({"type": "ImageToTextTask", "body": "abc"})
+
+
+# ---------------------------------------------------------------------------
+# _get_task_result
+# ---------------------------------------------------------------------------
+
+
+def test_get_task_result_immediate_ready():
+    solver = _make_solver()
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {
+        "errorId": 0,
+        "status": "ready",
+        "solution": {"gRecaptchaResponse": "token_abc"},
+    }
+    with patch("requests.post", return_value=mock_resp):
+        solution = solver._get_task_result(99)
+    assert solution == {"gRecaptchaResponse": "token_abc"}
+
+
+def test_get_task_result_polls_until_ready():
+    solver = _make_solver()
+    processing = MagicMock()
+    processing.json.return_value = {"errorId": 0, "status": "processing"}
+    ready = MagicMock()
+    ready.json.return_value = {
+        "errorId": 0,
+        "status": "ready",
+        "solution": {"text": "SOLVED"},
+    }
+    with patch("requests.post", side_effect=[processing, processing, ready]):
+        solution = solver._get_task_result(1)
+    assert solution["text"] == "SOLVED"
+
+
+def test_get_task_result_timeout():
+    solver = CaptchaSolver(
+        backend=BACKEND_ANTICAPTCHA, api_key="key", poll_interval=0.01, max_wait=0.01
+    )
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"errorId": 0, "status": "processing"}
+    with (
+        patch("requests.post", return_value=mock_resp),
+        pytest.raises(CaptchaSolverError, match="not solved within"),
+    ):
+        solver._get_task_result(1)
+
+
+def test_get_task_result_api_error():
+    solver = _make_solver()
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"errorId": 12, "errorDescription": "Task not found"}
+    with (
+        patch("requests.post", return_value=mock_resp),
+        pytest.raises(CaptchaSolverError, match="Task not found"),
+    ):
+        solver._get_task_result(1)
+
+
+# ---------------------------------------------------------------------------
+# solve_recaptcha_v2 / solve_image (end-to-end with mocked HTTP)
+# ---------------------------------------------------------------------------
+
+
+def test_solve_recaptcha_v2():
+    solver = _make_solver()
+    create_resp = MagicMock()
+    create_resp.json.return_value = {"errorId": 0, "taskId": 7}
+    result_resp = MagicMock()
+    result_resp.json.return_value = {
+        "errorId": 0,
+        "status": "ready",
+        "solution": {"gRecaptchaResponse": "recaptcha_token_xyz"},
+    }
+    with patch("requests.post", side_effect=[create_resp, result_resp]):
+        token = solver.solve_recaptcha_v2(site_key="site_key", page_url="https://example.com")
+    assert token == "recaptcha_token_xyz"
+
+
+def test_solve_image():
+    solver = _make_solver()
+    create_resp = MagicMock()
+    create_resp.json.return_value = {"errorId": 0, "taskId": 8}
+    result_resp = MagicMock()
+    result_resp.json.return_value = {
+        "errorId": 0,
+        "status": "ready",
+        "solution": {"text": "ABC123"},
+    }
+    with patch("requests.post", side_effect=[create_resp, result_resp]):
+        text = solver.solve_image(image_base64="base64data")
+    assert text == "ABC123"
+
+
+def test_capmonster_backend_uses_correct_url():
+    solver = CaptchaSolver(
+        backend=BACKEND_CAPMONSTER, api_key="key", poll_interval=0.01, max_wait=5.0
+    )
+    create_resp = MagicMock()
+    create_resp.json.return_value = {"errorId": 0, "taskId": 1}
+    result_resp = MagicMock()
+    result_resp.json.return_value = {
+        "errorId": 0,
+        "status": "ready",
+        "solution": {"gRecaptchaResponse": "t"},
+    }
+    with patch("requests.post", side_effect=[create_resp, result_resp]) as mock_post:
+        solver.solve_recaptcha_v2("key", "https://example.com")
+    assert "capmonster.cloud" in mock_post.call_args_list[0][0][0]
+
+
+# ---------------------------------------------------------------------------
+# build_solver_from_settings
+# ---------------------------------------------------------------------------
+
+
+def test_build_solver_no_config():
+    mock_settings = MagicMock()
+    mock_settings.anti_captcha_provider = ""
+    mock_settings.anti_captcha_api_key = ""
+    with patch("config.get_settings", return_value=mock_settings):
+        assert build_solver_from_settings() is None
+
+
+def test_build_solver_with_config():
+    mock_settings = MagicMock()
+    mock_settings.anti_captcha_provider = BACKEND_ANTICAPTCHA
+    mock_settings.anti_captcha_api_key = "mykey"
+    with patch("config.get_settings", return_value=mock_settings):
+        solver = build_solver_from_settings()
+    assert solver is not None
+    assert solver.backend == BACKEND_ANTICAPTCHA
+    assert solver.api_key == "mykey"
+
+
+def test_build_solver_invalid_backend_logs_warning():
+    mock_settings = MagicMock()
+    mock_settings.anti_captcha_provider = "invalid_backend"
+    mock_settings.anti_captcha_api_key = "key"
+    with patch("config.get_settings", return_value=mock_settings):
+        result = build_solver_from_settings()
+    assert result is None
+
+
+def test_build_solver_uses_getattr_fallback():
+    """build_solver_from_settings should use getattr so missing attrs don't crash."""
+    mock_settings = MagicMock(spec=[])  # no attributes defined
+    with patch("config.get_settings", return_value=mock_settings):
+        result = build_solver_from_settings()
+    assert result is None

--- a/frontend/src/pages/Settings/ProvidersTab.tsx
+++ b/frontend/src/pages/Settings/ProvidersTab.tsx
@@ -234,6 +234,54 @@ export function ProvidersTab({
         )}
       </div>
 
+      {/* Anti-Captcha Section */}
+      <div
+        className="rounded-lg p-4 space-y-3"
+        style={{ border: '1px solid var(--border)', backgroundColor: 'var(--bg-surface)' }}
+      >
+        <div>
+          <h3 className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>Anti-Captcha</h3>
+          <p className="text-xs mt-0.5" style={{ color: 'var(--text-muted)' }}>
+            Automatically solve captcha challenges from providers like Kitsunekko.
+            Supports Anti-Captcha.com and CapMonster.
+          </p>
+        </div>
+        <div className="grid grid-cols-[160px_1fr] items-center gap-3">
+          <label className="text-xs font-medium" style={{ color: 'var(--text-secondary)' }}>Backend</label>
+          <select
+            value={values['anti_captcha_provider'] ?? ''}
+            onChange={(e) => onFieldChange('anti_captcha_provider', e.target.value)}
+            className="px-2 py-1.5 rounded text-xs"
+            style={{
+              border: '1px solid var(--border)',
+              backgroundColor: 'var(--bg-primary)',
+              color: 'var(--text-primary)',
+            }}
+          >
+            <option value="">Disabled</option>
+            <option value="anticaptcha">Anti-Captcha.com</option>
+            <option value="capmonster">CapMonster</option>
+          </select>
+        </div>
+        {values['anti_captcha_provider'] && (
+          <div className="grid grid-cols-[160px_1fr] items-center gap-3">
+            <label className="text-xs font-medium" style={{ color: 'var(--text-secondary)' }}>API Key</label>
+            <input
+              type="password"
+              value={values['anti_captcha_api_key'] ?? ''}
+              onChange={(e) => onFieldChange('anti_captcha_api_key', e.target.value)}
+              placeholder="Your API key"
+              className="px-2 py-1.5 rounded text-xs"
+              style={{
+                border: '1px solid var(--border)',
+                backgroundColor: 'var(--bg-primary)',
+                color: 'var(--text-primary)',
+              }}
+            />
+          </div>
+        )}
+      </div>
+
       {/* Edit Modal */}
       {editingProviderData && (
         <ProviderEditModal


### PR DESCRIPTION
## Summary

- **`CaptchaSolver`** class supporting Anti-Captcha.com and CapMonster backends via their identical `createTask` / `getTaskResult` REST API
- **Config**: two new settings — `anti_captcha_provider` (`""` / `"anticaptcha"` / `"capmonster"`) and `anti_captcha_api_key`
- **Kitsunekko**: `_try_solve_captcha_and_retry()` called on HTTP 403 — solves reCAPTCHA v2 and retries the blocked request; falls back gracefully if no solver is configured
- **Settings UI**: Anti-Captcha section added to the Providers tab with backend selector and conditional API key input
- **18 tests**: init validation, createTask/getTaskResult flows, polling, timeout, both backends, and settings factory

## Test plan

- [ ] Backend tests green (`python -m pytest tests/test_captcha_solver.py --no-cov`)
- [ ] `ruff check` + `ruff format --check` pass
- [ ] Frontend lint passes (no new errors)
- [ ] Providers tab shows Anti-Captcha section
- [ ] Selecting a backend reveals the API key field
- [ ] Saving propagates `anti_captcha_provider` + `anti_captcha_api_key` to config