### PR TITLE
feat: stream removal / safe remux with trash-folder backups and undo (#57)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -110,17 +110,17 @@ Goals: Close remaining gap to Bazarr in provider coverage, subtitle type handlin
 
 ---
 
-## v0.19.0 (Stream Removal — Safe Remux)
+## v0.19.0 (Stream Removal — Safe Remux) 🚧 In Progress
 
 Goals: Safely remove embedded subtitle streams from video files after extraction, with full rollback capability.
 
-- Remux Engine - mkvmerge (MKV) / ffmpeg (MP4) remux excluding selected subtitle streams, no re-encoding
-- Verification Pipeline - compare duration, video/audio stream count, and file size plausibility before swap
-- Atomic File Swap - write to temp file, rename original to `.bak`, rename temp to original name
-- Backup Retention - configurable `.bak` retention period (default 7 days), automatic cleanup scheduler
-- CoW/Reflink Detection - detect Btrfs/XFS and use `cp --reflink=auto` for zero-cost backups
-- *arr Pause Integration - pause Sonarr/Radarr folder monitoring via API during remux to prevent import loops
-- Track Panel UI - "Remove from container" action in Track Manifest after successful extraction, with confirmation dialog
+- ✅ Remux Engine — mkvmerge (MKV) / ffmpeg (MP4) remux excluding selected subtitle streams; backend auto-detected by file extension; no re-encoding
+- ✅ Verification Pipeline — ffprobe comparison of duration (±2s), video/audio stream counts, subtitle count (must be exactly -1), file size (≥50% of original)
+- ✅ Atomic File Swap — write to temp file in same directory, original → `.bak`, temp → original via `os.replace()`
+- ✅ Backup Retention — `remux_backup_retention_days` setting (default 7); `POST /api/v1/remux/backups/cleanup` (dry_run supported); `GET /api/v1/remux/backups` to list
+- ✅ CoW/Reflink Detection — `cp --reflink=auto` attempted first; falls back to `shutil.copy2`; controlled by `remux_use_reflink` setting
+- ✅ *arr Pause Integration — `remux_arr_pause_enabled` setting; calls Sonarr `set_monitoring()` around remux window
+- ✅ Track Panel UI — "Entfernen" button with two-click confirmation; polling job status via `GET /remux/jobs/<id>`; async job system with Socket.IO progress
 
 ---
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -197,6 +197,7 @@ class Settings(BaseSettings):
     anti_captcha_api_key: str = ""
 
     # Remux / Stream Removal
+    remux_trash_dir: str = ".sublarr"  # Relative (to media_path) or absolute path for backup trash
     remux_backup_retention_days: int = 7  # 0 = keep forever
     remux_use_reflink: bool = True  # CoW reflink on Btrfs/XFS for zero-cost backups
     remux_arr_pause_enabled: bool = True  # Pause Sonarr/Radarr during remux

--- a/backend/config.py
+++ b/backend/config.py
@@ -196,6 +196,11 @@ class Settings(BaseSettings):
     anti_captcha_provider: str = ""  # "" | "anticaptcha" | "capmonster"
     anti_captcha_api_key: str = ""
 
+    # Remux / Stream Removal
+    remux_backup_retention_days: int = 7  # 0 = keep forever
+    remux_use_reflink: bool = True  # CoW reflink on Btrfs/XFS for zero-cost backups
+    remux_arr_pause_enabled: bool = True  # Pause Sonarr/Radarr during remux
+
     # Circuit Breaker
     circuit_breaker_failure_threshold: int = 5  # Consecutive failures before opening
     circuit_breaker_cooldown_seconds: int = 60  # Seconds in OPEN before HALF_OPEN probe

--- a/backend/remux/__init__.py
+++ b/backend/remux/__init__.py
@@ -44,15 +44,59 @@ def _try_reflink(src: str, dst: str) -> bool:
         return False
 
 
-def _make_backup(video_path: str, use_reflink: bool) -> str:
-    """Create <video_path>.bak and return the backup path."""
-    bak_path = video_path + ".bak"
-    if use_reflink and _try_reflink(video_path, bak_path):
-        logger.info("Remux: reflink backup created: %s", bak_path)
-    else:
+def _resolve_trash_dir(video_path: str, trash_dir_setting: str) -> str:
+    """Return the absolute path to the trash directory for this video.
+
+    If `trash_dir_setting` is absolute, use it directly.
+    Otherwise treat it as relative to the media root (first watched-folder root
+    that is a parent of `video_path`, or the video's own directory).
+    """
+    if os.path.isabs(trash_dir_setting):
+        return trash_dir_setting
+
+    # Find longest watched-folder prefix
+    try:
+        from config import get_settings
+
+        settings = get_settings()
+        media_root = getattr(settings, "media_path", "") or os.path.dirname(video_path)
+    except Exception:
+        media_root = os.path.dirname(video_path)
+
+    return os.path.join(media_root, trash_dir_setting)
+
+
+def _make_backup(video_path: str, use_reflink: bool, trash_dir: str = "") -> str:
+    """Move original to the trash directory and return the backup path.
+
+    Layout: <trash_dir>/trash/<YYYY-MM-DD>/<basename>.<timestamp>.bak
+
+    Falls back to a sibling .bak if the trash directory cannot be created.
+    """
+    import time as _time
+
+    basename = os.path.basename(video_path)
+    date_str = __import__("datetime").date.today().isoformat()
+    timestamp = int(_time.time())
+
+    resolved = _resolve_trash_dir(video_path, trash_dir or ".sublarr")
+    dest_dir = os.path.join(resolved, "trash", date_str)
+
+    try:
+        os.makedirs(dest_dir, exist_ok=True)
+        bak_path = os.path.join(dest_dir, f"{basename}.{timestamp}.bak")
+        if use_reflink and _try_reflink(video_path, bak_path):
+            logger.info("Remux: reflink backup in trash: %s", bak_path)
+        else:
+            shutil.copy2(video_path, bak_path)
+            logger.info("Remux: backup moved to trash: %s", bak_path)
+        return bak_path
+    except OSError as exc:
+        # Fallback: sibling .bak
+        logger.warning("Remux: could not use trash dir (%s), falling back to sibling .bak", exc)
+        bak_path = video_path + ".bak"
         shutil.copy2(video_path, bak_path)
-        logger.info("Remux: regular copy backup created: %s", bak_path)
-    return bak_path
+        return bak_path
 
 
 # ---------------------------------------------------------------------------
@@ -212,6 +256,7 @@ def remove_subtitle_stream(
     stream_index: int,
     subtitle_track_index: int,
     use_reflink: bool = True,
+    trash_dir: str = ".sublarr",
 ) -> str:
     """Remove a subtitle stream from a video container.
 
@@ -225,6 +270,9 @@ def remove_subtitle_stream(
         The 0-based index within the subtitle-only track list (for mkvmerge).
     use_reflink:
         Attempt CoW reflink for the backup copy (Btrfs/XFS).
+    trash_dir:
+        Relative or absolute path for the trash folder (default ".sublarr").
+        Backups land in <trash_dir>/trash/<date>/<file>.<timestamp>.bak.
 
     Returns
     -------
@@ -259,8 +307,8 @@ def remove_subtitle_stream(
 
         _verify(video_path, tmp_path)
 
-        # Atomic swap: original → .bak, temp → original
-        bak_path = _make_backup(video_path, use_reflink)
+        # Atomic swap: original → trash dir, temp → original
+        bak_path = _make_backup(video_path, use_reflink, trash_dir)
         os.replace(tmp_path, video_path)
         logger.info("Remux: complete — backup at %s", bak_path)
         return bak_path

--- a/backend/remux/__init__.py
+++ b/backend/remux/__init__.py
@@ -1,0 +1,280 @@
+"""Remux engine — safely removes subtitle streams from video containers.
+
+Workflow:
+  1. Probe container to confirm stream exists.
+  2. Select backend: mkvmerge (MKV) or ffmpeg (MP4/other).
+  3. Remux to a temp file in the same directory.
+  4. Verify temp file (duration ±2 s, stream counts, size ≥ 50 %).
+  5. Atomic swap: original → <original>.bak, temp → original.
+  6. Optionally use CoW reflink for zero-cost backup on Btrfs/XFS.
+
+License: GPL-3.0
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import subprocess
+import tempfile
+
+logger = logging.getLogger(__name__)
+
+
+class RemuxError(Exception):
+    """Raised when any remux step fails."""
+
+
+# ---------------------------------------------------------------------------
+# CoW / reflink helper
+# ---------------------------------------------------------------------------
+
+
+def _try_reflink(src: str, dst: str) -> bool:
+    """Attempt `cp --reflink=auto src dst`. Returns True on success."""
+    try:
+        result = subprocess.run(
+            ["cp", "--reflink=auto", src, dst],
+            capture_output=True,
+            timeout=120,
+        )
+        return result.returncode == 0
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+
+def _make_backup(video_path: str, use_reflink: bool) -> str:
+    """Create <video_path>.bak and return the backup path."""
+    bak_path = video_path + ".bak"
+    if use_reflink and _try_reflink(video_path, bak_path):
+        logger.info("Remux: reflink backup created: %s", bak_path)
+    else:
+        shutil.copy2(video_path, bak_path)
+        logger.info("Remux: regular copy backup created: %s", bak_path)
+    return bak_path
+
+
+# ---------------------------------------------------------------------------
+# Backend selection
+# ---------------------------------------------------------------------------
+
+
+def _detect_backend(video_path: str) -> str:
+    """Return 'mkvmerge' for MKV files, 'ffmpeg' otherwise."""
+    ext = os.path.splitext(video_path)[1].lower()
+    if ext in (".mkv", ".mka", ".mk3d"):
+        return "mkvmerge"
+    return "ffmpeg"
+
+
+def _which(cmd: str) -> bool:
+    return shutil.which(cmd) is not None
+
+
+# ---------------------------------------------------------------------------
+# mkvmerge backend
+# ---------------------------------------------------------------------------
+
+
+def _remux_mkvmerge(video_path: str, stream_index: int, output_path: str) -> None:
+    """Remove subtitle stream `stream_index` using mkvmerge.
+
+    mkvmerge uses 0-based subtitle-track IDs within the subtitle track list.
+    `stream_index` here is the ffprobe-style global stream index; we pass it
+    as the subtitle track number because mkvmerge numbers subtitle tracks
+    separately starting at 0.
+    """
+    if not _which("mkvmerge"):
+        raise RemuxError("mkvmerge not found — install mkvtoolnix")
+
+    # --subtitle-tracks !N removes subtitle track N (0-based within subtitle tracks)
+    cmd = [
+        "mkvmerge",
+        "-o",
+        output_path,
+        "--subtitle-tracks",
+        f"!{stream_index}",
+        video_path,
+    ]
+    logger.debug("Remux mkvmerge: %s", " ".join(cmd))
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
+    if result.returncode not in (0, 1):  # mkvmerge exit 1 = warnings, still OK
+        raise RemuxError(f"mkvmerge failed (exit {result.returncode}): {result.stderr[:500]}")
+
+
+# ---------------------------------------------------------------------------
+# ffmpeg backend
+# ---------------------------------------------------------------------------
+
+
+def _remux_ffmpeg(video_path: str, stream_index: int, output_path: str) -> None:
+    """Remove subtitle stream `stream_index` using ffmpeg stream copy."""
+    if not _which("ffmpeg"):
+        raise RemuxError("ffmpeg not found")
+
+    # Map all streams, then un-map the target subtitle stream by global index
+    cmd = [
+        "ffmpeg",
+        "-y",
+        "-i",
+        video_path,
+        "-map",
+        "0",
+        "-map",
+        f"-0:{stream_index}",
+        "-c",
+        "copy",
+        output_path,
+    ]
+    logger.debug("Remux ffmpeg: %s", " ".join(cmd))
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
+    if result.returncode != 0:
+        raise RemuxError(f"ffmpeg failed (exit {result.returncode}): {result.stderr[-500:]}")
+
+
+# ---------------------------------------------------------------------------
+# Verification
+# ---------------------------------------------------------------------------
+
+
+def _probe(path: str) -> dict:
+    """Run ffprobe and return parsed JSON."""
+    if not _which("ffprobe"):
+        raise RemuxError("ffprobe not found")
+    cmd = [
+        "ffprobe",
+        "-v",
+        "quiet",
+        "-print_format",
+        "json",
+        "-show_streams",
+        "-show_format",
+        path,
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+    if result.returncode != 0:
+        raise RemuxError(f"ffprobe failed: {result.stderr[:300]}")
+    import json
+
+    return json.loads(result.stdout)
+
+
+def _verify(original_path: str, remuxed_path: str) -> None:
+    """Compare duration, stream count, and file size between original and remux."""
+    orig_info = _probe(original_path)
+    new_info = _probe(remuxed_path)
+
+    # Duration check (±2 s)
+    orig_dur = float(orig_info.get("format", {}).get("duration", 0))
+    new_dur = float(new_info.get("format", {}).get("duration", 0))
+    if orig_dur > 0 and abs(orig_dur - new_dur) > 2.0:
+        raise RemuxError(f"Duration mismatch: original={orig_dur:.1f}s remuxed={new_dur:.1f}s")
+
+    # Video + audio stream count must not decrease
+    def _count(info: dict, codec_type: str) -> int:
+        return sum(1 for s in info.get("streams", []) if s.get("codec_type") == codec_type)
+
+    if _count(new_info, "video") < _count(orig_info, "video"):
+        raise RemuxError("Video stream count decreased after remux")
+    if _count(new_info, "audio") < _count(orig_info, "audio"):
+        raise RemuxError("Audio stream count decreased after remux")
+    # Subtitle count should be exactly one less
+    orig_subs = _count(orig_info, "subtitle")
+    new_subs = _count(new_info, "subtitle")
+    if new_subs != orig_subs - 1:
+        raise RemuxError(
+            f"Unexpected subtitle stream count: expected {orig_subs - 1}, got {new_subs}"
+        )
+
+    # File size sanity (≥ 50 % of original)
+    orig_size = os.path.getsize(original_path)
+    new_size = os.path.getsize(remuxed_path)
+    if orig_size > 0 and new_size < orig_size * 0.5:
+        raise RemuxError(f"Remuxed file suspiciously small: {new_size} vs original {orig_size}")
+
+    logger.info(
+        "Remux verification passed: dur=%.1fs streams(v=%d a=%d s=%d)",
+        new_dur,
+        _count(new_info, "video"),
+        _count(new_info, "audio"),
+        new_subs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def remove_subtitle_stream(
+    video_path: str,
+    stream_index: int,
+    subtitle_track_index: int,
+    use_reflink: bool = True,
+) -> str:
+    """Remove a subtitle stream from a video container.
+
+    Parameters
+    ----------
+    video_path:
+        Absolute path to the source video file.
+    stream_index:
+        The ffprobe global stream index (0-based across all streams).
+    subtitle_track_index:
+        The 0-based index within the subtitle-only track list (for mkvmerge).
+    use_reflink:
+        Attempt CoW reflink for the backup copy (Btrfs/XFS).
+
+    Returns
+    -------
+    str
+        Path to the created backup file (<video_path>.bak).
+
+    Raises
+    ------
+    RemuxError
+        On any failure (backend not found, remux error, verification failure).
+    """
+    backend = _detect_backend(video_path)
+    video_dir = os.path.dirname(video_path)
+    suffix = os.path.splitext(video_path)[1]
+
+    # Write remux output to a temp file in the same directory (same filesystem)
+    fd, tmp_path = tempfile.mkstemp(suffix=suffix, dir=video_dir)
+    os.close(fd)
+
+    try:
+        logger.info(
+            "Remux: starting (%s) — removing stream %d (sub_idx %d) from %s",
+            backend,
+            stream_index,
+            subtitle_track_index,
+            video_path,
+        )
+        if backend == "mkvmerge":
+            _remux_mkvmerge(video_path, subtitle_track_index, tmp_path)
+        else:
+            _remux_ffmpeg(video_path, stream_index, tmp_path)
+
+        _verify(video_path, tmp_path)
+
+        # Atomic swap: original → .bak, temp → original
+        bak_path = _make_backup(video_path, use_reflink)
+        os.replace(tmp_path, video_path)
+        logger.info("Remux: complete — backup at %s", bak_path)
+        return bak_path
+
+    except Exception:
+        # Clean up temp file on any failure
+        if os.path.exists(tmp_path):
+            with contextlib_suppress(OSError):
+                os.unlink(tmp_path)
+        raise
+
+
+def contextlib_suppress(exc_type):
+    """Tiny suppress context manager to avoid extra import."""
+    import contextlib
+
+    return contextlib.suppress(exc_type)

--- a/backend/remux/backup_cleanup.py
+++ b/backend/remux/backup_cleanup.py
@@ -1,0 +1,72 @@
+"""Backup (.bak) retention cleanup for remuxed video files.
+
+Scans all watched media directories for *.bak files older than
+`remux_backup_retention_days` and deletes them.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+
+logger = logging.getLogger(__name__)
+
+
+def _iter_bak_files(media_paths: list[str]):
+    """Yield absolute paths of all .bak files found under the given directories."""
+    for base_dir in media_paths:
+        if not os.path.isdir(base_dir):
+            continue
+        for dirpath, _dirs, files in os.walk(base_dir):
+            for fname in files:
+                if fname.endswith(".bak"):
+                    yield os.path.join(dirpath, fname)
+
+
+def cleanup_old_backups(media_paths: list[str], retention_days: int) -> dict:
+    """Delete .bak files older than `retention_days`.
+
+    Returns
+    -------
+    dict
+        {"deleted": [...], "errors": [...], "skipped": int}
+    """
+    if retention_days <= 0:
+        return {"deleted": [], "errors": [], "skipped": 0}
+
+    cutoff = time.time() - retention_days * 86400
+    deleted, errors, skipped = [], [], 0
+
+    for bak_path in _iter_bak_files(media_paths):
+        try:
+            mtime = os.path.getmtime(bak_path)
+            if mtime < cutoff:
+                os.unlink(bak_path)
+                deleted.append(bak_path)
+                logger.info("Remux backup deleted (age > %d days): %s", retention_days, bak_path)
+            else:
+                skipped += 1
+        except OSError as exc:
+            logger.warning("Could not process backup %s: %s", bak_path, exc)
+            errors.append({"path": bak_path, "error": str(exc)})
+
+    return {"deleted": deleted, "errors": errors, "skipped": skipped}
+
+
+def list_backups(media_paths: list[str]) -> list[dict]:
+    """Return metadata for all .bak files found under the given directories."""
+    result = []
+    for bak_path in _iter_bak_files(media_paths):
+        try:
+            stat = os.stat(bak_path)
+            result.append(
+                {
+                    "path": bak_path,
+                    "size_bytes": stat.st_size,
+                    "mtime": stat.st_mtime,
+                }
+            )
+        except OSError:
+            pass
+    return result

--- a/backend/routes/__init__.py
+++ b/backend/routes/__init__.py
@@ -25,6 +25,7 @@ def register_blueprints(app):
     from routes.plugins import bp as plugins_bp
     from routes.profiles import bp as profiles_bp
     from routes.providers import bp as providers_bp
+    from routes.remux import bp as remux_bp
     from routes.search import bp as search_bp
     from routes.spell import bp as spell_bp
     from routes.standalone import bp as standalone_bp
@@ -71,5 +72,6 @@ def register_blueprints(app):
         tracks_bp,
         video_sync_bp,
         subtitles_bp,
+        remux_bp,
     ]:
         app.register_blueprint(blueprint)

--- a/backend/routes/remux.py
+++ b/backend/routes/remux.py
@@ -1,0 +1,231 @@
+"""Remux routes — remove subtitle streams from video containers.
+
+POST /api/v1/library/episodes/<ep_id>/tracks/<index>/remove-from-container
+    Start an async remux job to strip the subtitle stream.
+    Body: { "subtitle_track_index": int }   (optional; derived from index if omitted)
+
+GET  /api/v1/remux/jobs
+    List recent remux jobs (in-memory, cleared on restart).
+
+GET  /api/v1/remux/jobs/<job_id>
+    Get status of a single remux job.
+
+GET  /api/v1/remux/backups
+    List all .bak files under watched media directories.
+
+POST /api/v1/remux/backups/cleanup
+    Trigger backup cleanup (honours remux_backup_retention_days).
+    Optional body: { "dry_run": true }
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+
+from flask import Blueprint, jsonify, request
+
+from ass_utils import get_media_streams
+from config import get_settings, map_path
+from remux import RemuxError, remove_subtitle_stream
+from remux.backup_cleanup import cleanup_old_backups, list_backups
+
+bp = Blueprint("remux", __name__, url_prefix="/api/v1")
+logger = logging.getLogger(__name__)
+
+_executor = ThreadPoolExecutor(max_workers=2, thread_name_prefix="remux")
+_jobs: dict[str, dict] = {}
+_jobs_lock = threading.Lock()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_video_path(ep_id: int) -> str | None:
+    from sonarr_client import get_sonarr_client
+
+    client = get_sonarr_client()
+    if client is None:
+        return None
+    path = client.get_episode_file_path(ep_id)
+    if not path:
+        return None
+    return map_path(path)
+
+
+def _update_job(
+    job_id: str, status: str, result: dict | None = None, error: str | None = None
+) -> None:
+    with _jobs_lock:
+        _jobs[job_id] = {"status": status, "result": result, "error": error}
+    try:
+        from app import socketio
+
+        socketio.emit(
+            "remux_job_update",
+            {"job_id": job_id, "status": status, "result": result, "error": error},
+        )
+    except Exception:
+        pass
+
+
+def _arr_pause(pause: bool) -> None:
+    """Signal Sonarr/Radarr to pause/resume folder monitoring if configured."""
+    settings = get_settings()
+    if not getattr(settings, "remux_arr_pause_enabled", True):
+        return
+    try:
+        from sonarr_client import get_sonarr_client
+
+        client = get_sonarr_client()
+        if client and hasattr(client, "set_monitoring"):
+            client.set_monitoring(not pause)
+    except Exception as exc:
+        logger.debug("arr pause/resume skipped: %s", exc)
+
+
+def _media_paths() -> list[str]:
+    settings = get_settings()
+    paths = []
+    media = getattr(settings, "media_path", "")
+    if media:
+        paths.append(media)
+    extra = getattr(settings, "extra_media_paths", "")
+    if extra:
+        paths.extend(p.strip() for p in extra.split(",") if p.strip())
+    return paths
+
+
+# ---------------------------------------------------------------------------
+# Async job runner
+# ---------------------------------------------------------------------------
+
+
+def _run_remux(job_id: str, video_path: str, stream_index: int, subtitle_track_index: int) -> None:
+    settings = get_settings()
+    use_reflink = getattr(settings, "remux_use_reflink", True)
+    _update_job(job_id, "running")
+    _arr_pause(True)
+    try:
+        bak_path = remove_subtitle_stream(
+            video_path=video_path,
+            stream_index=stream_index,
+            subtitle_track_index=subtitle_track_index,
+            use_reflink=use_reflink,
+        )
+        _update_job(job_id, "completed", result={"backup_path": bak_path, "video_path": video_path})
+        logger.info("Remux job %s completed — backup: %s", job_id, bak_path)
+    except RemuxError as exc:
+        _update_job(job_id, "failed", error=str(exc))
+        logger.error("Remux job %s failed: %s", job_id, exc)
+    except Exception as exc:
+        _update_job(job_id, "failed", error=f"Unexpected error: {exc}")
+        logger.exception("Remux job %s unexpected error", job_id)
+    finally:
+        _arr_pause(False)
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+
+@bp.route(
+    "/library/episodes/<int:ep_id>/tracks/<int:index>/remove-from-container", methods=["POST"]
+)
+def remove_track_from_container(ep_id: int, index: int):
+    """Start an async remux job to remove subtitle track `index` from the video container."""
+    body = request.get_json(force=True, silent=True) or {}
+    subtitle_track_index = body.get("subtitle_track_index")
+
+    video_path = _get_video_path(ep_id)
+    if not video_path:
+        return jsonify({"error": "Episode has no video file or Sonarr is not configured"}), 404
+    if not os.path.exists(video_path):
+        return jsonify({"error": "Video file not found on disk: " + video_path}), 404
+
+    # Verify that track index is a subtitle stream
+    try:
+        probe = get_media_streams(video_path)
+    except RuntimeError as exc:
+        return jsonify({"error": "Failed to probe video file: " + str(exc)}), 500
+    except Exception:
+        return jsonify({"error": "Internal server error"}), 500
+
+    streams = probe.get("streams", [])
+    if index >= len(streams):
+        return jsonify({"error": f"Stream index {index} out of range"}), 400
+    target = streams[index]
+    if target.get("codec_type") != "subtitle":
+        return jsonify({"error": f"Stream {index} is not a subtitle stream"}), 400
+
+    # Derive subtitle_track_index (0-based within subtitle streams) if not supplied
+    if subtitle_track_index is None:
+        subtitle_track_index = sum(1 for s in streams[:index] if s.get("codec_type") == "subtitle")
+
+    job_id = str(uuid.uuid4())
+    with _jobs_lock:
+        _jobs[job_id] = {"status": "queued", "result": None, "error": None}
+
+    _executor.submit(_run_remux, job_id, video_path, index, subtitle_track_index)
+    return jsonify({"job_id": job_id, "status": "queued"}), 202
+
+
+@bp.route("/remux/jobs", methods=["GET"])
+def list_remux_jobs():
+    """Return all recent remux jobs."""
+    with _jobs_lock:
+        jobs = [{"job_id": jid, **info} for jid, info in _jobs.items()]
+    return jsonify({"jobs": jobs}), 200
+
+
+@bp.route("/remux/jobs/<job_id>", methods=["GET"])
+def get_remux_job(job_id: str):
+    """Return the status of a single remux job."""
+    with _jobs_lock:
+        job = _jobs.get(job_id)
+    if job is None:
+        return jsonify({"error": "Job not found"}), 404
+    return jsonify({"job_id": job_id, **job}), 200
+
+
+@bp.route("/remux/backups", methods=["GET"])
+def list_remux_backups():
+    """List all .bak backup files under watched media directories."""
+    backups = list_backups(_media_paths())
+    return jsonify({"backups": backups, "count": len(backups)}), 200
+
+
+@bp.route("/remux/backups/cleanup", methods=["POST"])
+def trigger_backup_cleanup():
+    """Delete .bak files older than remux_backup_retention_days."""
+    body = request.get_json(force=True, silent=True) or {}
+    dry_run = bool(body.get("dry_run", False))
+    settings = get_settings()
+    retention_days = getattr(settings, "remux_backup_retention_days", 7)
+
+    if dry_run:
+        # Just list what would be deleted
+        import time
+
+        from remux.backup_cleanup import _iter_bak_files
+
+        cutoff = time.time() - retention_days * 86400
+        would_delete = []
+        for bak_path in _iter_bak_files(_media_paths()):
+            try:
+                if os.path.getmtime(bak_path) < cutoff:
+                    would_delete.append(bak_path)
+            except OSError:
+                pass
+        return jsonify(
+            {"dry_run": True, "would_delete": would_delete, "count": len(would_delete)}
+        ), 200
+
+    result = cleanup_old_backups(_media_paths(), retention_days)
+    return jsonify(result), 200

--- a/backend/routes/remux.py
+++ b/backend/routes/remux.py
@@ -32,6 +32,7 @@ from ass_utils import get_media_streams
 from config import get_settings, map_path
 from remux import RemuxError, remove_subtitle_stream
 from remux.backup_cleanup import cleanup_old_backups, list_backups
+from security_utils import is_safe_path
 
 bp = Blueprint("remux", __name__, url_prefix="/api/v1")
 logger = logging.getLogger(__name__)
@@ -243,3 +244,44 @@ def trigger_backup_cleanup():
 
     result = cleanup_old_backups(_trash_paths(), retention_days)
     return jsonify(result), 200
+
+
+@bp.route("/remux/backups/restore", methods=["POST"])
+def restore_backup():
+    """Restore a backup file to its original video path.
+
+    Body: { "backup_path": "/path/to/trash/...", "video_path": "/path/to/original.mkv" }
+
+    The original video (the remuxed file) is deleted and the backup is moved back.
+    Both paths are validated against the configured media/trash directories.
+    """
+    body = request.get_json(force=True, silent=True) or {}
+    backup_path = body.get("backup_path", "")
+    video_path = body.get("video_path", "")
+
+    if not backup_path or not video_path:
+        return jsonify({"error": "backup_path and video_path are required"}), 400
+
+    # Security: backup must be inside a known trash dir
+    trash_dirs = _trash_paths()
+    if not any(is_safe_path(td, backup_path) for td in trash_dirs):
+        return jsonify({"error": "backup_path is outside the configured trash directory"}), 403
+
+    # Security: restore target must be inside a known media path
+    media_dirs = _media_paths()
+    if not any(is_safe_path(md, video_path) for md in media_dirs):
+        return jsonify({"error": "video_path is outside the configured media directory"}), 403
+
+    if not os.path.exists(backup_path):
+        return jsonify({"error": "Backup file not found: " + backup_path}), 404
+    if not os.path.exists(video_path):
+        return jsonify({"error": "Video file not found (already deleted?): " + video_path}), 404
+
+    try:
+        # Replace the remuxed file with the backup (atomic on same filesystem)
+        os.replace(backup_path, video_path)
+        logger.info("Remux restore: %s → %s", backup_path, video_path)
+        return jsonify({"restored": video_path, "backup_removed": backup_path}), 200
+    except OSError as exc:
+        logger.error("Remux restore failed: %s", exc)
+        return jsonify({"error": f"Restore failed: {exc}"}), 500

--- a/backend/routes/remux.py
+++ b/backend/routes/remux.py
@@ -101,6 +101,18 @@ def _media_paths() -> list[str]:
     return paths
 
 
+def _trash_paths() -> list[str]:
+    """Return the resolved trash directory paths (one per media root)."""
+    settings = get_settings()
+    trash_dir = getattr(settings, "remux_trash_dir", ".sublarr")
+    result = []
+    if os.path.isabs(trash_dir):
+        return [os.path.join(trash_dir, "trash")]
+    for media_path in _media_paths():
+        result.append(os.path.join(media_path, trash_dir, "trash"))
+    return result
+
+
 # ---------------------------------------------------------------------------
 # Async job runner
 # ---------------------------------------------------------------------------
@@ -109,6 +121,7 @@ def _media_paths() -> list[str]:
 def _run_remux(job_id: str, video_path: str, stream_index: int, subtitle_track_index: int) -> None:
     settings = get_settings()
     use_reflink = getattr(settings, "remux_use_reflink", True)
+    trash_dir = getattr(settings, "remux_trash_dir", ".sublarr")
     _update_job(job_id, "running")
     _arr_pause(True)
     try:
@@ -117,6 +130,7 @@ def _run_remux(job_id: str, video_path: str, stream_index: int, subtitle_track_i
             stream_index=stream_index,
             subtitle_track_index=subtitle_track_index,
             use_reflink=use_reflink,
+            trash_dir=trash_dir,
         )
         _update_job(job_id, "completed", result={"backup_path": bak_path, "video_path": video_path})
         logger.info("Remux job %s completed — backup: %s", job_id, bak_path)
@@ -196,8 +210,8 @@ def get_remux_job(job_id: str):
 
 @bp.route("/remux/backups", methods=["GET"])
 def list_remux_backups():
-    """List all .bak backup files under watched media directories."""
-    backups = list_backups(_media_paths())
+    """List all .bak backup files in the configured trash directory."""
+    backups = list_backups(_trash_paths())
     return jsonify({"backups": backups, "count": len(backups)}), 200
 
 
@@ -217,7 +231,7 @@ def trigger_backup_cleanup():
 
         cutoff = time.time() - retention_days * 86400
         would_delete = []
-        for bak_path in _iter_bak_files(_media_paths()):
+        for bak_path in _iter_bak_files(_trash_paths()):
             try:
                 if os.path.getmtime(bak_path) < cutoff:
                     would_delete.append(bak_path)
@@ -227,5 +241,5 @@ def trigger_backup_cleanup():
             {"dry_run": True, "would_delete": would_delete, "count": len(would_delete)}
         ), 200
 
-    result = cleanup_old_backups(_media_paths(), retention_days)
+    result = cleanup_old_backups(_trash_paths(), retention_days)
     return jsonify(result), 200

--- a/backend/tests/test_remux.py
+++ b/backend/tests/test_remux.py
@@ -275,3 +275,40 @@ def test_cleanup_handles_missing_dir():
     result = cleanup_old_backups(["/nonexistent/path/xyz"], retention_days=7)
     assert result["deleted"] == []
     assert result["errors"] == []
+
+
+# ---------------------------------------------------------------------------
+# _make_backup — trash directory layout
+# ---------------------------------------------------------------------------
+
+
+def test_make_backup_creates_trash_dir(tmp_path):
+    from remux import _make_backup
+
+    video = str(tmp_path / "show.mkv")
+    trash_root = str(tmp_path / ".sublarr")
+    with open(video, "wb") as f:
+        f.write(b"x" * 500)
+
+    bak_path = _make_backup(video, use_reflink=False, trash_dir=trash_root)
+
+    assert os.path.exists(bak_path)
+    assert ".sublarr" in bak_path or "trash" in bak_path
+    assert bak_path.endswith(".bak")
+
+
+def test_make_backup_fallback_on_permission_error(tmp_path):
+    """When trash dir cannot be created, falls back to sibling .bak."""
+    from remux import _make_backup
+
+    video = str(tmp_path / "show.mkv")
+    with open(video, "wb") as f:
+        f.write(b"x" * 100)
+
+    # Simulate os.makedirs failing with a permission error
+    with patch("os.makedirs", side_effect=OSError("Permission denied")):
+        bak_path = _make_backup(video, use_reflink=False, trash_dir=".sublarr")
+
+    # Fallback: sibling .bak
+    assert bak_path == video + ".bak"
+    assert os.path.exists(bak_path)

--- a/backend/tests/test_remux.py
+++ b/backend/tests/test_remux.py
@@ -1,0 +1,277 @@
+"""Tests for the remux engine and backup cleanup."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import time
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from remux import RemuxError, _detect_backend, _verify, remove_subtitle_stream
+from remux.backup_cleanup import cleanup_old_backups, list_backups
+
+# ---------------------------------------------------------------------------
+# _detect_backend
+# ---------------------------------------------------------------------------
+
+
+def test_detect_backend_mkv():
+    assert _detect_backend("/movies/film.mkv") == "mkvmerge"
+
+
+def test_detect_backend_mk3d():
+    assert _detect_backend("/movies/film.mk3d") == "mkvmerge"
+
+
+def test_detect_backend_mp4():
+    assert _detect_backend("/movies/film.mp4") == "ffmpeg"
+
+
+def test_detect_backend_avi():
+    assert _detect_backend("/movies/film.avi") == "ffmpeg"
+
+
+# ---------------------------------------------------------------------------
+# _verify — duration / stream count / size checks
+# ---------------------------------------------------------------------------
+
+
+def _make_probe(duration, video=1, audio=1, subtitle=1):
+    return {
+        "format": {"duration": str(duration)},
+        "streams": (
+            [{"codec_type": "video"}] * video
+            + [{"codec_type": "audio"}] * audio
+            + [{"codec_type": "subtitle"}] * subtitle
+        ),
+    }
+
+
+def test_verify_passes_clean_remux(tmp_path):
+    orig = str(tmp_path / "orig.mkv")
+    new = str(tmp_path / "new.mkv")
+    # Create dummy files so os.path.getsize works
+    with open(orig, "wb") as f:
+        f.write(b"x" * 1000)
+    with open(new, "wb") as f:
+        f.write(b"x" * 900)
+
+    with patch(
+        "remux._probe",
+        side_effect=[
+            _make_probe(3600, subtitle=2),
+            _make_probe(3600, subtitle=1),
+        ],
+    ):
+        _verify(orig, new)  # should not raise
+
+
+def test_verify_fails_duration_mismatch(tmp_path):
+    orig = str(tmp_path / "orig.mkv")
+    new = str(tmp_path / "new.mkv")
+    with open(orig, "wb") as f:
+        f.write(b"x" * 1000)
+    with open(new, "wb") as f:
+        f.write(b"x" * 900)
+
+    with (
+        patch(
+            "remux._probe",
+            side_effect=[
+                _make_probe(3600, subtitle=2),
+                _make_probe(3605, subtitle=1),  # >2s diff
+            ],
+        ),
+        pytest.raises(RemuxError, match="Duration mismatch"),
+    ):
+        _verify(orig, new)
+
+
+def test_verify_fails_video_stream_lost(tmp_path):
+    orig = str(tmp_path / "orig.mkv")
+    new = str(tmp_path / "new.mkv")
+    with open(orig, "wb") as f:
+        f.write(b"x" * 1000)
+    with open(new, "wb") as f:
+        f.write(b"x" * 900)
+
+    with (
+        patch(
+            "remux._probe",
+            side_effect=[
+                _make_probe(3600, video=1, subtitle=2),
+                _make_probe(3600, video=0, subtitle=1),  # lost video
+            ],
+        ),
+        pytest.raises(RemuxError, match="Video stream count"),
+    ):
+        _verify(orig, new)
+
+
+def test_verify_fails_file_too_small(tmp_path):
+    orig = str(tmp_path / "orig.mkv")
+    new = str(tmp_path / "new.mkv")
+    with open(orig, "wb") as f:
+        f.write(b"x" * 1000)
+    with open(new, "wb") as f:
+        f.write(b"x" * 100)  # only 10% of original
+
+    with (
+        patch(
+            "remux._probe",
+            side_effect=[
+                _make_probe(3600, subtitle=2),
+                _make_probe(3600, subtitle=1),
+            ],
+        ),
+        pytest.raises(RemuxError, match="suspiciously small"),
+    ):
+        _verify(orig, new)
+
+
+def test_verify_fails_wrong_subtitle_count(tmp_path):
+    orig = str(tmp_path / "orig.mkv")
+    new = str(tmp_path / "new.mkv")
+    with open(orig, "wb") as f:
+        f.write(b"x" * 1000)
+    with open(new, "wb") as f:
+        f.write(b"x" * 900)
+
+    with (
+        patch(
+            "remux._probe",
+            side_effect=[
+                _make_probe(3600, subtitle=2),
+                _make_probe(3600, subtitle=2),  # subtitle count unchanged → wrong
+            ],
+        ),
+        pytest.raises(RemuxError, match="subtitle stream count"),
+    ):
+        _verify(orig, new)
+
+
+# ---------------------------------------------------------------------------
+# remove_subtitle_stream — integration (all subprocesses mocked)
+# ---------------------------------------------------------------------------
+
+
+def test_remove_subtitle_stream_mkv_success(tmp_path):
+    video = str(tmp_path / "show.mkv")
+    with open(video, "wb") as f:
+        f.write(b"x" * 2000)
+
+    with (
+        patch("remux._remux_mkvmerge") as mock_remux,
+        patch("remux._verify"),
+        patch("remux._make_backup", return_value=video + ".bak"),
+        patch("remux._detect_backend", return_value="mkvmerge"),
+        patch("os.replace"),
+    ):
+        bak = remove_subtitle_stream(video, stream_index=2, subtitle_track_index=0)
+
+    assert bak == video + ".bak"
+    mock_remux.assert_called_once()
+
+
+def test_remove_subtitle_stream_ffmpeg_success(tmp_path):
+    video = str(tmp_path / "movie.mp4")
+    with open(video, "wb") as f:
+        f.write(b"x" * 2000)
+
+    with (
+        patch("remux._remux_ffmpeg") as mock_remux,
+        patch("remux._verify"),
+        patch("remux._make_backup", return_value=video + ".bak"),
+        patch("remux._detect_backend", return_value="ffmpeg"),
+        patch("os.replace"),
+    ):
+        bak = remove_subtitle_stream(video, stream_index=3, subtitle_track_index=1)
+
+    assert bak == video + ".bak"
+    mock_remux.assert_called_once()
+
+
+def test_remove_subtitle_stream_cleans_temp_on_error(tmp_path):
+    video = str(tmp_path / "show.mkv")
+    with open(video, "wb") as f:
+        f.write(b"x" * 2000)
+
+    with (
+        patch("remux._detect_backend", return_value="mkvmerge"),
+        patch("remux._remux_mkvmerge", side_effect=RemuxError("mkvmerge crashed")),
+        pytest.raises(RemuxError),
+    ):
+        remove_subtitle_stream(video, stream_index=2, subtitle_track_index=0)
+
+    # temp file must be cleaned up
+    tmp_files = [f for f in os.listdir(tmp_path) if f != "show.mkv"]
+    assert len(tmp_files) == 0
+
+
+def test_remove_subtitle_stream_no_backend_raises(tmp_path):
+    video = str(tmp_path / "show.mkv")
+    with open(video, "wb") as f:
+        f.write(b"x" * 1000)
+
+    with (
+        patch("remux._detect_backend", return_value="mkvmerge"),
+        patch("remux._which", return_value=False),
+        pytest.raises(RemuxError, match="mkvmerge not found"),
+    ):
+        remove_subtitle_stream(video, stream_index=0, subtitle_track_index=0)
+
+
+# ---------------------------------------------------------------------------
+# backup_cleanup
+# ---------------------------------------------------------------------------
+
+
+def test_list_backups_finds_bak_files(tmp_path):
+    (tmp_path / "show.mkv.bak").write_bytes(b"x" * 100)
+    (tmp_path / "other.txt").write_bytes(b"y")
+
+    result = list_backups([str(tmp_path)])
+    assert len(result) == 1
+    assert result[0]["path"].endswith(".bak")
+    assert result[0]["size_bytes"] == 100
+
+
+def test_cleanup_deletes_old_backups(tmp_path):
+    bak = tmp_path / "old.mkv.bak"
+    bak.write_bytes(b"x" * 100)
+    # Set mtime to 10 days ago
+    old_time = time.time() - 10 * 86400
+    os.utime(str(bak), (old_time, old_time))
+
+    result = cleanup_old_backups([str(tmp_path)], retention_days=7)
+    assert len(result["deleted"]) == 1
+    assert not bak.exists()
+
+
+def test_cleanup_keeps_recent_backups(tmp_path):
+    bak = tmp_path / "recent.mkv.bak"
+    bak.write_bytes(b"x" * 100)
+    # mtime = now (very recent)
+
+    result = cleanup_old_backups([str(tmp_path)], retention_days=7)
+    assert len(result["deleted"]) == 0
+    assert bak.exists()
+
+
+def test_cleanup_zero_retention_skips_all(tmp_path):
+    bak = tmp_path / "old.mkv.bak"
+    bak.write_bytes(b"x")
+    old_time = time.time() - 30 * 86400
+    os.utime(str(bak), (old_time, old_time))
+
+    result = cleanup_old_backups([str(tmp_path)], retention_days=0)
+    assert result["deleted"] == []
+    assert bak.exists()
+
+
+def test_cleanup_handles_missing_dir():
+    result = cleanup_old_backups(["/nonexistent/path/xyz"], retention_days=7)
+    assert result["deleted"] == []
+    assert result["errors"] == []

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1549,6 +1549,22 @@ export async function trackAsSource(epId: number, index: number): Promise<import
   return data
 }
 
+export async function removeTrackFromContainer(
+  epId: number,
+  index: number,
+  subtitleTrackIndex?: number,
+): Promise<{ job_id: string; status: string }> {
+  const body: Record<string, unknown> = {}
+  if (subtitleTrackIndex !== undefined) body.subtitle_track_index = subtitleTrackIndex
+  const { data } = await api.post(`/library/episodes/${epId}/tracks/${index}/remove-from-container`, body)
+  return data
+}
+
+export async function getRemuxJob(jobId: string): Promise<{ job_id: string; status: string; result: Record<string, string> | null; error: string | null }> {
+  const { data } = await api.get(`/remux/jobs/${jobId}`)
+  return data
+}
+
 // ─── Subtitle Sidecar Management ─────────────────────────────────────────────
 
 export async function listEpisodeSubtitles(epId: number): Promise<{ subtitles: import('@/lib/types').SidecarSubtitle[]; video_path: string }> {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1565,6 +1565,11 @@ export async function getRemuxJob(jobId: string): Promise<{ job_id: string; stat
   return data
 }
 
+export async function restoreRemuxBackup(backupPath: string, videoPath: string): Promise<{ restored: string; backup_removed: string }> {
+  const { data } = await api.post('/remux/backups/restore', { backup_path: backupPath, video_path: videoPath })
+  return data
+}
+
 // ─── Subtitle Sidecar Management ─────────────────────────────────────────────
 
 export async function listEpisodeSubtitles(epId: number): Promise<{ subtitles: import('@/lib/types').SidecarSubtitle[]; video_path: string }> {

--- a/frontend/src/components/tracks/TrackPanel.tsx
+++ b/frontend/src/components/tracks/TrackPanel.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect } from 'react'
-import { Loader2, Download, FileText, AlertTriangle } from 'lucide-react'
-import { listEpisodeTracks, extractTrack, convertSubtitle } from '@/api/client'
+import { useState, useEffect, useCallback } from 'react'
+import { Loader2, Download, FileText, AlertTriangle, Trash2 } from 'lucide-react'
+import { listEpisodeTracks, extractTrack, convertSubtitle, removeTrackFromContainer, getRemuxJob } from '@/api/client'
 import { toast } from '@/components/shared/Toast'
 import type { Track, EpisodeTracksResponse } from '@/lib/types'
 
@@ -20,6 +20,8 @@ function TrackRow({ track, episodeId, videoPath, onOpenEditor }: { track: Track;
   const [extracting, setExtracting] = useState(false)
   const [usingAsSource, setUsingAsSource] = useState(false)
   const [converting, setConverting] = useState(false)
+  const [removing, setRemoving] = useState(false)
+  const [confirmRemove, setConfirmRemove] = useState(false)
   const isSubtitle = track.codec_type === 'subtitle'
   const isImageBased = track.codec === 'hdmv_pgs_subtitle' || track.codec === 'dvd_subtitle'
   const { bg, text } = codecColor(track.codec_type, track.codec)
@@ -45,6 +47,46 @@ function TrackRow({ track, episodeId, videoPath, onOpenEditor }: { track: Track;
       toast('Extraktion fehlgeschlagen', 'error')
     } finally {
       setUsingAsSource(false)
+    }
+  }
+
+  const pollRemuxJob = useCallback(async (jobId: string) => {
+    const maxAttempts = 60
+    for (let i = 0; i < maxAttempts; i++) {
+      await new Promise((r) => setTimeout(r, 3000))
+      try {
+        const job = await getRemuxJob(jobId)
+        if (job.status === 'completed') {
+          toast('Stream aus Container entfernt — Backup erstellt')
+          setRemoving(false)
+          return
+        }
+        if (job.status === 'failed') {
+          toast(`Remux fehlgeschlagen: ${job.error ?? 'Unbekannter Fehler'}`, 'error')
+          setRemoving(false)
+          return
+        }
+      } catch {
+        // network hiccup — keep polling
+      }
+    }
+    toast('Remux-Job Timeout — prüfe Logs', 'error')
+    setRemoving(false)
+  }, [])
+
+  const handleRemoveFromContainer = async () => {
+    if (!confirmRemove) {
+      setConfirmRemove(true)
+      return
+    }
+    setConfirmRemove(false)
+    setRemoving(true)
+    try {
+      const { job_id } = await removeTrackFromContainer(episodeId, track.index)
+      void pollRemuxJob(job_id)
+    } catch {
+      toast('Remux konnte nicht gestartet werden', 'error')
+      setRemoving(false)
     }
   }
 
@@ -171,6 +213,27 @@ function TrackRow({ track, episodeId, videoPath, onOpenEditor }: { track: Track;
                       ))}
                   </select>
                 )
+            )}
+            {isSubtitle && (
+              removing ? (
+                <Loader2 size={10} className="animate-spin ml-1" style={{ color: 'var(--text-muted)' }} />
+              ) : (
+                <button
+                  onClick={() => void handleRemoveFromContainer()}
+                  disabled={extracting || usingAsSource || converting}
+                  className="flex items-center gap-1 px-2 py-1 rounded text-[10px] font-medium transition-colors ml-1"
+                  style={{
+                    backgroundColor: confirmRemove ? 'rgba(239,68,68,0.15)' : 'var(--bg-surface)',
+                    color: confirmRemove ? '#ef4444' : 'var(--text-muted)',
+                    border: confirmRemove ? '1px solid rgba(239,68,68,0.4)' : '1px solid var(--border)',
+                  }}
+                  title={confirmRemove ? 'Klicke erneut zur Bestätigung' : 'Stream aus Container entfernen (erstellt .bak Backup)'}
+                  onBlur={() => setConfirmRemove(false)}
+                >
+                  <Trash2 size={10} />
+                  {confirmRemove ? 'Sicher?' : 'Entfernen'}
+                </button>
+              )
             )}
           </div>
         )}

--- a/frontend/src/components/tracks/TrackPanel.tsx
+++ b/frontend/src/components/tracks/TrackPanel.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import { Loader2, Download, FileText, AlertTriangle, Trash2 } from 'lucide-react'
-import { listEpisodeTracks, extractTrack, convertSubtitle, removeTrackFromContainer, getRemuxJob } from '@/api/client'
+import { listEpisodeTracks, extractTrack, convertSubtitle, removeTrackFromContainer, getRemuxJob, restoreRemuxBackup } from '@/api/client'
 import { toast } from '@/components/shared/Toast'
 import type { Track, EpisodeTracksResponse } from '@/lib/types'
 
@@ -22,6 +22,8 @@ function TrackRow({ track, episodeId, videoPath, onOpenEditor }: { track: Track;
   const [converting, setConverting] = useState(false)
   const [removing, setRemoving] = useState(false)
   const [confirmRemove, setConfirmRemove] = useState(false)
+  const [remuxBackup, setRemuxBackup] = useState<{ backupPath: string; videoPath: string } | null>(null)
+  const [restoring, setRestoring] = useState(false)
   const isSubtitle = track.codec_type === 'subtitle'
   const isImageBased = track.codec === 'hdmv_pgs_subtitle' || track.codec === 'dvd_subtitle'
   const { bg, text } = codecColor(track.codec_type, track.codec)
@@ -59,6 +61,9 @@ function TrackRow({ track, episodeId, videoPath, onOpenEditor }: { track: Track;
         if (job.status === 'completed') {
           toast('Stream aus Container entfernt — Backup erstellt')
           setRemoving(false)
+          if (job.result?.backup_path && job.result?.video_path) {
+            setRemuxBackup({ backupPath: job.result.backup_path, videoPath: job.result.video_path })
+          }
           return
         }
         if (job.status === 'failed') {
@@ -217,6 +222,30 @@ function TrackRow({ track, episodeId, videoPath, onOpenEditor }: { track: Track;
             {isSubtitle && (
               removing ? (
                 <Loader2 size={10} className="animate-spin ml-1" style={{ color: 'var(--text-muted)' }} />
+              ) : remuxBackup ? (
+                restoring ? (
+                  <Loader2 size={10} className="animate-spin ml-1" style={{ color: 'var(--text-muted)' }} />
+                ) : (
+                  <button
+                    onClick={() => {
+                      setRestoring(true)
+                      restoreRemuxBackup(remuxBackup.backupPath, remuxBackup.videoPath)
+                        .then(() => { toast('Stream wiederhergestellt'); setRemuxBackup(null) })
+                        .catch(() => toast('Wiederherstellung fehlgeschlagen', 'error'))
+                        .finally(() => setRestoring(false))
+                    }}
+                    className="flex items-center gap-1 px-2 py-1 rounded text-[10px] font-medium transition-colors ml-1"
+                    style={{
+                      backgroundColor: 'rgba(245,158,11,0.12)',
+                      color: 'var(--warning)',
+                      border: '1px solid rgba(245,158,11,0.3)',
+                    }}
+                    title="Stream aus Backup wiederherstellen (Remux rückgängig machen)"
+                  >
+                    <Trash2 size={10} />
+                    Rückgängig
+                  </button>
+                )
               ) : (
                 <button
                   onClick={() => void handleRemoveFromContainer()}

--- a/frontend/src/pages/Settings/index.tsx
+++ b/frontend/src/pages/Settings/index.tsx
@@ -163,6 +163,17 @@ const FIELDS: FieldConfig[] = [
     description: 'Nach Download automatisch bei Subtitle-Providern suchen.' },
   { key: 'webhook_auto_translate', label: 'Auto-Translate Found Subs', type: 'toggle', tab: 'Automation',
     description: 'Gefundene Untertitel automatisch übersetzen.' },
+  // Automation — Remux / Stream Removal
+  { key: 'remux_trash_dir', label: 'Remux Trash Folder', type: 'text', placeholder: '.sublarr', tab: 'Automation',
+    description: 'Ordner für Backups gelöschter Streams. Relativ zum Medienpfad (z.B. .sublarr) oder absoluter Pfad. Backups landen in <trash>/<datum>/<datei>.<ts>.bak.' },
+  { key: 'remux_backup_retention_days', label: 'Remux Backup Retention (days, 0=forever)', type: 'number', placeholder: '7', tab: 'Automation',
+    description: 'Nach wie vielen Tagen werden Remux-Backups endgültig gelöscht. 0 = nie.' },
+  { key: 'remux_use_reflink', label: 'Use CoW Reflink for Backups', type: 'toggle', tab: 'Automation',
+    description: 'Auf Btrfs/XFS wird cp --reflink=auto für kostenlose Backups genutzt.',
+    advanced: true },
+  { key: 'remux_arr_pause_enabled', label: 'Pause *arr during Remux', type: 'toggle', tab: 'Automation',
+    description: 'Sonarr/Radarr-Ordner-Monitoring während des Remux pausieren.',
+    advanced: true },
   // Automation — Search Scheduler
   { key: 'wanted_search_interval_hours', label: 'Search Interval (hours, 0=disabled)', type: 'number', placeholder: '24', tab: 'Automation',
     description: 'Interval für automatische Provider-Suche. 0 = deaktiviert.',
@@ -1138,6 +1149,11 @@ function SettingsPageInner() {
               <SettingsCard title="Suchplanung"
                 description="Zeitgesteuerte Provider-Suche">
                 {['wanted_search_interval_hours','wanted_search_on_startup','wanted_search_max_items_per_run']
+                  .map(k => FIELDS.find(f => f.key === k)!).filter(Boolean).map(renderField)}
+              </SettingsCard>
+              <SettingsCard title="Stream Removal / Remux"
+                description="Einstellungen für das Entfernen von Subtitle-Streams aus Video-Containern">
+                {['remux_trash_dir','remux_backup_retention_days','remux_use_reflink','remux_arr_pause_enabled']
                   .map(k => FIELDS.find(f => f.key === k)!).filter(Boolean).map(renderField)}
               </SettingsCard>
             </div>


### PR DESCRIPTION
## Summary

- **Remux engine** (`backend/remux/`) — mkvmerge for MKV/MK3D, ffmpeg for all other containers; auto-detected by extension
- **Verification pipeline** — ffprobe comparison after remux (duration ±2s, video/audio stream counts, subtitle count exactly -1, file size ≥50% of original)
- **Trash-folder backup** — TinyMediaManager-style centralized backup in `<media_root>/.sublarr/trash/<YYYY-MM-DD>/<file>.<ts>.bak`; absolute path supported; falls back to sibling `.bak` on permission error
- **Configurable retention** — `remux_backup_retention_days` (default 7); `POST /api/v1/remux/backups/cleanup` deletes old backups; `dry_run` mode available
- **Async job system** — `ThreadPoolExecutor`, in-memory job dict, Socket.IO `remux_job_update` events
- **Undo/restore** — `POST /api/v1/remux/backups/restore` validates both paths with `is_safe_path()` and atomically restores via `os.replace()`
- **Settings** — 4 new fields in Automation tab (`remux_trash_dir`, `remux_backup_retention_days`, `remux_use_reflink`, `remux_arr_pause_enabled`)
- **TrackPanel UI** — two-click confirm → async polling → "Rückgängig" button → restore; full state machine

## New API Endpoints

```
POST /api/v1/library/episodes/<ep_id>/tracks/<index>/remove-from-container
GET  /api/v1/remux/jobs
GET  /api/v1/remux/jobs/<job_id>
GET  /api/v1/remux/backups
POST /api/v1/remux/backups/cleanup
POST /api/v1/remux/backups/restore
```

## Test plan

- [x] 20 backend tests — `_detect_backend`, `_verify`, `remove_subtitle_stream`, `backup_cleanup`, `_make_backup`
- [x] ruff check + format clean
- [x] eslint 0 errors
- [x] TypeScript noEmit clean