### PR TITLE
fix: add mkvtoolnix to Dockerfile for MKV stream removal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ LABEL org.opencontainers.image.version="${VERSION}"
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ffmpeg \
+        mkvtoolnix \
         curl \
         unrar-free \
         postgresql-client \


### PR DESCRIPTION
## Summary

- Added `mkvtoolnix` to the Docker apt-get install step
- Required for the v0.19.0 stream removal feature: mkvmerge is used as the backend for MKV/MK3D containers
- ffmpeg was already present (handles MP4/AVI and other containers)

## Test plan

- [x] Dockerfile updated with `mkvtoolnix` in apt-get
- [ ] Docker build succeeds with mkvtoolnix installed
- [ ] `mkvmerge --version` works inside container