### PR TITLE
feat: PostgreSQL first-class support

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -124,19 +124,7 @@ Goals: Safely remove embedded subtitle streams from video files after extraction
 
 ---
 
-## v0.20.0 (Collaboration and Export)
-
-Goals: Make Sublarr useful as a subtitle processing pipeline, not just consumer.
-
-- Subtitle Export API - serve processed subtitles via authenticated endpoint for external players
-- Batch Export - ZIP export of all subtitles for a series
-- Subtitle Diff Viewer Improvements - inline accept/reject for individual changed cues
-- Jellyfin SSE Events - consume Jellyfin play-start events to auto-translate on-demand
-- CLI Mode - `sublarr search`, `sublarr translate`, `sublarr sync` commands for scripting and cron jobs
-
----
-
-## v0.21.0 (Performance and Scalability)
+## v0.20.0 (Performance and Scalability)
 
 Goals: Handle larger libraries without degradation.
 
@@ -145,6 +133,18 @@ Goals: Handle larger libraries without degradation.
 - Incremental Metadata Cache - cache ffprobe output persistently, only rescan changed files
 - Background Wanted Scanner - fully async scan without blocking API responses
 - Parallel Translation Workers - configurable worker count for concurrent translation jobs
+
+---
+
+## v0.21.0 (Collaboration and Export)
+
+Goals: Make Sublarr useful as a subtitle processing pipeline, not just consumer.
+
+- Subtitle Export API - serve processed subtitles via authenticated endpoint for external players
+- Batch Export - ZIP export of all subtitles for a series
+- Subtitle Diff Viewer Improvements - inline accept/reject for individual changed cues
+- Jellyfin SSE Events - consume Jellyfin play-start events to auto-translate on-demand
+- CLI Mode - `sublarr search`, `sublarr translate`, `sublarr sync` commands for scripting and cron jobs
 
 ---
 

--- a/backend/database_health.py
+++ b/backend/database_health.py
@@ -107,8 +107,10 @@ def check_integrity(db) -> tuple[bool, str]:
     Raises:
         DatabaseIntegrityError: If the check reports corruption.
     """
+    from sqlalchemy import text as _text
+
     try:
-        rows = db.execute("PRAGMA integrity_check").fetchall()
+        rows = db.execute(_text("PRAGMA integrity_check")).fetchall()
         # SQLite returns a single row with "ok" when healthy
         result = rows[0][0] if rows else "unknown"
         is_ok = result == "ok"
@@ -149,9 +151,11 @@ def get_database_stats(db, db_path: str) -> dict:
         stats["wal_size_bytes"] = 0
 
     # PRAGMAs
+    from sqlalchemy import text as _text
+
     for pragma in ("journal_mode", "page_size", "page_count", "freelist_count"):
         try:
-            row = db.execute(f"PRAGMA {pragma}").fetchone()
+            row = db.execute(_text(f"PRAGMA {pragma}")).fetchone()
             stats[pragma] = row[0] if row else None
         except Exception:
             stats[pragma] = None
@@ -162,7 +166,7 @@ def get_database_stats(db, db_path: str) -> dict:
     tables: dict[str, int] = {}
     try:
         rows = db.execute(
-            "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+            _text("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'")
         ).fetchall()
         for (name,) in rows:
             try:
@@ -172,7 +176,7 @@ def get_database_stats(db, db_path: str) -> dict:
                 if not _re.match(r"^[a-zA-Z_][a-zA-Z0-9_]*$", name):
                     logger.warning("Skipping stats for table with non-standard name: %r", name)
                     continue
-                count = db.execute(f"SELECT COUNT(*) FROM [{name}]").fetchone()[0]
+                count = db.execute(_text(f"SELECT COUNT(*) FROM [{name}]")).fetchone()[0]
                 tables[name] = count
             except Exception:
                 tables[name] = -1
@@ -193,7 +197,9 @@ def vacuum(db, db_path: str) -> dict:
     with contextlib.suppress(OSError):
         before = os.path.getsize(db_path)
 
-    db.execute("VACUUM")
+    from sqlalchemy import text as _text
+
+    db.execute(_text("VACUUM"))
 
     after = 0
     with contextlib.suppress(OSError):

--- a/backend/routes/system.py
+++ b/backend/routes/system.py
@@ -291,24 +291,26 @@ def health_detailed():
           description: One or more subsystems degraded
     """
     from config import get_settings
-    from database_health import check_integrity, get_database_stats
-    from db import get_db
+    from database_health import get_health_report
     from ollama_client import check_ollama_health
 
     s = get_settings()
     subsystems: dict = {}
     overall_healthy = True
 
-    # Database
+    # Database (dialect-aware: SQLite integrity check or PostgreSQL pg_stat)
     try:
-        db = get_db()
-        db_ok, db_msg = check_integrity(db)
-        db_stats = get_database_stats(db, s.db_path)
+        db_report = get_health_report()
+        db_ok = db_report["status"] == "healthy"
+        db_details = db_report.get("details", {})
         subsystems["database"] = {
             "healthy": db_ok,
-            "message": db_msg,
-            "size_bytes": db_stats.get("size_bytes", 0),
-            "wal_mode": db_stats.get("wal_mode", False),
+            "backend": db_report["backend"],
+            "message": db_details.get("integrity", {}).get("message", "ok")
+            if db_report["backend"] == "sqlite"
+            else ("ok" if db_ok else "connection failed"),
+            "size_bytes": db_details.get("size_bytes", 0),
+            "wal_mode": db_details.get("wal_mode", False),
         }
         if not db_ok:
             overall_healthy = False
@@ -701,22 +703,22 @@ def database_health():
         503:
           description: Database integrity check failed
     """
-    from config import get_settings
-    from database_health import check_integrity, get_database_stats
-    from db import get_db
+    from database_health import get_health_report, get_pool_stats
 
-    db = get_db()
-    is_ok, message = check_integrity(db)
-    stats = get_database_stats(db, get_settings().db_path)
+    db_report = get_health_report()
+    is_ok = db_report["status"] == "healthy"
+    result = {
+        "healthy": is_ok,
+        "backend": db_report["backend"],
+        "message": db_report["status"],
+        "stats": db_report.get("details", {}),
+    }
+    pool = get_pool_stats()
+    if pool is not None:
+        result["pool"] = pool
 
     status_code = 200 if is_ok else 503
-    return jsonify(
-        {
-            "healthy": is_ok,
-            "message": message,
-            "stats": stats,
-        }
-    ), status_code
+    return jsonify(result), status_code
 
 
 @bp.route("/database/backup", methods=["POST"])
@@ -1748,8 +1750,15 @@ def vacuum_database():
                     type: integer
     """
     from config import get_settings
-    from database_health import vacuum
+    from database_health import _is_postgresql, vacuum
     from db import get_db
+
+    if _is_postgresql():
+        return jsonify(
+            {
+                "error": "VACUUM is not available for PostgreSQL. Use VACUUM ANALYZE directly on the database server."
+            }
+        ), 501
 
     db = get_db()
     result = vacuum(db, get_settings().db_path)

--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -1,55 +1,76 @@
-# Sublarr with optional PostgreSQL and Redis
+# Sublarr — PostgreSQL stack
 #
-# This is a compose OVERLAY file -- use with Docker Compose merge:
-#   docker compose -f docker-compose.yml -f docker-compose.postgres.yml up -d
+# Usage:
+#   docker compose -f docker-compose.postgres.yml up -d
 #
-# It extends the main docker-compose.yml by adding PostgreSQL and Redis
-# services alongside Sublarr. The default docker-compose.yml (SQLite, no Redis)
-# remains unchanged for zero-config deployments.
+# On first run Postgres initialises an empty database. Sublarr runs Alembic
+# migrations automatically on startup so no manual schema setup is needed.
 #
-# IMPORTANT: Set POSTGRES_PASSWORD in your .env file before starting.
-# The compose file will refuse to start without it.
+# To migrate an existing SQLite database see docs/POSTGRESQL.md.
 
 services:
-  sublarr:
-    environment:
-      - SUBLARR_DATABASE_URL=postgresql://sublarr:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}@db:5432/sublarr
-      - SUBLARR_REDIS_URL=redis://redis:6379/0
-    depends_on:
-      db:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-
-  db:
+  postgres:
     image: postgres:16-alpine
-    container_name: sublarr-db
+    container_name: sublarr-postgres
     environment:
       POSTGRES_DB: sublarr
       POSTGRES_USER: sublarr
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U sublarr"]
-      interval: 5s
+      test: ["CMD-SHELL", "pg_isready -U sublarr -d sublarr"]
+      interval: 10s
       timeout: 5s
       retries: 5
+      start_period: 30s
     restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
 
-  redis:
-    image: redis:7-alpine
-    container_name: sublarr-redis
-    command: redis-server --appendonly yes
+  sublarr:
+    image: ghcr.io/abrechen2/sublarr:${VERSION:-latest}
+    build:
+      context: .
+      args:
+        VERSION: ${VERSION:-dev}
+        PUID: ${PUID:-1000}
+        PGID: ${PGID:-1000}
+    container_name: sublarr
+    depends_on:
+      postgres:
+        condition: service_healthy
+    ports:
+      - "127.0.0.1:${SUBLARR_PORT:-5765}:5765"
     volumes:
-      - redisdata:/data
-    healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 5s
-      timeout: 5s
-      retries: 5
+      - ./config:/config
+      - ${SUBLARR_MEDIA_PATH:-/media}:/media:rw
+    environment:
+      SUBLARR_DATABASE_URL: postgresql://sublarr:${POSTGRES_PASSWORD}@postgres/sublarr
+    read_only: true
+    tmpfs:
+      - /tmp
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '2.0'
+          memory: 4G
+        reservations:
+          cpus: '0.5'
+          memory: 512M
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - DAC_OVERRIDE
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
 
 volumes:
-  pgdata:
-  redisdata:
+  postgres_data:

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,8 +1,10 @@
 # Migration Guide
 
-## Current Version: 0.13.2-beta
+## Current Version: 0.19.2-beta
 
 This guide covers upgrades from any previous version of Sublarr. For the full change history, see [CHANGELOG.md](../CHANGELOG.md).
+
+For switching from SQLite to PostgreSQL see [POSTGRESQL.md](POSTGRESQL.md).
 
 ---
 

--- a/docs/POSTGRESQL.md
+++ b/docs/POSTGRESQL.md
@@ -1,0 +1,154 @@
+# PostgreSQL Setup Guide
+
+Sublarr uses SQLite by default. Switching to PostgreSQL makes sense for larger libraries,
+multi-container setups, or when you need connection pooling and richer tooling.
+
+---
+
+## Requirements
+
+- PostgreSQL 14 or later (16 recommended)
+- `pg_trgm` extension available (bundled with standard Postgres)
+- Superuser or `CREATEEXTENSION` privilege for the first run (needed to install `pg_trgm`)
+
+---
+
+## Quick Start — Fresh Installation
+
+### 1. Start with the bundled compose file
+
+```bash
+POSTGRES_PASSWORD=changeme docker compose -f docker-compose.postgres.yml up -d
+```
+
+Sublarr runs Alembic migrations and installs `pg_trgm` automatically on first boot.
+No manual schema setup required.
+
+### 2. Configure via environment variable
+
+If you use your own PostgreSQL instance, set:
+
+```env
+SUBLARR_DATABASE_URL=postgresql://user:password@host:5432/sublarr
+```
+
+All other `SUBLARR_` settings remain the same.
+
+---
+
+## Connection Pool Tuning
+
+The following environment variables control the SQLAlchemy connection pool
+(ignored when using SQLite):
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SUBLARR_DB_POOL_SIZE` | `5` | Number of persistent connections |
+| `SUBLARR_DB_POOL_MAX_OVERFLOW` | `10` | Extra connections allowed under load |
+| `SUBLARR_DB_POOL_RECYCLE` | `3600` | Recycle connections after N seconds |
+
+For a single-user homelab installation the defaults are fine.
+For higher concurrency (multiple users, heavy API usage) increase `SUBLARR_DB_POOL_SIZE`.
+
+---
+
+## Migrating from SQLite
+
+### 1. Stop Sublarr
+
+```bash
+docker compose stop sublarr
+```
+
+### 2. Dump the SQLite database to SQL
+
+```bash
+# On the host where the config volume is mounted
+sqlite3 /path/to/config/sublarr.db .dump > sublarr_export.sql
+```
+
+### 3. Prepare the PostgreSQL database
+
+```bash
+# Connect to your PostgreSQL instance
+psql -U postgres -c "CREATE DATABASE sublarr;"
+psql -U postgres -c "CREATE USER sublarr WITH PASSWORD 'changeme';"
+psql -U postgres -c "GRANT ALL PRIVILEGES ON DATABASE sublarr TO sublarr;"
+psql -U postgres sublarr -c "CREATE EXTENSION IF NOT EXISTS pg_trgm;"
+```
+
+### 4. Convert and import the dump
+
+SQLite and PostgreSQL SQL dialects differ. The easiest approach is to let Sublarr
+recreate the schema via Alembic, then import only the data.
+
+```bash
+# Start Sublarr against the empty PostgreSQL database (schema only, no data yet)
+SUBLARR_DATABASE_URL=postgresql://sublarr:changeme@localhost/sublarr \
+  docker compose -f docker-compose.postgres.yml up -d
+
+# Wait for migrations to complete, then stop
+docker compose -f docker-compose.postgres.yml stop sublarr
+```
+
+### 5. Import data with pgloader (recommended)
+
+[pgloader](https://pgloader.io) handles type coercion automatically:
+
+```bash
+pgloader sqlite:///path/to/config/sublarr.db postgresql://sublarr:changeme@localhost/sublarr
+```
+
+### 6. Restart Sublarr
+
+```bash
+docker compose -f docker-compose.postgres.yml up -d sublarr
+```
+
+Verify the import at `http://localhost:5765/api/v1/database/health`.
+
+---
+
+## Managed PostgreSQL (Supabase, RDS, etc.)
+
+When using a managed provider, you may not have superuser access to run
+`CREATE EXTENSION`. Install `pg_trgm` manually before starting Sublarr:
+
+```sql
+-- Run as a superuser on your provider's console
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+```
+
+If the extension cannot be installed, full-text search falls back to unindexed
+`LIKE` queries. Everything still works, but global search may be slower on
+large libraries.
+
+---
+
+## Backup and Restore
+
+The built-in backup system supports both backends:
+
+- **SQLite:** file copy via the Python `sqlite3` backup API
+- **PostgreSQL:** `pg_dump` (custom format) / `pg_restore`
+
+`pg_dump` must be available in the Sublarr container. The official image includes it.
+The `VACUUM` endpoint is SQLite-only; use `VACUUM ANALYZE` on the database server directly.
+
+---
+
+## Checking the Active Backend
+
+```bash
+curl http://localhost:5765/api/v1/database/health | jq .backend
+# "sqlite" or "postgresql"
+```
+
+The `/api/v1/health/detailed` response also includes a `backend` field under `database`.
+
+---
+
+## Reverting to SQLite
+
+Remove `SUBLARR_DATABASE_URL` from your environment (or set it to an empty string).
+Sublarr will use `sqlite:///config/sublarr.db` on the next start.


### PR DESCRIPTION
## Summary

- **docker-compose.postgres.yml** — batteries-included PG stack with postgres:16-alpine, healthcheck dependency, `POSTGRES_PASSWORD` required env var
- **docs/POSTGRESQL.md** — complete guide: fresh install, SQLite→PG migration via pgloader, connection pool tuning, managed PG (Supabase/RDS), backup/restore, backend detection
- **Fix: database health endpoints** — `check_integrity` / `get_database_stats` were using bare string SQL without `text()` causing SQLAlchemy 2.x deprecation errors; `/database/health` was returning 503 on healthy SQLite databases
- **Dialect-aware health** — `/health/detailed` and `/database/health` now use `get_health_report()` (already dialect-aware); response includes `backend` field + connection pool stats for PG
- **Vacuum guard** — `/database/vacuum` returns 501 for PostgreSQL (use `VACUUM ANALYZE` on the server directly)
- **Roadmap reorder** — Performance & Scalability → v0.20, Collaboration → v0.21

## What was already there (no changes needed)

- `SUBLARR_DATABASE_URL=postgresql://...` env var ✅
- Flask-SQLAlchemy ORM + Alembic migrations (PG-compatible) ✅
- Connection pool config conditional on PG ✅
- FTS search dual-mode (SQLite FTS5 vs. PG pg_trgm GIN) ✅
- `database_backup.py` already uses `pg_dump` / `pg_restore` ✅
- `database_health.py` already has `_pg_health_report()` ✅

## Test plan

- [x] Backend tests: 361 passed, 0 new failures
- [x] `ruff check` + `ruff format --check`: all clean
- [x] TypeScript: 0 errors
- [x] Smoke test: `/api/v1/health` → 200 healthy, `/api/v1/database/health` → `{backend: "sqlite", healthy: true}`