### PR TITLE
fix: ffprobe cache — batch probe caching + cleanup endpoint

### DIFF
--- a/backend/db/cache.py
+++ b/backend/db/cache.py
@@ -27,6 +27,16 @@ def clear_ffprobe_cache(file_path: str = None):
     return _get_repo().clear_ffprobe_cache(file_path)
 
 
+def cleanup_stale_ffprobe_cache(dry_run: bool = False) -> dict:
+    """Remove cache entries for files that no longer exist on disk."""
+    return _get_repo().cleanup_stale_ffprobe_cache(dry_run=dry_run)
+
+
+def get_ffprobe_cache_stats() -> dict:
+    """Return statistics about the ffprobe cache table."""
+    return _get_repo().get_ffprobe_cache_stats()
+
+
 def get_episode_history(file_path: str) -> list:
     """Get combined download + job history for a file path."""
     return _get_repo().get_episode_history(file_path)

--- a/backend/db/repositories/cache.py
+++ b/backend/db/repositories/cache.py
@@ -92,6 +92,48 @@ class CacheRepository(BaseRepository):
             self.session.execute(delete(FfprobeCache))
         self._commit()
 
+    def cleanup_stale_ffprobe_cache(self, dry_run: bool = False) -> dict:
+        """Remove cache entries for files that no longer exist on disk.
+
+        Returns:
+            Dict with ``removed`` (int) and ``paths`` (list of removed paths).
+        """
+        import os
+
+        all_paths = self.session.execute(select(FfprobeCache.file_path)).scalars().all()
+        stale = [p for p in all_paths if not os.path.exists(p)]
+
+        if not dry_run and stale:
+            self.session.execute(delete(FfprobeCache).where(FfprobeCache.file_path.in_(stale)))
+            self._commit()
+            logger.info("Removed %d stale ffprobe cache entries", len(stale))
+
+        return {"removed": len(stale), "paths": stale, "dry_run": dry_run}
+
+    def get_ffprobe_cache_stats(self) -> dict:
+        """Return statistics about the ffprobe cache table."""
+        total = self.session.execute(select(func.count()).select_from(FfprobeCache)).scalar() or 0
+        oldest = self.session.execute(
+            select(FfprobeCache.cached_at).order_by(FfprobeCache.cached_at.asc()).limit(1)
+        ).scalar_one_or_none()
+        newest = self.session.execute(
+            select(FfprobeCache.cached_at).order_by(FfprobeCache.cached_at.desc()).limit(1)
+        ).scalar_one_or_none()
+        return {"total_entries": total, "oldest_entry": oldest, "newest_entry": newest}
+
+    def get_cache_stats(self) -> dict:
+        """Return combined cache statistics (provider cache + ffprobe cache)."""
+        from db.models.providers import ProviderCache
+
+        provider_total = (
+            self.session.execute(select(func.count()).select_from(ProviderCache)).scalar() or 0
+        )
+        ffprobe_stats = self.get_ffprobe_cache_stats()
+        return {
+            "provider_cache_entries": provider_total,
+            "ffprobe_cache": ffprobe_stats,
+        }
+
     # ---- Episode History (cross-table) ----------------------------------------
 
     def get_episode_history(self, file_path: str) -> list:

--- a/backend/routes/system.py
+++ b/backend/routes/system.py
@@ -1765,6 +1765,71 @@ def vacuum_database():
     return jsonify(result)
 
 
+@bp.route("/cache/ffprobe/stats", methods=["GET"])
+def ffprobe_cache_stats():
+    """Return ffprobe cache statistics.
+    ---
+    get:
+      tags:
+        - System
+      summary: FFprobe cache stats
+      description: Returns the number of cached ffprobe entries and timestamps.
+      security:
+        - apiKeyAuth: []
+      responses:
+        200:
+          description: Cache statistics
+    """
+    from db.cache import get_ffprobe_cache_stats
+
+    return jsonify(get_ffprobe_cache_stats())
+
+
+@bp.route("/cache/ffprobe/cleanup", methods=["POST"])
+def ffprobe_cache_cleanup():
+    """Remove stale ffprobe cache entries for files that no longer exist.
+    ---
+    post:
+      tags:
+        - System
+      summary: Clean up stale ffprobe cache entries
+      description: Deletes cache entries whose video files no longer exist on disk. Supports dry_run.
+      security:
+        - apiKeyAuth: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                dry_run:
+                  type: boolean
+                  default: false
+      responses:
+        200:
+          description: Cleanup result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  removed:
+                    type: integer
+                  dry_run:
+                    type: boolean
+                  paths:
+                    type: array
+                    items:
+                      type: string
+    """
+    from db.cache import cleanup_stale_ffprobe_cache
+
+    data = request.get_json() or {}
+    dry_run = bool(data.get("dry_run", False))
+    result = cleanup_stale_ffprobe_cache(dry_run=dry_run)
+    return jsonify(result)
+
+
 @bp.route("/logs", methods=["GET"])
 def get_logs():
     """Get recent log entries.

--- a/backend/routes/wanted.py
+++ b/backend/routes/wanted.py
@@ -1049,7 +1049,7 @@ def _run_batch_probe(items, app):
     try:
         with app.app_context(), ThreadPoolExecutor(max_workers=max_workers) as executor:
             future_to_item = {
-                executor.submit(get_media_streams, item["file_path"], False): item for item in items
+                executor.submit(get_media_streams, item["file_path"], True): item for item in items
             }
             for future in as_completed(future_to_item):
                 item = future_to_item[future]


### PR DESCRIPTION
## Summary

- **Fix batch probe cache** — `wanted.py:1052` had `use_cache=False`, meaning every batch scan re-ran ffprobe on all files regardless of whether they changed. Now uses the persistent cache (mtime-based invalidation).
- **Stale entry cleanup** — `POST /api/v1/cache/ffprobe/cleanup` removes cache entries for files that no longer exist on disk. Supports `dry_run: true` for preview.
- **Cache stats endpoint** — `GET /api/v1/cache/ffprobe/stats` returns total entry count and oldest/newest timestamps.
- **Wires `get_cache_stats()`** — pre-existing stub in `db/cache.py` now delegates to a real implementation covering both provider cache and ffprobe cache.

## Impact

Libraries with 500+ episodes will see significantly faster wanted scans since ffprobe (30s timeout per file) is now skipped for unchanged files during batch probing.

## Test plan

- [x] Backend tests: 361 passed, 0 new failures
- [x] `ruff check` + `ruff format --check`: clean
- [x] Smoke test: `GET /api/v1/cache/ffprobe/stats` → 200 with entry count; `POST /api/v1/cache/ffprobe/cleanup` with `dry_run: true` → correct stale paths listed