### PR TITLE
feat: configurable translation worker count + unified job queue routing

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -262,7 +262,10 @@ def create_app(testing=False):
         app.cache_backend = create_cache_backend(
             settings.redis_url if settings.redis_cache_enabled else ""
         )
-        app.job_queue = create_job_queue(settings.redis_url if settings.redis_queue_enabled else "")
+        app.job_queue = create_job_queue(
+            settings.redis_url if settings.redis_queue_enabled else "",
+            max_workers=getattr(settings, "translation_max_workers", 4),
+        )
 
         # Initialize database (legacy -- no-op now that SQLAlchemy handles lifecycle)
         from db import init_db

--- a/backend/config.py
+++ b/backend/config.py
@@ -117,6 +117,9 @@ class Settings(BaseSettings):
     scan_metadata_engine: str = "auto"  # "ffprobe" | "mediainfo" | "auto"
     scan_metadata_max_workers: int = 4  # Parallel workers for batch metadata scans
 
+    # Translation Workers
+    translation_max_workers: int = 4  # Parallel workers in the job queue thread pool
+
     # Wanted System
     wanted_scan_interval_hours: int = (
         0  # 0 = disabled; scan is event-driven (webhook / manual / file-watcher)

--- a/backend/job_queue/__init__.py
+++ b/backend/job_queue/__init__.py
@@ -110,7 +110,9 @@ class QueueBackend(ABC):
         """
 
 
-def create_job_queue(redis_url: str = "", queue_name: str = "sublarr") -> QueueBackend:
+def create_job_queue(
+    redis_url: str = "", queue_name: str = "sublarr", max_workers: int = 2
+) -> QueueBackend:
     """Factory function to create the appropriate job queue backend.
 
     If redis_url is provided, attempts to connect to Redis and import RQ.
@@ -120,6 +122,7 @@ def create_job_queue(redis_url: str = "", queue_name: str = "sublarr") -> QueueB
     Args:
         redis_url: Redis connection URL. Empty string means use memory fallback.
         queue_name: Queue name for RQ (default: "sublarr").
+        max_workers: Max concurrent worker threads for MemoryJobQueue (default: 2).
 
     Returns:
         A QueueBackend instance (RQ or Memory).
@@ -131,7 +134,7 @@ def create_job_queue(redis_url: str = "", queue_name: str = "sublarr") -> QueueB
             logger.info("redis package not installed, using memory job queue")
             from job_queue.memory_queue import MemoryJobQueue
 
-            return MemoryJobQueue()
+            return MemoryJobQueue(max_workers=max_workers)
 
         try:
             import rq  # noqa: F401
@@ -139,7 +142,7 @@ def create_job_queue(redis_url: str = "", queue_name: str = "sublarr") -> QueueB
             logger.info("rq package not installed, using memory job queue")
             from job_queue.memory_queue import MemoryJobQueue
 
-            return MemoryJobQueue()
+            return MemoryJobQueue(max_workers=max_workers)
 
         try:
             client = redis_lib.Redis.from_url(
@@ -156,4 +159,4 @@ def create_job_queue(redis_url: str = "", queue_name: str = "sublarr") -> QueueB
 
     from job_queue.memory_queue import MemoryJobQueue
 
-    return MemoryJobQueue()
+    return MemoryJobQueue(max_workers=max_workers)

--- a/backend/routes/translate.py
+++ b/backend/routes/translate.py
@@ -327,14 +327,7 @@ def translate_async():
 
     arr_context = _build_arr_context(data)
     job = create_job(file_path, force, arr_context)
-    _app = current_app._get_current_object()
-
-    def _run_with_ctx():
-        with _app.app_context():
-            _run_job(job)
-
-    thread = threading.Thread(target=_run_with_ctx, daemon=True)
-    thread.start()
+    current_app.job_queue.enqueue(_run_job, job, job_id=job["id"])
 
     return jsonify(
         {


### PR DESCRIPTION
## Summary
- Add `SUBLARR_TRANSLATION_MAX_WORKERS` setting (default: 4) — controls thread pool size for the in-memory job queue
- Add `max_workers` parameter to `create_job_queue()` factory so it's wired through to `MemoryJobQueue`
- Pass `settings.translation_max_workers` from `app.py` when initializing the queue at startup
- Replace bare `threading.Thread(daemon=True)` in `/translate` async endpoint with `job_queue.enqueue()` — now all async translation jobs are bounded by the shared thread pool (same as `/translate/sync`)

## Why
The `/translate` endpoint was spawning unbounded daemon threads, bypassing the `MemoryJobQueue` entirely. This meant the worker-count setting had no effect on async translate requests. Unifying both routes through the queue ensures concurrency is always bounded and observable via `GET /jobs`.

## Test plan
- [x] Backend tests green (73 passed)
- [x] `create_job_queue('', max_workers=4)` returns `max_workers: 4` in backend info
- [ ] Manually verify `GET /api/v1/jobs` reflects active/queued counts during concurrent translations
- [ ] Set `SUBLARR_TRANSLATION_MAX_WORKERS=2` and confirm only 2 jobs run in parallel