### PR TITLE
feat: Redis/RQ job queue with worker entry point

### DIFF
--- a/backend/worker.py
+++ b/backend/worker.py
@@ -1,0 +1,102 @@
+"""RQ worker entry point for Sublarr background jobs.
+
+Start this process alongside the main Flask app to enable persistent,
+Redis-backed job queuing. Each job runs inside a Flask application context
+so that db.session, config, and all Flask extensions are available.
+
+Usage:
+    python worker.py
+
+Configuration via environment variables (same as the main app):
+    SUBLARR_REDIS_URL   Redis connection URL (required)
+    SUBLARR_QUEUE_NAME  Queue name (default: sublarr)
+
+Docker:
+    Use docker-compose.redis.yml which configures the rq-worker service.
+    Scale workers with:
+        docker compose -f docker-compose.redis.yml up -d --scale rq-worker=N
+"""
+
+import logging
+import os
+import sys
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+class _AppContextWorker:
+    """Mixin that pushes a Flask app context around every RQ job.
+
+    Defined at module level so it is picklable (required by RQ).
+    """
+
+    _app = None
+
+    @classmethod
+    def set_app(cls, app):
+        cls._app = app
+
+    def perform_job(self, job, queue, *args, **kwargs):
+        if self._app is not None:
+            with self._app.app_context():
+                return super().perform_job(job, queue, *args, **kwargs)
+        return super().perform_job(job, queue, *args, **kwargs)
+
+
+def main():
+    from app import create_app
+
+    try:
+        from redis import Redis
+        from rq import Queue, Worker
+    except ImportError as exc:
+        logger.error("redis and rq packages are required: %s", exc)
+        sys.exit(1)
+
+    redis_url = os.environ.get("SUBLARR_REDIS_URL", "")
+    if not redis_url:
+        # Fall back to Pydantic settings so the same env var works
+        try:
+            from config import get_settings
+
+            redis_url = get_settings().redis_url
+        except Exception:
+            pass
+
+    if not redis_url:
+        logger.error(
+            "SUBLARR_REDIS_URL is not set. Set it to a Redis connection URL, "
+            "e.g. redis://localhost:6379/0"
+        )
+        sys.exit(1)
+
+    queue_name = os.environ.get("SUBLARR_QUEUE_NAME", "sublarr")
+
+    app = create_app()
+
+    try:
+        redis_conn = Redis.from_url(redis_url, socket_connect_timeout=10)
+        redis_conn.ping()
+    except Exception as exc:
+        logger.error("Cannot connect to Redis at %s: %s", redis_url, exc)
+        sys.exit(1)
+
+    # Build a Worker subclass with app context support
+    class AppContextWorker(_AppContextWorker, Worker):
+        pass
+
+    AppContextWorker.set_app(app)
+
+    queues = [Queue(queue_name, connection=redis_conn)]
+    worker = AppContextWorker(queues, connection=redis_conn)
+
+    logger.info("Sublarr RQ worker started — queue=%s  redis=%s", queue_name, redis_url)
+    worker.work(with_scheduler=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/docker-compose.redis.yml
+++ b/docker-compose.redis.yml
@@ -1,0 +1,124 @@
+# Sublarr — Redis + RQ Worker stack
+#
+# Usage:
+#   docker compose -f docker-compose.redis.yml up -d
+#
+# Enables persistent job queuing and Redis caching.
+# The rq-worker service dequeues and executes translation jobs.
+#
+# Scale workers (e.g. for parallel translation):
+#   docker compose -f docker-compose.redis.yml up -d --scale rq-worker=3
+#
+# Combine with PostgreSQL:
+#   docker compose -f docker-compose.postgres.yml -f docker-compose.redis.yml up -d
+#
+# See docs/REDIS.md for full setup instructions.
+
+services:
+  redis:
+    image: redis:7-alpine
+    container_name: sublarr-redis
+    # No persistence needed — job queue survives short Redis restarts via retry
+    command: redis-server --save "" --appendonly no --maxmemory 256mb --maxmemory-policy allkeys-lru
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "5m"
+        max-file: "2"
+
+  sublarr:
+    image: ghcr.io/abrechen2/sublarr:${VERSION:-latest}
+    build:
+      context: .
+      args:
+        VERSION: ${VERSION:-dev}
+        PUID: ${PUID:-1000}
+        PGID: ${PGID:-1000}
+    container_name: sublarr
+    depends_on:
+      redis:
+        condition: service_healthy
+    ports:
+      - "127.0.0.1:${SUBLARR_PORT:-5765}:5765"
+    volumes:
+      - ./config:/config
+      - ${SUBLARR_MEDIA_PATH:-/media}:/media:rw
+    environment:
+      SUBLARR_REDIS_URL: redis://redis:6379/0
+      SUBLARR_REDIS_QUEUE_ENABLED: "true"
+      SUBLARR_REDIS_CACHE_ENABLED: "true"
+    read_only: true
+    tmpfs:
+      - /tmp
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '2.0'
+          memory: 4G
+        reservations:
+          cpus: '0.5'
+          memory: 512M
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - DAC_OVERRIDE
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  rq-worker:
+    image: ghcr.io/abrechen2/sublarr:${VERSION:-latest}
+    build:
+      context: .
+      args:
+        VERSION: ${VERSION:-dev}
+        PUID: ${PUID:-1000}
+        PGID: ${PGID:-1000}
+    command: ["python", "worker.py"]
+    depends_on:
+      redis:
+        condition: service_healthy
+    volumes:
+      - ./config:/config
+      - ${SUBLARR_MEDIA_PATH:-/media}:/media:rw
+    environment:
+      SUBLARR_REDIS_URL: redis://redis:6379/0
+    read_only: true
+    tmpfs:
+      - /tmp
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '4.0'
+          memory: 8G
+        reservations:
+          cpus: '1.0'
+          memory: 1G
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - DAC_OVERRIDE
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"


### PR DESCRIPTION
## Summary
- Add \`backend/worker.py\`: RQ worker entry point with \`AppContextWorker\` subclass — each job runs inside a Flask app context so \`db.session\`, config, and all extensions are available
- Add \`docker-compose.redis.yml\`: batteries-included Redis 7 + Sublarr + \`rq-worker\` stack; scale workers with \`--scale rq-worker=N\` for parallel translation throughput
- Compose file auto-wires \`SUBLARR_REDIS_URL\`, \`SUBLARR_REDIS_QUEUE_ENABLED=true\`, \`SUBLARR_REDIS_CACHE_ENABLED=true\`
- Graceful fallback: if Redis is unreachable at startup, Sublarr logs a warning and uses \`MemoryJobQueue\` automatically (no user action needed)

## Architecture
```
sublarr (Flask)  →  enqueue()  →  Redis  →  rq-worker (worker.py)
                                             └── AppContextWorker.perform_job()
                                                 └── with app.app_context(): _run_job(job)
```

## Usage
```bash
# Start full stack
docker compose -f docker-compose.redis.yml up -d

# Scale to 3 parallel translation workers
docker compose -f docker-compose.redis.yml up -d --scale rq-worker=3

# Combine with PostgreSQL
POSTGRES_PASSWORD=secret \
docker compose -f docker-compose.postgres.yml -f docker-compose.redis.yml up -d
```

## Test plan
- [x] \`worker.py\` imports cleanly (\`python -c "import worker"\`)
- [x] Backend tests green
- [ ] Start Redis locally, set \`SUBLARR_REDIS_URL\`, start worker, submit translation job — verify job executes and status updates via \`GET /api/v1/jobs\`
- [ ] Stop Redis mid-run — verify Sublarr falls back to MemoryJobQueue on next start