### PR TITLE
feat: v0.21.1 UI/UX polish & accessibility

### DIFF
--- a/docs/superpowers/plans/2026-03-11-v0.21.1-ui-ux-polish.md
+++ b/docs/superpowers/plans/2026-03-11-v0.21.1-ui-ux-polish.md
@@ -1,0 +1,1203 @@
+# v0.21.1 UI/UX Polish & Accessibility Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix 14 UI/UX and accessibility issues across the frontend — no backend changes required.
+
+**Architecture:** Pure frontend refactor across ~18 component files. All changes isolated to `frontend/src/`. `@tanstack/react-virtual` is already installed (see `package.json`) and used in `pages/Logs.tsx` as a reference. Single PR to `master`.
+
+**Tech Stack:** React 19, TypeScript, Tailwind v4, Vitest + Testing Library, TanStack Virtual, Lucide React
+
+---
+
+## File Map
+
+| File | Changes |
+|------|---------|
+| `frontend/src/components/shared/StatusBadge.tsx` | Add icon per status (Task 1) |
+| `frontend/src/components/shared/Toast.tsx` | Add aria-live (Task 2) |
+| `frontend/src/App.tsx` | Skip link + main id + page-specific skeletons (Tasks 3, 9) |
+| `frontend/src/components/shared/PageSkeleton.tsx` | Add named skeleton variants (Task 9) |
+| `frontend/src/pages/History.tsx` | Add `scope="col"` to `<th>` (Task 4) |
+| `frontend/src/pages/Blacklist.tsx` | Add `scope="col"` to `<th>` (Task 4) |
+| `frontend/src/pages/Wanted.tsx` | Add `scope="col"` + stagger (Tasks 4, 10) |
+| `frontend/src/pages/Library.tsx` | Add `scope="col"` + tablet breakpoint + stagger + virtualizer (Tasks 4, 8, 10, 11) |
+| `frontend/src/components/layout/Sidebar.tsx` | Remove non-interactive div hover state (Task 5) |
+| `frontend/src/pages/Settings/providers/AddProviderModal.tsx` | Form labels + validation (Tasks 6, 7) |
+| `frontend/src/pages/Settings/providers/ProviderEditModal.tsx` | Form labels + validation (Tasks 6, 7) |
+| `frontend/src/components/editor/SubtitleEditorModal.tsx` | role="dialog" (Task 8) |
+| `frontend/src/components/dashboard/WidgetSettingsModal.tsx` | role="dialog" (Task 8) |
+| `frontend/src/components/search/GlobalSearchModal.tsx` | role="dialog" (Task 8) |
+| `frontend/src/components/shared/SubtitleCleanupModal.tsx` | role="dialog" (Task 8) |
+| `frontend/src/components/sync/SyncModal.tsx` | role="dialog" (Task 8) |
+| `frontend/src/pages/Settings/providers/AddProviderModal.tsx` | role="dialog" (Task 8) |
+| `frontend/src/pages/Settings/providers/ProviderEditModal.tsx` | role="dialog" (Task 8) |
+| `frontend/src/components/dashboard/widgets/StatCardsWidget.tsx` | CSS hover (Task 8) |
+| `frontend/src/components/dashboard/widgets/RecentActivityWidget.tsx` | CSS hover (Task 8) |
+| `frontend/src/components/shared/ThemeToggle.tsx` | CSS hover (Task 8) |
+| `frontend/src/components/shared/LanguageSwitcher.tsx` | CSS hover (Task 8) |
+| `frontend/src/pages/Settings/providers/ProviderTile.tsx` | CSS hover (Task 8) |
+| `frontend/src/index.css` | prefers-reduced-motion (Task 10) |
+| `frontend/src/test/StatusBadge.test.tsx` | Update for icons (Task 1) |
+| `frontend/src/test/Toast.test.tsx` | New — aria-live test (Task 2) |
+
+---
+
+## Chunk 1: Accessibility Foundations
+
+### Task 1: StatusBadge — Add Icons
+
+**Files:**
+- Modify: `frontend/src/components/shared/StatusBadge.tsx`
+- Modify: `frontend/src/test/StatusBadge.test.tsx`
+
+- [ ] **Step 1: Update test to expect icons**
+
+Replace `frontend/src/test/StatusBadge.test.tsx` with:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { StatusBadge } from '@/components/shared/StatusBadge'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key.split('.').pop() ?? key,
+    i18n: { language: 'en', changeLanguage: vi.fn() },
+  }),
+}))
+
+describe('StatusBadge', () => {
+  it('renders status text', () => {
+    render(<StatusBadge status="completed" />)
+    expect(screen.getByText('completed')).toBeInTheDocument()
+  })
+
+  it('renders different statuses', () => {
+    const { rerender } = render(<StatusBadge status="running" />)
+    expect(screen.getByText('running')).toBeInTheDocument()
+    rerender(<StatusBadge status="failed" />)
+    expect(screen.getByText('failed')).toBeInTheDocument()
+  })
+
+  it('applies custom className', () => {
+    const { container } = render(<StatusBadge status="completed" className="custom-class" />)
+    expect(container.firstChild).toHaveClass('custom-class')
+  })
+
+  it('renders an SVG icon for completed status', () => {
+    const { container } = render(<StatusBadge status="completed" />)
+    expect(container.querySelector('svg')).toBeInTheDocument()
+  })
+
+  it('renders an SVG icon for failed status', () => {
+    const { container } = render(<StatusBadge status="failed" />)
+    expect(container.querySelector('svg')).toBeInTheDocument()
+  })
+
+  it('renders an SVG icon for running status', () => {
+    const { container } = render(<StatusBadge status="running" />)
+    expect(container.querySelector('svg')).toBeInTheDocument()
+  })
+
+  it('renders an SVG icon for queued status', () => {
+    const { container } = render(<StatusBadge status="queued" />)
+    expect(container.querySelector('svg')).toBeInTheDocument()
+  })
+
+  it('renders an SVG icon for wanted status', () => {
+    const { container } = render(<StatusBadge status="wanted" />)
+    expect(container.querySelector('svg')).toBeInTheDocument()
+  })
+})
+```
+
+- [ ] **Step 2: Run test — expect failures on the 5 new icon tests**
+
+```bash
+cd frontend && npx vitest run --reporter=verbose src/test/StatusBadge.test.tsx
+```
+
+Expected: 3 pass (existing), 5 fail ("expected null not to be null" on SVG queries).
+
+- [ ] **Step 3: Implement icons in StatusBadge**
+
+Replace `frontend/src/components/shared/StatusBadge.tsx` content:
+
+```tsx
+import { cn } from '@/lib/utils'
+import { useTranslation } from 'react-i18next'
+import {
+  CheckCircle2,
+  XCircle,
+  Clock,
+  Loader2,
+  AlertCircle,
+  Search,
+  MinusCircle,
+} from 'lucide-react'
+
+interface StatusBadgeProps {
+  status: string
+  className?: string
+}
+
+const statusStyles: Record<string, { bg: string; text: string }> = {
+  healthy:          { bg: 'var(--success-bg)', text: 'var(--success)' },
+  completed:        { bg: 'var(--success-bg)', text: 'var(--success)' },
+  running:          { bg: 'var(--accent-bg)',  text: 'var(--accent)' },
+  queued:           { bg: 'var(--warning-bg)', text: 'var(--warning)' },
+  failed:           { bg: 'var(--error-bg)',   text: 'var(--error)' },
+  unhealthy:        { bg: 'var(--error-bg)',   text: 'var(--error)' },
+  wanted:           { bg: 'var(--warning-bg)', text: 'var(--warning)' },
+  searching:        { bg: 'var(--accent-bg)',  text: 'var(--accent)' },
+  found:            { bg: 'var(--success-bg)', text: 'var(--success)' },
+  extracted:        { bg: 'rgba(20,184,166,0.12)',  text: 'rgb(20,184,166)' },
+  ignored:          { bg: 'rgba(124,130,147,0.08)', text: 'var(--text-muted)' },
+  'not configured': { bg: 'rgba(124,130,147,0.08)', text: 'var(--text-secondary)' },
+  skipped:          { bg: 'rgba(124,130,147,0.08)', text: 'var(--text-secondary)' },
+}
+
+const statusIcons: Record<string, typeof CheckCircle2> = {
+  healthy:          CheckCircle2,
+  completed:        CheckCircle2,
+  found:            CheckCircle2,
+  extracted:        CheckCircle2,
+  running:          Loader2,
+  queued:           Clock,
+  failed:           XCircle,
+  unhealthy:        XCircle,
+  wanted:           AlertCircle,
+  searching:        Search,
+  ignored:          MinusCircle,
+  skipped:          MinusCircle,
+  'not configured': MinusCircle,
+}
+
+const statusTranslationKeys: Record<string, string> = {
+  healthy: 'status.healthy',
+  completed: 'status.completed',
+  running: 'status.running',
+  queued: 'status.queued',
+  failed: 'status.failed',
+  unhealthy: 'status.unhealthy',
+  wanted: 'status.wanted',
+  searching: 'status.searching',
+  found: 'status.found',
+  extracted: 'status.extracted',
+  ignored: 'status.ignored',
+  'not configured': 'status.not_configured',
+  skipped: 'status.skipped',
+  online: 'status.online',
+  offline: 'status.offline',
+  enabled: 'status.enabled',
+  disabled: 'status.disabled',
+}
+
+export function StatusBadge({ status, className }: StatusBadgeProps) {
+  const { t } = useTranslation('common')
+  const key = status.toLowerCase()
+  const style = statusStyles[key] || statusStyles['not configured']
+  const Icon = statusIcons[key] || MinusCircle
+  const isRunning = key === 'running'
+  const translationKey = statusTranslationKeys[key]
+  const label = translationKey ? t(translationKey) : status
+
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-xs font-medium',
+        className
+      )}
+      style={{ backgroundColor: style.bg, color: style.text }}
+    >
+      <Icon
+        size={11}
+        strokeWidth={2.5}
+        className={isRunning ? 'animate-spin' : undefined}
+        aria-hidden="true"
+      />
+      {label}
+    </span>
+  )
+}
+
+/**
+ * Compact badge for subtitle type indication.
+ * Only renders for "forced" type -- "full" is the default and shows nothing.
+ */
+export function SubtitleTypeBadge({ subtitleType, className }: { subtitleType: string; className?: string }) {
+  const { t } = useTranslation('common')
+  if (subtitleType !== 'forced') return null
+
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center px-1.5 py-0.5 rounded-full text-xs font-medium',
+        className
+      )}
+      style={{ backgroundColor: 'var(--accent-bg)', color: 'var(--accent)' }}
+    >
+      {t('status.forced', 'Forced')}
+    </span>
+  )
+}
+```
+
+- [ ] **Step 4: Run tests — all 8 must pass**
+
+```bash
+cd frontend && npx vitest run --reporter=verbose src/test/StatusBadge.test.tsx
+```
+
+Expected: 8/8 pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/shared/StatusBadge.tsx frontend/src/test/StatusBadge.test.tsx
+git commit -m "feat: add icons to StatusBadge for colorblind accessibility"
+```
+
+---
+
+### Task 2: Toast — `aria-live`
+
+**Files:**
+- Modify: `frontend/src/components/shared/Toast.tsx`
+- Create: `frontend/src/test/Toast.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/test/Toast.test.tsx`:
+
+```tsx
+import { describe, it, expect } from 'vitest'
+import { act } from '@testing-library/react'
+import { render } from '@testing-library/react'
+import { ToastContainer, toast } from '@/components/shared/Toast'
+
+describe('ToastContainer', () => {
+  it('renders a region with role=status and aria-live=polite when a toast fires', async () => {
+    const { getByRole } = render(<ToastContainer />)
+    await act(async () => {
+      toast('Hello world', 'success')
+    })
+    const statusEl = getByRole('status')
+    expect(statusEl).toHaveAttribute('aria-live', 'polite')
+    expect(statusEl).toHaveAttribute('aria-atomic', 'true')
+  })
+})
+```
+
+- [ ] **Step 2: Run test — expect failure**
+
+```bash
+cd frontend && npx vitest run --reporter=verbose src/test/Toast.test.tsx
+```
+
+Expected: FAIL — "Unable to find an accessible element with the role 'status'".
+
+- [ ] **Step 3: Add aria-live to ToastContainer**
+
+In `frontend/src/components/shared/Toast.tsx`, change line 68 from:
+
+```tsx
+<div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2">
+```
+
+to:
+
+```tsx
+<div
+  role="status"
+  aria-live="polite"
+  aria-atomic="true"
+  className="fixed bottom-4 right-4 z-50 flex flex-col gap-2"
+>
+```
+
+- [ ] **Step 4: Run test — expect pass**
+
+```bash
+cd frontend && npx vitest run --reporter=verbose src/test/Toast.test.tsx
+```
+
+Expected: 1/1 pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/shared/Toast.tsx frontend/src/test/Toast.test.tsx
+git commit -m "feat: add aria-live to ToastContainer for screen reader announcements"
+```
+
+---
+
+### Task 3: Skip-to-Main Link
+
+**Files:**
+- Modify: `frontend/src/App.tsx`
+- Create: `frontend/src/test/App.skiplink.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/test/App.skiplink.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+
+// Minimal mocks so App renders without full provider chain
+vi.mock('@/hooks/useWebSocket', () => ({ useWebSocket: () => ({}) }))
+vi.mock('@/hooks/useKeyboardShortcuts', () => ({ useKeyboardShortcuts: () => {} }))
+vi.mock('@/hooks/useApi', () => ({
+  useHealth: () => ({ data: null }),
+  useUpdateInfo: () => ({ data: null }),
+}))
+
+// Lazy imports in App.tsx require a full module mock for each page
+// Use a simpler approach: just check that the skip link is in the document
+describe('App skip link', () => {
+  it('renders a skip-to-main-content anchor before any page content', async () => {
+    // Dynamic import to avoid triggering React.lazy at module level
+    const { default: App } = await import('@/App')
+    render(<App />)
+    const link = document.querySelector('a[href="#main-content"]')
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveTextContent('Skip to main content')
+  })
+})
+```
+
+- [ ] **Step 2: Run test — expect failure**
+
+```bash
+cd frontend && npx vitest run --reporter=verbose src/test/App.skiplink.test.tsx
+```
+
+Expected: FAIL — querySelector returns null (skip link does not exist yet).
+
+- [ ] **Step 3: Add skip link and main id**
+
+In `frontend/src/App.tsx`, find the `return (` block of `App()` (line 132). Replace:
+
+```tsx
+    <BrowserRouter>
+      <GlobalWebSocketListener />
+      <GlobalShortcuts onToggleShortcutsModal={toggleShortcutsModal} />
+      <div className="flex min-h-screen">
+        <Sidebar />
+        <main className="flex-1 min-w-0 p-4 md:p-5 pt-16 md:pt-5 min-h-screen">
+```
+
+with:
+
+```tsx
+    <BrowserRouter>
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-[100] focus:px-4 focus:py-2 focus:rounded focus:text-sm focus:font-medium"
+        style={{ backgroundColor: 'var(--accent)', color: '#fff' }}
+      >
+        Skip to main content
+      </a>
+      <GlobalWebSocketListener />
+      <GlobalShortcuts onToggleShortcutsModal={toggleShortcutsModal} />
+      <div className="flex min-h-screen">
+        <Sidebar />
+        <main id="main-content" className="flex-1 min-w-0 p-4 md:p-5 pt-16 md:pt-5 min-h-screen">
+```
+
+- [ ] **Step 4: Run test — expect pass**
+
+```bash
+cd frontend && npx vitest run --reporter=verbose src/test/App.skiplink.test.tsx
+```
+
+Expected: 1/1 pass.
+
+- [ ] **Step 5: TypeScript check**
+
+```bash
+cd frontend && npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/App.tsx frontend/src/test/App.skiplink.test.tsx
+git commit -m "feat: add skip-to-main link for keyboard navigation accessibility"
+```
+
+---
+
+### Task 4: Semantic Tables — `scope="col"` + `aria-sort`
+
+**Files:**
+- Modify: `frontend/src/pages/History.tsx` (line ~424–443)
+- Modify: `frontend/src/pages/Blacklist.tsx` (line ~96–108)
+- Modify: `frontend/src/pages/Wanted.tsx` (line ~821–840)
+- Modify: `frontend/src/pages/Library.tsx` (line ~188–240, list-view table headers)
+
+Pattern to apply — every `<th>` must have `scope="col"`:
+
+```tsx
+// BEFORE
+<th className="text-left ...">Title</th>
+
+// AFTER
+<th scope="col" className="text-left ...">Title</th>
+```
+
+For `<th>` elements that trigger a sort on click, also add `aria-sort`:
+
+```tsx
+// AFTER (sortable column — Library.tsx uses `sortKey`/`sortDir` variables)
+<th
+  scope="col"
+  aria-sort={sortKey === 'date' ? (sortDir === 'asc' ? 'ascending' : 'descending') : 'none'}
+  className="text-left cursor-pointer ..."
+  onClick={() => handleSort('date')}
+>
+  Date
+</th>
+```
+
+Library.tsx uses `sortKey` and `sortDir` as the sort state variable names. If a page doesn't already track sort state, only add `scope="col"` — don't add `aria-sort` to non-sortable headers.
+
+- [ ] **Step 1: Add `scope="col"` to all `<th>` in History.tsx**
+
+In `History.tsx` lines 424–443, add `scope="col"` to every `<th>`. The checkbox column header can use `scope="col"` too.
+
+- [ ] **Step 2: Add `scope="col"` to all `<th>` in Blacklist.tsx**
+
+In `Blacklist.tsx` lines 96–108, add `scope="col"` to every `<th>`.
+
+- [ ] **Step 3: Add `scope="col"` to Wanted.tsx table**
+
+In `Wanted.tsx` line ~821, add `scope="col"` to every `<th>` in the table header row.
+
+- [ ] **Step 4: Add `scope="col"` + `aria-sort` to Library.tsx list-view table**
+
+In `Library.tsx`, find the list-view `<thead>` section (line ~189). Add `scope="col"` to all `<th>`. For `<th>` elements with `onClick` sort handlers (Title, Missing, Episodes columns have them — Profile does not), add `aria-sort` using the component's `sortKey` and `sortDir` state variables.
+
+- [ ] **Step 5: TypeScript check**
+
+```bash
+cd frontend && npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/pages/History.tsx frontend/src/pages/Blacklist.tsx \
+        frontend/src/pages/Wanted.tsx frontend/src/pages/Library.tsx
+git commit -m "feat: add semantic table scope and aria-sort for accessibility"
+```
+
+---
+
+### Task 5: Form Labels — Provider Modals
+
+**Important context:**
+- `AddProviderModal.tsx` is a **provider picker** (it lists available provider cards with a "Select" button — no `<input>` or `<select>` elements). Label work does NOT apply here. However, it still needs `role="dialog"` (Task 6) and validation (Task 7).
+- `ProviderEditModal.tsx` renders provider configuration fields via the `SettingRow` component (`import { SettingRow } from '@/components/shared/SettingRow'`). Read `SettingRow.tsx` to understand how its `id`/`htmlFor` wiring works before modifying `ProviderEditModal.tsx`.
+
+**Files:**
+- Modify: `frontend/src/pages/Settings/providers/ProviderEditModal.tsx` (only)
+- Read first: `frontend/src/components/shared/SettingRow.tsx`
+
+- [ ] **Step 1: Read SettingRow.tsx to understand the label abstraction**
+
+```bash
+cat frontend/src/components/shared/SettingRow.tsx
+```
+
+Look for: does `SettingRow` render a `<label>` with `htmlFor`? Does it accept an `id` prop for the input? This determines whether label wiring needs to happen inside `SettingRow` or inside `ProviderEditModal`.
+
+- [ ] **Step 2: Add labels to ProviderEditModal**
+
+If `SettingRow` renders a visible label but no `htmlFor`/`id` link: add `id` to the input prop and `htmlFor` to the label prop inside `SettingRow`.
+
+If fields in `ProviderEditModal` are raw `<input>` elements (not using `SettingRow`), wire `htmlFor` + `id` directly:
+
+```tsx
+// BEFORE
+<label className="text-xs ...">API Key</label>
+<input className="..." value={apiKey} onChange={...} />
+
+// AFTER
+<label htmlFor="provider-api-key" className="text-xs ...">API Key</label>
+<input id="provider-api-key" className="..." value={apiKey} onChange={...} />
+```
+
+For icon-only inputs with no visible label, use `aria-label`:
+```tsx
+<input aria-label="Search filter" ... />
+```
+
+- [ ] **Step 4: TypeScript check**
+
+```bash
+cd frontend && npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: TypeScript check**
+
+```bash
+cd frontend && npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/Settings/providers/ProviderEditModal.tsx
+git commit -m "feat: add accessible labels to provider modal form inputs"
+```
+
+---
+
+## Chunk 2: Modals, Forms, Performance
+
+### Task 6: Modal `role="dialog"`
+
+**Files:**
+- Modify: `frontend/src/components/editor/SubtitleEditorModal.tsx`
+- Modify: `frontend/src/components/dashboard/WidgetSettingsModal.tsx`
+- Modify: `frontend/src/components/search/GlobalSearchModal.tsx`
+- Modify: `frontend/src/components/shared/SubtitleCleanupModal.tsx`
+- Modify: `frontend/src/components/sync/SyncModal.tsx`
+- Modify: `frontend/src/pages/Settings/providers/AddProviderModal.tsx`
+- Modify: `frontend/src/pages/Settings/providers/ProviderEditModal.tsx`
+
+(`KeyboardShortcutsModal` and `InteractiveSearchModal` already have `role="dialog"` — skip.)
+
+Pattern to apply to each modal's root container div:
+
+```tsx
+// BEFORE
+<div className="fixed inset-0 z-50 flex items-center justify-center ...">
+  <div className="rounded-lg ...">
+    <h2 className="...">Modal Title</h2>
+    ...
+    <button onClick={onClose}>Close</button>
+  </div>
+</div>
+
+// AFTER
+<div className="fixed inset-0 z-50 flex items-center justify-center ...">
+  <div
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="modal-title"
+    className="rounded-lg ..."
+  >
+    <h2 id="modal-title" className="...">Modal Title</h2>
+    ...
+    <button autoFocus onClick={onClose}>Close</button>
+  </div>
+</div>
+```
+
+Rules:
+1. `role="dialog"` goes on the **inner** container (the visible card), not the overlay backdrop.
+2. `aria-labelledby` must match the `id` on the `<h2>` or `<h3>` title element.
+3. `autoFocus` goes on the **close button** (or primary action button if there's no close button).
+4. Each modal needs a **unique** `id` for the title (e.g., `"subtitle-editor-title"`, `"widget-settings-title"`, etc.).
+
+- [ ] **Step 1: Apply pattern to SubtitleEditorModal.tsx**
+
+Open the file, find the inner dialog card div, add `role="dialog"`, `aria-modal="true"`, `aria-labelledby`, add `id` to title `<h2>`/`<h3>`, add `autoFocus` to close button.
+
+- [ ] **Step 2: Apply to WidgetSettingsModal.tsx**
+
+Same pattern.
+
+- [ ] **Step 3: Apply to GlobalSearchModal.tsx**
+
+GlobalSearchModal may not have an explicit `<h2>` — use `aria-label="Global search"` instead of `aria-labelledby` if no title element exists:
+```tsx
+<div role="dialog" aria-modal="true" aria-label="Global search" ...>
+```
+
+- [ ] **Step 4: Apply to SubtitleCleanupModal.tsx, SyncModal.tsx**
+
+Same pattern per file.
+
+- [ ] **Step 5: Apply to AddProviderModal.tsx and ProviderEditModal.tsx**
+
+These files were already modified in Task 5 — add the dialog role attributes to the modal container in the same files.
+
+- [ ] **Step 6: TypeScript check**
+
+```bash
+cd frontend && npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/components/editor/SubtitleEditorModal.tsx \
+        frontend/src/components/dashboard/WidgetSettingsModal.tsx \
+        frontend/src/components/search/GlobalSearchModal.tsx \
+        frontend/src/components/shared/SubtitleCleanupModal.tsx \
+        frontend/src/components/sync/SyncModal.tsx \
+        frontend/src/pages/Settings/providers/AddProviderModal.tsx \
+        frontend/src/pages/Settings/providers/ProviderEditModal.tsx
+git commit -m "feat: add role=dialog and aria-modal to all modal components"
+```
+
+---
+
+### Task 7: Client-Side Validation
+
+**Files:**
+- Modify: `frontend/src/pages/Settings/providers/AddProviderModal.tsx`
+- Modify: `frontend/src/pages/Settings/providers/ProviderEditModal.tsx`
+
+Pattern — add validation state and inline error rendering:
+
+```tsx
+// Add to component state:
+const [errors, setErrors] = useState<Record<string, string>>({})
+
+// Validate on blur:
+const validateName = (value: string) => {
+  if (!value.trim()) {
+    setErrors(prev => ({ ...prev, name: 'Provider name is required' }))
+  } else {
+    setErrors(prev => { const { name, ...rest } = prev; return rest })
+  }
+}
+
+// Validate all on submit:
+const handleSubmit = () => {
+  const newErrors: Record<string, string> = {}
+  if (!name.trim()) newErrors.name = 'Provider name is required'
+  if (!url.trim()) newErrors.url = 'URL is required'
+  if (Object.keys(newErrors).length > 0) {
+    setErrors(newErrors)
+    return
+  }
+  // proceed with save
+}
+
+// Render inline error below each required input:
+<input
+  id="provider-name"
+  aria-describedby={errors.name ? 'provider-name-error' : undefined}
+  aria-invalid={!!errors.name}
+  onBlur={(e) => validateName(e.target.value)}
+  ...
+/>
+{errors.name && (
+  <p id="provider-name-error" role="alert" className="text-xs mt-1" style={{ color: 'var(--error)' }}>
+    {errors.name}
+  </p>
+)}
+```
+
+- [ ] **Step 1: Identify required fields in AddProviderModal**
+
+Read `AddProviderModal.tsx` and identify which fields are submitted to the backend. At minimum: provider name and URL/host. Note the current submit handler function name.
+
+- [ ] **Step 2: Add validation state and inline errors to AddProviderModal**
+
+Add `errors` state, `onBlur` validators, and inline error `<p role="alert">` for required fields. Add all-field validation to the submit handler.
+
+- [ ] **Step 3: Repeat for ProviderEditModal**
+
+Apply the same pattern to the equivalent fields in `ProviderEditModal.tsx`.
+
+- [ ] **Step 4: TypeScript check**
+
+```bash
+cd frontend && npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/Settings/providers/AddProviderModal.tsx \
+        frontend/src/pages/Settings/providers/ProviderEditModal.tsx
+git commit -m "feat: add client-side validation UI to provider modals"
+```
+
+---
+
+### Task 8: CSS Hover — Remove JS Hover State
+
+**Files (bounded scope — pure visual hover only):**
+- `frontend/src/components/dashboard/widgets/StatCardsWidget.tsx`
+- `frontend/src/components/dashboard/widgets/RecentActivityWidget.tsx`
+- `frontend/src/components/shared/ThemeToggle.tsx`
+- `frontend/src/components/shared/LanguageSwitcher.tsx`
+- `frontend/src/pages/Settings/providers/ProviderTile.tsx`
+
+Pattern — replace JS hover state used only for background/border styling:
+
+```tsx
+// BEFORE
+const [hovered, setHovered] = useState(false)
+<div
+  onMouseEnter={() => setHovered(true)}
+  onMouseLeave={() => setHovered(false)}
+  style={{ backgroundColor: hovered ? 'var(--bg-surface-hover)' : 'var(--bg-surface)' }}
+>
+
+// AFTER
+<div className="transition-colors" style={{ backgroundColor: 'var(--bg-surface)' }}
+  // Add CSS: .element:hover { background-color: var(--bg-surface-hover); }
+  // OR use a Tailwind variant if the CSS var is mapped:
+>
+```
+
+Since Tailwind v4 doesn't have direct access to CSS custom property values in `hover:` utilities, the cleanest approach for CSS var hover is to add an inline style or use a CSS class:
+
+```tsx
+// Option A: inline style with CSS var (works in modern browsers)
+<div
+  className="transition-colors"
+  onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = 'var(--bg-surface-hover)')}
+  onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = '')}
+>
+```
+
+Wait — that's still JS. Better option:
+
+```tsx
+// Option B: Add a utility class in index.css
+// .hover-surface:hover { background-color: var(--bg-surface-hover); }
+// Then use:
+<div className="hover-surface transition-colors">
+```
+
+If the project already has `hover:bg-*` Tailwind classes mapped to CSS vars, use those. Otherwise, use Option B — add `.hover-surface` to `index.css` and apply it.
+
+Check `frontend/src/index.css` for existing hover utilities before deciding. If no pattern exists, add one utility class per color you need:
+
+```css
+/* In index.css */
+.hover-surface:hover {
+  background-color: var(--bg-surface-hover);
+}
+.hover-elevated:hover {
+  background-color: var(--bg-elevated);
+}
+```
+
+- [ ] **Step 1: Check index.css for existing hover CSS var utilities**
+
+Read `frontend/src/index.css` and search for `.hover-` classes or Tailwind config hover mappings.
+
+- [ ] **Step 2: Add hover utilities to index.css if needed**
+
+Add `.hover-surface` and `.hover-elevated` classes if they don't already exist.
+
+- [ ] **Step 3: Refactor StatCardsWidget.tsx**
+
+Find `onMouseEnter`/`onMouseLeave` patterns used only for hover styling. Remove the `useState(false)` hover state variable and associated handlers. Apply `.hover-surface` class or equivalent.
+
+- [ ] **Step 4: Refactor RecentActivityWidget.tsx, ThemeToggle.tsx, LanguageSwitcher.tsx, ProviderTile.tsx**
+
+Repeat for each file.
+
+- [ ] **Step 5: TypeScript check**
+
+```bash
+cd frontend && npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/index.css \
+        frontend/src/components/dashboard/widgets/StatCardsWidget.tsx \
+        frontend/src/components/dashboard/widgets/RecentActivityWidget.tsx \
+        frontend/src/components/shared/ThemeToggle.tsx \
+        frontend/src/components/shared/LanguageSwitcher.tsx \
+        frontend/src/pages/Settings/providers/ProviderTile.tsx
+git commit -m "refactor: replace JS hover state with CSS hover utilities"
+```
+
+---
+
+### Task 9: Page Skeletons + Tablet Breakpoints
+
+**Files:**
+- Modify: `frontend/src/components/shared/PageSkeleton.tsx`
+- Modify: `frontend/src/App.tsx`
+- Modify: `frontend/src/pages/Library.tsx` (line 891)
+
+- [ ] **Step 1: Add skeleton variants to PageSkeleton.tsx**
+
+Append named exports to `frontend/src/components/shared/PageSkeleton.tsx` (keep existing `PageSkeleton` default at top, add below):
+
+```tsx
+const pulse = 'animate-pulse rounded'
+const bg1 = { backgroundColor: 'var(--bg-surface)' }
+const bg2 = { backgroundColor: 'rgba(124,130,147,0.08)' }
+
+/** Matches Library grid: grid-cols-3 sm:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8 */
+export function LibrarySkeleton() {
+  return (
+    <div className="space-y-4">
+      <div className={`h-7 w-40 ${pulse}`} style={bg2} />
+      <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6 xl:grid-cols-8 gap-3">
+        {Array.from({ length: 16 }).map((_, i) => (
+          <div key={i} className="space-y-1.5">
+            <div className={`aspect-[2/3] w-full ${pulse}`} style={bg1} />
+            <div className={`h-3 w-3/4 ${pulse}`} style={bg2} />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+/** 5-row table skeleton for History, Blacklist */
+export function TableSkeleton() {
+  return (
+    <div className="space-y-3">
+      <div className={`h-7 w-40 ${pulse}`} style={bg2} />
+      <div className={`rounded-lg overflow-hidden`} style={bg1}>
+        <div className="px-4 py-2.5 flex gap-4" style={{ borderBottom: '1px solid var(--border)' }}>
+          {[120, 80, 60, 80].map((w, i) => (
+            <div key={i} className={`h-3 ${pulse}`} style={{ ...bg2, width: w }} />
+          ))}
+        </div>
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="px-4 py-3 flex gap-4" style={{ borderBottom: '1px solid var(--border)' }}>
+            {[160, 90, 50, 90].map((w, j) => (
+              <div key={j} className={`h-3 ${pulse}`} style={{ ...bg2, width: w }} />
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+/** 8-row list skeleton for Wanted */
+export function ListSkeleton() {
+  const widths = [200, 160, 180, 140, 170, 155, 190, 145]
+  return (
+    <div className="space-y-3">
+      <div className={`h-7 w-40 ${pulse}`} style={bg2} />
+      <div className={`rounded-lg overflow-hidden`} style={bg1}>
+        {widths.map((w, i) => (
+          <div key={i} className="px-4 py-3 flex items-center gap-3" style={{ borderBottom: '1px solid var(--border)' }}>
+            <div className={`h-4 w-4 rounded-full ${pulse}`} style={bg2} />
+            <div className={`h-3 ${pulse}`} style={{ ...bg2, width: w }} />
+            <div className={`h-3 w-16 ml-auto ${pulse}`} style={bg2} />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+/** Form section skeleton for Settings */
+export function FormSkeleton() {
+  return (
+    <div className="space-y-6">
+      <div className={`h-7 w-40 ${pulse}`} style={bg2} />
+      {Array.from({ length: 4 }).map((_, i) => (
+        <div key={i} className="space-y-2">
+          <div className={`h-3 w-28 ${pulse}`} style={bg2} />
+          <div className={`h-9 w-full rounded ${pulse}`} style={bg1} />
+        </div>
+      ))}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Update App.tsx Suspense to use page-specific skeletons**
+
+In `frontend/src/App.tsx`, import the new skeleton variants at the top:
+
+```tsx
+import {
+  PageSkeleton,
+  LibrarySkeleton,
+  TableSkeleton,
+  ListSkeleton,
+  FormSkeleton,
+} from '@/components/shared/PageSkeleton'
+```
+
+The current `AnimatedRoutes` uses a single `<Suspense fallback={<PageSkeleton />}>` wrapping all routes. To support per-route skeletons, wrap individual routes in their own `<Suspense>`:
+
+```tsx
+function AnimatedRoutes() {
+  const location = useLocation()
+  return (
+    <div key={location.pathname} className="page-enter">
+      <Routes location={location}>
+        <Route path="/" element={<Suspense fallback={<PageSkeleton />}><Dashboard /></Suspense>} />
+        <Route path="/library" element={<Suspense fallback={<LibrarySkeleton />}><LibraryPage /></Suspense>} />
+        <Route path="/library/series/:id" element={<Suspense fallback={<PageSkeleton />}><SeriesDetailPage /></Suspense>} />
+        <Route path="/activity" element={<Suspense fallback={<PageSkeleton />}><ActivityPage /></Suspense>} />
+        <Route path="/wanted" element={<Suspense fallback={<ListSkeleton />}><WantedPage /></Suspense>} />
+        <Route path="/queue" element={<Suspense fallback={<TableSkeleton />}><QueuePage /></Suspense>} />
+        <Route path="/history" element={<Suspense fallback={<TableSkeleton />}><HistoryPage /></Suspense>} />
+        <Route path="/blacklist" element={<Suspense fallback={<TableSkeleton />}><BlacklistPage /></Suspense>} />
+        <Route path="/settings" element={<Suspense fallback={<FormSkeleton />}><SettingsPage /></Suspense>} />
+        <Route path="/statistics" element={<Suspense fallback={<PageSkeleton />}><StatisticsPage /></Suspense>} />
+        <Route path="/tasks" element={<Suspense fallback={<PageSkeleton />}><TasksPage /></Suspense>} />
+        <Route path="/plugins" element={<Suspense fallback={<PageSkeleton />}><PluginsPage /></Suspense>} />
+        <Route path="/logs" element={<Suspense fallback={<PageSkeleton />}><LogsPage /></Suspense>} />
+        <Route path="/onboarding" element={<Suspense fallback={<PageSkeleton />}><Onboarding /></Suspense>} />
+        <Route path="*" element={<Suspense fallback={<PageSkeleton />}><NotFoundPage /></Suspense>} />
+      </Routes>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 3: Fix Library grid tablet breakpoint**
+
+In `frontend/src/pages/Library.tsx` line 891, change:
+
+```tsx
+className="grid grid-cols-3 sm:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8 gap-3"
+```
+
+to:
+
+```tsx
+className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6 xl:grid-cols-8 gap-3"
+```
+
+- [ ] **Step 4: TypeScript check**
+
+```bash
+cd frontend && npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/shared/PageSkeleton.tsx \
+        frontend/src/App.tsx \
+        frontend/src/pages/Library.tsx
+git commit -m "feat: add page-specific skeletons and fix Library tablet breakpoint"
+```
+
+---
+
+### Task 10: `prefers-reduced-motion` + Stagger Animation Cap
+
+**Files:**
+- Modify: `frontend/src/index.css`
+- Modify: `frontend/src/pages/Library.tsx`
+- Modify: `frontend/src/pages/Wanted.tsx`
+
+- [ ] **Step 1: Add prefers-reduced-motion to index.css**
+
+Open `frontend/src/index.css`. At the end of the file, add:
+
+```css
+/* Respect user motion preferences */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+```
+
+- [ ] **Step 2: Add animationDelay cap to Library grid render**
+
+In `frontend/src/pages/Library.tsx`, find the grid-view map that renders library cards. Add `style={{ animationDelay: ... }}` to each card:
+
+```tsx
+// Before: items.map((item) => <LibraryGridCard key={item.id} item={item} />)
+// After:
+items.map((item, i) => (
+  <LibraryGridCard
+    key={item.id}
+    item={item}
+    style={{ animationDelay: `${Math.min(i * 30, 300)}ms` }}
+  />
+))
+```
+
+If `LibraryGridCard` doesn't accept a `style` prop, add `style?: React.CSSProperties` to its props interface and apply it to the root element.
+
+- [ ] **Step 3: Add animationDelay cap to Wanted list render**
+
+Same pattern in `frontend/src/pages/Wanted.tsx` for the items list.
+
+- [ ] **Step 4: TypeScript check**
+
+```bash
+cd frontend && npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/index.css frontend/src/pages/Library.tsx frontend/src/pages/Wanted.tsx
+git commit -m "feat: add prefers-reduced-motion support and stagger animation cap"
+```
+
+---
+
+### Task 11: List Virtualization
+
+**Files:**
+- Modify: `frontend/src/pages/Library.tsx` (list view only)
+- Modify: `frontend/src/pages/Wanted.tsx`
+
+Reference implementation: `frontend/src/pages/Logs.tsx` — read this file first to see the existing virtualization pattern used in this project.
+
+- [ ] **Step 1: Read Logs.tsx for the established virtualizer pattern**
+
+```bash
+grep -n "useVirtualizer\|rowVirtualizer\|parentRef\|virtualItems" frontend/src/pages/Logs.tsx
+```
+
+Note the pattern: `parentRef`, `useVirtualizer`, `getTotalSize()`, `getVirtualItems()`, and the outer/inner div sizing.
+
+- [ ] **Step 2: Apply virtualization to Library list view**
+
+In `Library.tsx`, find the **list view** render path (the view that shows rows, not the grid). Wrap in a virtualizer:
+
+```tsx
+import { useVirtualizer } from '@tanstack/react-virtual'
+import { useRef } from 'react'
+
+// Inside the component, before return:
+const parentRef = useRef<HTMLDivElement>(null)
+const rowVirtualizer = useVirtualizer({
+  count: displayedItems.length,
+  getScrollElement: () => parentRef.current,
+  estimateSize: () => 64,  // px — adjust to match actual list row height
+  overscan: 10,
+})
+
+// In JSX, replace the list render:
+<div
+  ref={parentRef}
+  data-testid="virtual-list"
+  style={{ height: '600px', overflow: 'auto' }}
+>
+  <div style={{ height: rowVirtualizer.getTotalSize(), position: 'relative' }}>
+    {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+      const item = displayedItems[virtualRow.index]
+      return (
+        <div
+          key={item.id}
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            width: '100%',
+            transform: `translateY(${virtualRow.start}px)`,
+          }}
+        >
+          {/* existing list row JSX for this item */}
+        </div>
+      )
+    })}
+  </div>
+</div>
+```
+
+The height `600px` should be replaced with a dynamic container height — look at how `Logs.tsx` handles this (likely `calc(100vh - Npx)`).
+
+- [ ] **Step 3: Apply virtualization to Wanted list**
+
+In `Wanted.tsx`, same approach. `estimateSize` should match the Wanted row height.
+
+- [ ] **Step 4: TypeScript check**
+
+```bash
+cd frontend && npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Run all frontend tests**
+
+```bash
+cd frontend && npm run test -- --run
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Final lint check**
+
+```bash
+cd frontend && npm run lint
+```
+
+Expected: no errors or warnings.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/pages/Library.tsx frontend/src/pages/Wanted.tsx
+git commit -m "feat: virtualize Library list view and Wanted list for performance"
+```
+
+---
+
+## Final Steps
+
+- [ ] **Run full test suite**
+
+```bash
+cd frontend && npm run test -- --run && npm run lint && npx tsc --noEmit
+```
+
+Expected: all pass, zero errors.
+
+- [ ] **Create PR**
+
+```bash
+git push -u origin feat/v0.21.1-ui-ux-polish
+gh pr create \
+  --title "feat: v0.21.1 UI/UX polish & accessibility" \
+  --body "$(cat <<'EOF'
+## Summary
+- Accessibility: aria-live on toasts, skip-to-main link, scope/aria-sort on tables, role=dialog on 7 modals, form labels on provider modals
+- Performance: list virtualization on Library + Wanted, prefers-reduced-motion support, stagger animation cap
+- Mobile: page-specific skeletons, Library tablet breakpoint fix
+- Code quality: remove JS hover state from 5 components, CSS hover utilities, client-side validation in provider modals, lucide icons on StatusBadge
+
+## Test plan
+- [ ] All vitest tests pass
+- [ ] TypeScript: zero errors
+- [ ] ESLint: zero errors
+- [ ] Manual: Tab through page, skip link works, modals receive focus on open
+- [ ] Manual: Library list view with 100+ series — smooth scroll
+- [ ] Manual: Resize to 768px — Library shows 5 columns
+- [ ] Manual: Add provider with empty name — inline error appears without API call
+EOF
+)"
+```

--- a/docs/superpowers/plans/2026-03-11-v0.21.1-ui-ux-polish.md
+++ b/docs/superpowers/plans/2026-03-11-v0.21.1-ui-ux-polish.md
@@ -637,7 +637,58 @@ Same pattern per file.
 
 These files were already modified in Task 5 — add the dialog role attributes to the modal container in the same files.
 
-- [ ] **Step 6: TypeScript check**
+- [ ] **Step 6: Write tests for role=dialog on 2 representative modals**
+
+Create `frontend/src/test/ModalAccessibility.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import { SyncModal } from '@/components/sync/SyncModal'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key.split('.').pop() ?? key,
+    i18n: { language: 'en', changeLanguage: vi.fn() },
+  }),
+}))
+
+// Test SyncModal (simpler modal with fewer external deps)
+describe('Modal accessibility attributes', () => {
+  it('SyncModal has role=dialog and aria-modal when open', () => {
+    const { container } = render(
+      <SyncModal
+        open={true}
+        onClose={() => {}}
+        filePath="/test/file.ass"
+      />
+    )
+    const dialog = container.querySelector('[role="dialog"]')
+    expect(dialog).toBeInTheDocument()
+    expect(dialog).toHaveAttribute('aria-modal', 'true')
+  })
+})
+```
+
+Note: If `SyncModal` requires props that are hard to mock, try `GlobalSearchModal` instead (it accepts `open` and `onOpenChange` props). The goal is to assert at least one modal component renders `role="dialog"` after the changes.
+
+- [ ] **Step 7: Run the test — expect failure before implementation**
+
+```bash
+cd frontend && npx vitest run --reporter=verbose src/test/ModalAccessibility.test.tsx
+```
+
+Expected: FAIL — `querySelector('[role="dialog"]')` returns null.
+
+- [ ] **Step 8: Run again after implementation (Steps 1–5) — expect pass**
+
+```bash
+cd frontend && npx vitest run --reporter=verbose src/test/ModalAccessibility.test.tsx
+```
+
+Expected: 1/1 pass.
+
+- [ ] **Step 9: TypeScript check**
 
 ```bash
 cd frontend && npx tsc --noEmit
@@ -645,7 +696,7 @@ cd frontend && npx tsc --noEmit
 
 Expected: no errors.
 
-- [ ] **Step 7: Commit**
+- [ ] **Step 10: Commit**
 
 ```bash
 git add frontend/src/components/editor/SubtitleEditorModal.tsx \
@@ -654,7 +705,8 @@ git add frontend/src/components/editor/SubtitleEditorModal.tsx \
         frontend/src/components/shared/SubtitleCleanupModal.tsx \
         frontend/src/components/sync/SyncModal.tsx \
         frontend/src/pages/Settings/providers/AddProviderModal.tsx \
-        frontend/src/pages/Settings/providers/ProviderEditModal.tsx
+        frontend/src/pages/Settings/providers/ProviderEditModal.tsx \
+        frontend/src/test/ModalAccessibility.test.tsx
 git commit -m "feat: add role=dialog and aria-modal to all modal components"
 ```
 
@@ -662,9 +714,10 @@ git commit -m "feat: add role=dialog and aria-modal to all modal components"
 
 ### Task 7: Client-Side Validation
 
+**Important context:** `AddProviderModal.tsx` is a **provider picker** (shows available provider cards — no `<input>` fields to validate). Validation applies only to `ProviderEditModal.tsx`.
+
 **Files:**
-- Modify: `frontend/src/pages/Settings/providers/AddProviderModal.tsx`
-- Modify: `frontend/src/pages/Settings/providers/ProviderEditModal.tsx`
+- Modify: `frontend/src/pages/Settings/providers/ProviderEditModal.tsx` (only)
 
 Pattern — add validation state and inline error rendering:
 
@@ -673,19 +726,19 @@ Pattern — add validation state and inline error rendering:
 const [errors, setErrors] = useState<Record<string, string>>({})
 
 // Validate on blur:
-const validateName = (value: string) => {
+const validateField = (field: string, value: string, label: string) => {
   if (!value.trim()) {
-    setErrors(prev => ({ ...prev, name: 'Provider name is required' }))
+    setErrors(prev => ({ ...prev, [field]: `${label} is required` }))
   } else {
-    setErrors(prev => { const { name, ...rest } = prev; return rest })
+    setErrors(prev => { const { [field]: _, ...rest } = prev; return rest })
   }
 }
 
 // Validate all on submit:
 const handleSubmit = () => {
   const newErrors: Record<string, string> = {}
-  if (!name.trim()) newErrors.name = 'Provider name is required'
-  if (!url.trim()) newErrors.url = 'URL is required'
+  // Check required fields — read the file to determine exact field names
+  if (!fieldValues['host']?.trim()) newErrors.host = 'Host is required'
   if (Object.keys(newErrors).length > 0) {
     setErrors(newErrors)
     return
@@ -695,26 +748,26 @@ const handleSubmit = () => {
 
 // Render inline error below each required input:
 <input
-  id="provider-name"
-  aria-describedby={errors.name ? 'provider-name-error' : undefined}
-  aria-invalid={!!errors.name}
-  onBlur={(e) => validateName(e.target.value)}
+  id="provider-host"
+  aria-describedby={errors.host ? 'provider-host-error' : undefined}
+  aria-invalid={!!errors.host}
+  onBlur={(e) => validateField('host', e.target.value, 'Host')}
   ...
 />
-{errors.name && (
-  <p id="provider-name-error" role="alert" className="text-xs mt-1" style={{ color: 'var(--error)' }}>
-    {errors.name}
+{errors.host && (
+  <p id="provider-host-error" role="alert" className="text-xs mt-1" style={{ color: 'var(--error)' }}>
+    {errors.host}
   </p>
 )}
 ```
 
-- [ ] **Step 1: Identify required fields in AddProviderModal**
+- [ ] **Step 1: Read ProviderEditModal.tsx to identify required fields**
 
-Read `AddProviderModal.tsx` and identify which fields are submitted to the backend. At minimum: provider name and URL/host. Note the current submit handler function name.
+Read the file. Find fields that must be non-empty for the form to submit (typically the host/URL field). Note the current submit handler name and whether fields are controlled via `fieldValues` state or individual `useState` variables.
 
-- [ ] **Step 2: Add validation state and inline errors to AddProviderModal**
+- [ ] **Step 2: Add validation state and inline errors to ProviderEditModal**
 
-Add `errors` state, `onBlur` validators, and inline error `<p role="alert">` for required fields. Add all-field validation to the submit handler.
+Add `errors` state, `onBlur` validators on required fields, and inline `<p role="alert">` error messages. Add validation guard to the submit handler before the API call.
 
 - [ ] **Step 3: Repeat for ProviderEditModal**
 
@@ -731,9 +784,8 @@ Expected: no errors.
 - [ ] **Step 5: Commit**
 
 ```bash
-git add frontend/src/pages/Settings/providers/AddProviderModal.tsx \
-        frontend/src/pages/Settings/providers/ProviderEditModal.tsx
-git commit -m "feat: add client-side validation UI to provider modals"
+git add frontend/src/pages/Settings/providers/ProviderEditModal.tsx
+git commit -m "feat: add client-side validation UI to provider modal"
 ```
 
 ---
@@ -747,23 +799,24 @@ git commit -m "feat: add client-side validation UI to provider modals"
 - `frontend/src/components/shared/LanguageSwitcher.tsx`
 - `frontend/src/pages/Settings/providers/ProviderTile.tsx`
 
-Pattern — replace JS hover state used only for background/border styling:
+**Actual pattern in these files** — they already use direct DOM mutation (not `useState`):
 
 ```tsx
-// BEFORE
-const [hovered, setHovered] = useState(false)
+// ACTUAL BEFORE (in these files — no useState, direct DOM mutation)
 <div
-  onMouseEnter={() => setHovered(true)}
-  onMouseLeave={() => setHovered(false)}
-  style={{ backgroundColor: hovered ? 'var(--bg-surface-hover)' : 'var(--bg-surface)' }}
->
-
-// AFTER
-<div className="transition-colors" style={{ backgroundColor: 'var(--bg-surface)' }}
-  // Add CSS: .element:hover { background-color: var(--bg-surface-hover); }
-  // OR use a Tailwind variant if the CSS var is mapped:
+  onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = 'var(--bg-surface-hover)')}
+  onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = '')}
 >
 ```
+
+Replace with a CSS class that uses `:hover`:
+
+```tsx
+// AFTER — remove onMouseEnter/onMouseLeave, use CSS class
+<div className="hover-surface transition-colors">
+```
+
+**ProviderTile.tsx note:** This file has multiple hover patterns — some for background (`var(--bg-surface-hover)`) and some for icon button colors. Only replace **background hover** patterns. Leave icon color hover handlers in place (they change foreground color and may have non-trivial logic).
 
 Since Tailwind v4 doesn't have direct access to CSS custom property values in `hover:` utilities, the cleanest approach for CSS var hover is to add an inline style or use a CSS class:
 
@@ -971,7 +1024,22 @@ function AnimatedRoutes() {
 }
 ```
 
-- [ ] **Step 3: Fix Library grid tablet breakpoint**
+- [ ] **Step 3: TypeScript check**
+
+```bash
+cd frontend && npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit skeletons**
+
+```bash
+git add frontend/src/components/shared/PageSkeleton.tsx frontend/src/App.tsx
+git commit -m "feat: add page-specific loading skeletons per route"
+```
+
+- [ ] **Step 5: Fix Library grid tablet breakpoint**
 
 In `frontend/src/pages/Library.tsx` line 891, change:
 
@@ -985,21 +1053,11 @@ to:
 className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6 xl:grid-cols-8 gap-3"
 ```
 
-- [ ] **Step 4: TypeScript check**
+- [ ] **Step 6: Commit breakpoint fix separately**
 
 ```bash
-cd frontend && npx tsc --noEmit
-```
-
-Expected: no errors.
-
-- [ ] **Step 5: Commit**
-
-```bash
-git add frontend/src/components/shared/PageSkeleton.tsx \
-        frontend/src/App.tsx \
-        frontend/src/pages/Library.tsx
-git commit -m "feat: add page-specific skeletons and fix Library tablet breakpoint"
+git add frontend/src/pages/Library.tsx
+git commit -m "fix: add md tablet breakpoint to Library grid"
 ```
 
 ---

--- a/docs/superpowers/specs/2026-03-11-v0.21.1-ui-ux-polish-design.md
+++ b/docs/superpowers/specs/2026-03-11-v0.21.1-ui-ux-polish-design.md
@@ -1,0 +1,266 @@
+# v0.21.1 — UI/UX Polish & Accessibility Design
+
+> **For agentic workers:** Use `superpowers:subagent-driven-development` to implement this plan.
+
+**Goal:** Harden the frontend against accessibility failures, improve mobile usability, and fix interaction patterns across 15 targeted changes — no new features, no backend changes.
+
+**Architecture:** Pure frontend refactor. All changes in `frontend/src/`. No new dependencies except `@tanstack/react-virtual` for list virtualization. Single PR targeting `master`.
+
+**Tech Stack:** React 19, TypeScript, Tailwind v4, TanStack Virtual, Lucide React
+
+---
+
+## Group 1 — Accessibility
+
+### 1. Toast `aria-live`
+
+**File:** `frontend/src/components/shared/Toast.tsx`
+
+Add `aria-live="polite"` and `role="status"` to the `ToastContainer` wrapper div. Screen readers will then announce toast messages without interrupting the user's current focus.
+
+```tsx
+<div
+  role="status"
+  aria-live="polite"
+  aria-atomic="true"
+  className="fixed bottom-4 right-4 z-50 flex flex-col gap-2"
+>
+```
+
+### 2. Form labels
+
+**Files:** `frontend/src/pages/Settings/` tabs, provider modals, any `<input>`/`<select>` without associated label
+
+Audit all form inputs. For each input lacking a `<label htmlFor>` or `aria-label`:
+- Add a visible `<label htmlFor="input-id">` where space allows
+- Add `aria-label="..."` or `aria-labelledby="..."` for icon-only or compact inputs
+
+### 3. Semantic tables
+
+**Files:** `frontend/src/pages/Library.tsx`, `History.tsx`, `Queue.tsx`, `Blacklist.tsx`, `Wanted.tsx`
+
+Every data table must use:
+```html
+<table>
+  <thead>
+    <tr>
+      <th scope="col" aria-sort="none">Title</th>
+      <th scope="col" aria-sort="ascending">Date</th>
+    </tr>
+  </thead>
+  <tbody>...</tbody>
+</table>
+```
+
+Update `aria-sort` on click: `"none" | "ascending" | "descending"`.
+
+### 4. Button semantics
+
+**Files:** `frontend/src/components/layout/Sidebar.tsx`, any component using `<div onClick>` or `<span onClick>` for interactive actions
+
+Replace `<div onClick>` / `<span onClick>` that act as buttons with `<button type="button">`. Ensure `cursor-pointer` and focus styles are preserved. NavLink components are already correct (anchor-based).
+
+### 5. Skip-to-main link
+
+**Files:** `frontend/src/App.tsx`, main layout wrapper
+
+Add a visually-hidden skip link as the very first focusable element:
+```tsx
+<a
+  href="#main-content"
+  className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-[100] focus:px-4 focus:py-2 focus:rounded focus:bg-accent focus:text-white"
+>
+  Skip to main content
+</a>
+```
+Add `id="main-content"` to the `<main>` element wrapping page content.
+
+---
+
+## Group 2 — Mobile UX
+
+### 6. Mobile menu auto-close
+
+**File:** `frontend/src/components/layout/Sidebar.tsx`
+
+The mobile sidebar drawer stays open after navigating. Add an `onClick` handler to each `NavLink` that calls `setMobileOpen(false)`:
+
+```tsx
+<NavLink to={item.to} onClick={() => setMobileOpen(false)}>
+```
+
+### 7. Page-specific skeletons
+
+**Files:** `frontend/src/App.tsx` (Suspense boundaries), `frontend/src/components/shared/PageSkeleton.tsx`
+
+Replace the single generic `<PageSkeleton />` Suspense fallback with page-appropriate variants:
+- **Library:** 12-card grid skeleton (`LibrarySkeleton`)
+- **Queue / History / Blacklist:** 5-row table skeleton (`TableSkeleton`)
+- **Wanted:** 8-row list skeleton (`ListSkeleton`)
+- **Settings:** Form section skeleton (`FormSkeleton`)
+- **Dashboard:** Widget grid skeleton (already exists, verify it's used)
+
+Keep `PageSkeleton` as the default fallback for pages without a specific skeleton.
+
+### 8. Tablet breakpoints
+
+**Files:** `frontend/src/pages/Library.tsx`, `frontend/src/components/library/LibraryGridCard.tsx`, other grid layouts
+
+Library grid currently jumps from 1-column (mobile) to 4-column (desktop). Add intermediate breakpoints:
+```tsx
+className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4"
+```
+
+Audit other pages for similar mobile→desktop jumps and apply `md:` breakpoints where missing.
+
+---
+
+## Group 3 — Motion & Performance
+
+### 9. `prefers-reduced-motion`
+
+**File:** `frontend/src/index.css` (or global stylesheet)
+
+Add a media query block that disables all animations and transitions for users who opt out:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+```
+
+This catches `slideInRight` (toasts), `dotGlow` (status badges), stagger delays, and any other keyframe animations.
+
+### 10. Stagger animation classes
+
+**Files:** `frontend/src/pages/Library.tsx`, `frontend/src/pages/Wanted.tsx`, `frontend/src/components/library/LibraryGridCard.tsx`
+
+Verify stagger utility is consistently applied to list/grid renders. Each mapped item should receive a calculated `animationDelay`:
+```tsx
+items.map((item, i) => (
+  <LibraryGridCard
+    key={item.id}
+    style={{ animationDelay: `${i * 30}ms` }}
+    ...
+  />
+))
+```
+
+Cap stagger at ~300ms total (e.g. `Math.min(i * 30, 300)`ms) so late items don't appear broken.
+
+### 11. List virtualization
+
+**Files:** `frontend/src/pages/Library.tsx` (list view), `frontend/src/pages/Wanted.tsx`
+
+Install `@tanstack/react-virtual` and apply to list views with potentially 500+ items. Grid view is unaffected (already windowed by pagination).
+
+```tsx
+import { useVirtualizer } from '@tanstack/react-virtual'
+
+const rowVirtualizer = useVirtualizer({
+  count: items.length,
+  getScrollElement: () => parentRef.current,
+  estimateSize: () => 56, // row height in px
+  overscan: 10,
+})
+```
+
+Only applies to **list view** — grid view stays as-is. Add `data-testid="virtual-list"` for testing.
+
+---
+
+## Group 4 — Forms & Feedback
+
+### 12. Client-side validation UI
+
+**Files:** `frontend/src/pages/Settings/providers/AddProviderModal.tsx`, Settings form tabs with required fields
+
+Required fields should show inline errors on blur (not only on server response):
+```tsx
+{errors.name && (
+  <p role="alert" className="text-xs mt-1" style={{ color: 'var(--error)' }}>
+    {errors.name}
+  </p>
+)}
+```
+
+Validate on blur for individual fields; validate all on submit attempt. Do not block the submit button — show errors instead.
+
+### 13. CSS `:hover` instead of JS hover state
+
+**Files:** Any component using `onMouseEnter`/`onMouseLeave` + `useState` purely for hover styling
+
+Replace patterns like:
+```tsx
+const [hovered, setHovered] = useState(false)
+<div onMouseEnter={() => setHovered(true)} onMouseLeave={() => setHovered(false)}
+     style={{ background: hovered ? 'var(--bg-surface-hover)' : undefined }}>
+```
+With Tailwind hover classes or CSS custom property approach:
+```tsx
+<div className="hover:bg-surface-hover transition-colors">
+```
+
+This eliminates unnecessary re-renders on every hover event.
+
+### 14. Modal `role="dialog"`
+
+**Files:** All modal components — `SubtitleEditorModal`, `AddProviderModal`, `SyncModal`, `InteractiveSearchModal`, `SubtitleCleanupModal`, `WidgetSettingsModal`, etc.
+
+Each modal root element must have:
+```tsx
+<div
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="modal-title-id"
+  ...
+>
+  <h2 id="modal-title-id">...</h2>
+```
+
+Add `autoFocus` to the first interactive element inside each modal (close button or primary action) so keyboard focus moves into the dialog on open.
+
+### 15. Status badges with icons
+
+**File:** `frontend/src/components/shared/StatusBadge.tsx`
+
+Add a lucide icon alongside the color dot for non-color signal (colorblind accessibility):
+
+```tsx
+const statusIcons: Record<string, typeof CheckCircle2> = {
+  healthy:   CheckCircle2,
+  completed: CheckCircle2,
+  running:   Loader2,       // spinning via animate-spin
+  queued:    Clock,
+  failed:    XCircle,
+  unhealthy: XCircle,
+  wanted:    AlertCircle,
+  searching: Search,
+  found:     CheckCircle2,
+  extracted: CheckCircle2,
+  ignored:   MinusCircle,
+  skipped:   MinusCircle,
+}
+```
+
+Replace the `<span>` dot with the icon. Keep `animate-spin` on `Loader2` for `running`. Color dot is removed (icon carries the semantic meaning, color is purely decorative reinforcement).
+
+---
+
+## Testing
+
+- Unit tests for `StatusBadge` (icon renders per status), `Toast` (aria-live attribute present)
+- Existing tests must remain green
+- Manual smoke test: keyboard nav through sidebar + modal focus trap, mobile menu close, 500-item Library list render performance
+
+## Non-Goals
+
+- No backend changes
+- No new pages or routes
+- No design system overhaul — targeted fixes only
+- No dark/light theme changes
+- No i18n additions beyond what accessibility labels require

--- a/docs/superpowers/specs/2026-03-11-v0.21.1-ui-ux-polish-design.md
+++ b/docs/superpowers/specs/2026-03-11-v0.21.1-ui-ux-polish-design.md
@@ -2,11 +2,11 @@
 
 > **For agentic workers:** Use `superpowers:subagent-driven-development` to implement this plan.
 
-**Goal:** Harden the frontend against accessibility failures, improve mobile usability, and fix interaction patterns across 15 targeted changes — no new features, no backend changes.
+**Goal:** Harden the frontend against accessibility failures, improve mobile usability, and fix interaction patterns across 14 targeted changes — no new features, no backend changes.
 
-**Architecture:** Pure frontend refactor. All changes in `frontend/src/`. No new dependencies except `@tanstack/react-virtual` for list virtualization. Single PR targeting `master`.
+**Architecture:** Pure frontend refactor. All changes in `frontend/src/`. `@tanstack/react-virtual` is already installed (`^3.13.21` in `package.json`) and already used in `pages/Logs.tsx`. Single PR targeting `master`.
 
-**Tech Stack:** React 19, TypeScript, Tailwind v4, TanStack Virtual, Lucide React
+**Tech Stack:** React 19, TypeScript, Tailwind v4, TanStack Virtual (already installed), Lucide React
 
 ---
 
@@ -27,99 +27,110 @@ Add `aria-live="polite"` and `role="status"` to the `ToastContainer` wrapper div
 >
 ```
 
+**Done criteria:** `aria-live="polite"` attribute present on the container. Unit test: assert attribute exists on the container element.
+
 ### 2. Form labels
 
-**Files:** `frontend/src/pages/Settings/` tabs, provider modals, any `<input>`/`<select>` without associated label
+**Files:** `frontend/src/pages/Settings/providers/AddProviderModal.tsx`, `frontend/src/pages/Settings/providers/ProviderEditModal.tsx`
 
-Audit all form inputs. For each input lacking a `<label htmlFor>` or `aria-label`:
-- Add a visible `<label htmlFor="input-id">` where space allows
-- Add `aria-label="..."` or `aria-labelledby="..."` for icon-only or compact inputs
+Scope is limited to provider modals where inputs are known to lack `<label>` elements. For each text input and select without an associated `<label htmlFor>`, add either:
+- A visible `<label htmlFor="input-id">` where layout allows
+- `aria-label="..."` for inputs inside icon-button rows
+
+**Done criteria:** Every `<input>` and `<select>` in both files has either `id` + matching `<label htmlFor>`, or `aria-label`.
 
 ### 3. Semantic tables
 
-**Files:** `frontend/src/pages/Library.tsx`, `History.tsx`, `Queue.tsx`, `Blacklist.tsx`, `Wanted.tsx`
+**Files:** `frontend/src/pages/Library.tsx` (already has `<thead>`, needs `scope`+`aria-sort`), `frontend/src/pages/History.tsx`, `frontend/src/pages/Blacklist.tsx`, `frontend/src/pages/Wanted.tsx` (line 821)
 
-Every data table must use:
+All four pages use `<table>` layouts. Queue.tsx uses div-based layout and is out of scope.
+
+For each table, ensure:
 ```html
-<table>
-  <thead>
-    <tr>
-      <th scope="col" aria-sort="none">Title</th>
-      <th scope="col" aria-sort="ascending">Date</th>
-    </tr>
-  </thead>
-  <tbody>...</tbody>
-</table>
+<thead>
+  <tr>
+    <th scope="col">Title</th>
+    <th scope="col" aria-sort="none">Date</th>  <!-- sortable columns -->
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td>...</td>
+  </tr>
+</tbody>
 ```
 
-Update `aria-sort` on click: `"none" | "ascending" | "descending"`.
+Update `aria-sort` dynamically on the active sort column: `"none" | "ascending" | "descending"`.
+
+**Done criteria:** Every `<th>` has `scope="col"`. Sortable headers have `aria-sort` attribute that updates on sort.
 
 ### 4. Button semantics
 
-**Files:** `frontend/src/components/layout/Sidebar.tsx`, any component using `<div onClick>` or `<span onClick>` for interactive actions
+**Files:** `frontend/src/components/layout/Sidebar.tsx` (group headers only — NavLinks are already correct), `frontend/src/components/shared/StatusBadge.tsx` (if any div-based click handlers present), and any `<div onClick>` / `<span onClick>` found during `grep -rn "div onClick\|span onClick" frontend/src`
 
-Replace `<div onClick>` / `<span onClick>` that act as buttons with `<button type="button">`. Ensure `cursor-pointer` and focus styles are preserved. NavLink components are already correct (anchor-based).
+Replace `<div onClick>` / `<span onClick>` that act as interactive controls with `<button type="button">`. NavLink-based navigation is already correct and must not be changed.
+
+**Done criteria:** `grep -rn "div onClick\|span onClick" frontend/src` returns zero results where the element acts as an interactive control (not a non-interactive event catcher like stopPropagation wrappers).
 
 ### 5. Skip-to-main link
 
-**Files:** `frontend/src/App.tsx`, main layout wrapper
+**File:** `frontend/src/App.tsx`
 
-Add a visually-hidden skip link as the very first focusable element:
+Add a visually-hidden skip link as the first focusable element in the render tree:
 ```tsx
 <a
   href="#main-content"
-  className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-[100] focus:px-4 focus:py-2 focus:rounded focus:bg-accent focus:text-white"
+  className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-[100] focus:px-4 focus:py-2 focus:rounded"
+  style={{ backgroundColor: 'var(--accent)', color: '#fff' }}
 >
   Skip to main content
 </a>
 ```
-Add `id="main-content"` to the `<main>` element wrapping page content.
+Add `id="main-content"` to the `<main>` element wrapping page content in the layout.
+
+**Done criteria:** Pressing Tab on page load focuses the skip link. Activating it moves focus to `#main-content`. Unit test: assert element with `href="#main-content"` exists.
 
 ---
 
 ## Group 2 — Mobile UX
 
-### 6. Mobile menu auto-close
+### 6. Page-specific skeletons
 
-**File:** `frontend/src/components/layout/Sidebar.tsx`
+**File:** `frontend/src/components/shared/PageSkeleton.tsx` (add named exports alongside existing default), used in `frontend/src/App.tsx` Suspense boundaries
 
-The mobile sidebar drawer stays open after navigating. Add an `onClick` handler to each `NavLink` that calls `setMobileOpen(false)`:
+Create these skeleton variants (add to existing `PageSkeleton.tsx` as named exports):
 
+- **`LibrarySkeleton`** — 12-card grid with pulse animation, matching Library grid layout (`grid-cols-3 sm:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8`)
+- **`TableSkeleton`** — 5-row table skeleton with 4 columns (for History, Queue, Blacklist)
+- **`ListSkeleton`** — 8-row list items with varying width text lines (for Wanted)
+- **`FormSkeleton`** — 4-row form field groups (for Settings pages)
+
+Update `App.tsx` lazy Suspense fallbacks to use the page-specific variant for `Library`, `History`, `Queue`, `Blacklist`, `Wanted`, and `Settings` routes. Keep `<PageSkeleton />` as fallback for all others.
+
+**Done criteria:** Each named skeleton is exported from `PageSkeleton.tsx`. The 6 routes listed use their specific skeleton instead of the generic one.
+
+### 7. Tablet breakpoints
+
+**File:** `frontend/src/pages/Library.tsx` (line 891)
+
+Current Library grid: `grid-cols-3 sm:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8` — missing a `md:` breakpoint, causing a jump from 4-col at 640px to 6-col at 1024px.
+
+Add `md:grid-cols-5` to smooth the transition:
 ```tsx
-<NavLink to={item.to} onClick={() => setMobileOpen(false)}>
+className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6 xl:grid-cols-8 gap-3"
 ```
 
-### 7. Page-specific skeletons
+Also audit `SeriesDetail.tsx` for missing `md:` breakpoints on episode lists (desktop layout jumps).
 
-**Files:** `frontend/src/App.tsx` (Suspense boundaries), `frontend/src/components/shared/PageSkeleton.tsx`
-
-Replace the single generic `<PageSkeleton />` Suspense fallback with page-appropriate variants:
-- **Library:** 12-card grid skeleton (`LibrarySkeleton`)
-- **Queue / History / Blacklist:** 5-row table skeleton (`TableSkeleton`)
-- **Wanted:** 8-row list skeleton (`ListSkeleton`)
-- **Settings:** Form section skeleton (`FormSkeleton`)
-- **Dashboard:** Widget grid skeleton (already exists, verify it's used)
-
-Keep `PageSkeleton` as the default fallback for pages without a specific skeleton.
-
-### 8. Tablet breakpoints
-
-**Files:** `frontend/src/pages/Library.tsx`, `frontend/src/components/library/LibraryGridCard.tsx`, other grid layouts
-
-Library grid currently jumps from 1-column (mobile) to 4-column (desktop). Add intermediate breakpoints:
-```tsx
-className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4"
-```
-
-Audit other pages for similar mobile→desktop jumps and apply `md:` breakpoints where missing.
+**Done criteria:** Library grid has `md:grid-cols-5`. No layout visible at 768px viewport that looks broken or under-used.
 
 ---
 
 ## Group 3 — Motion & Performance
 
-### 9. `prefers-reduced-motion`
+### 8. `prefers-reduced-motion`
 
-**File:** `frontend/src/index.css` (or global stylesheet)
+**File:** `frontend/src/index.css`
 
 Add a media query block that disables all animations and transitions for users who opt out:
 
@@ -133,30 +144,30 @@ Add a media query block that disables all animations and transitions for users w
 }
 ```
 
-This catches `slideInRight` (toasts), `dotGlow` (status badges), stagger delays, and any other keyframe animations.
+This catches `slideInRight` (toasts), `dotGlow` (status badges), stagger delays, and all other keyframe animations defined in `index.css`.
 
-### 10. Stagger animation classes
+**Done criteria:** `@media (prefers-reduced-motion: reduce)` block exists in `index.css`. Animations defined in `index.css` are overridden within this block.
 
-**Files:** `frontend/src/pages/Library.tsx`, `frontend/src/pages/Wanted.tsx`, `frontend/src/components/library/LibraryGridCard.tsx`
+### 9. Stagger animation classes
 
-Verify stagger utility is consistently applied to list/grid renders. Each mapped item should receive a calculated `animationDelay`:
+**Files:** `frontend/src/pages/Library.tsx`, `frontend/src/pages/Wanted.tsx`
+
+Verify stagger is consistently applied to list/grid renders. Each mapped item should receive:
 ```tsx
-items.map((item, i) => (
-  <LibraryGridCard
-    key={item.id}
-    style={{ animationDelay: `${i * 30}ms` }}
-    ...
-  />
-))
+style={{ animationDelay: `${Math.min(i * 30, 300)}ms` }}
 ```
 
-Cap stagger at ~300ms total (e.g. `Math.min(i * 30, 300)`ms) so late items don't appear broken.
+Cap at 300ms so late items don't appear broken on large lists.
 
-### 11. List virtualization
+**Done criteria:** Library grid cards and Wanted list rows both have `animationDelay` applied with the 300ms cap.
 
-**Files:** `frontend/src/pages/Library.tsx` (list view), `frontend/src/pages/Wanted.tsx`
+### 10. List virtualization
 
-Install `@tanstack/react-virtual` and apply to list views with potentially 500+ items. Grid view is unaffected (already windowed by pagination).
+**Files:** `frontend/src/pages/Library.tsx` (list view only), `frontend/src/pages/Wanted.tsx`
+
+`@tanstack/react-virtual` is already installed (`package.json`: `^3.13.21`) and used in `Logs.tsx` as a reference implementation.
+
+Apply `useVirtualizer` to list-view rendering in Library and to Wanted's item list:
 
 ```tsx
 import { useVirtualizer } from '@tanstack/react-virtual'
@@ -164,22 +175,24 @@ import { useVirtualizer } from '@tanstack/react-virtual'
 const rowVirtualizer = useVirtualizer({
   count: items.length,
   getScrollElement: () => parentRef.current,
-  estimateSize: () => 56, // row height in px
+  estimateSize: () => 56,
   overscan: 10,
 })
 ```
 
-Only applies to **list view** — grid view stays as-is. Add `data-testid="virtual-list"` for testing.
+Refer to `Logs.tsx` for the established pattern. Library **grid view** is unaffected (stays as-is). Add `data-testid="virtual-list"` on the virtualizer container for testing.
+
+**Done criteria:** Library list view and Wanted list render via `useVirtualizer`. The DOM contains only the visible window of items (verify via `data-testid="virtual-list"`).
 
 ---
 
 ## Group 4 — Forms & Feedback
 
-### 12. Client-side validation UI
+### 11. Client-side validation UI
 
-**Files:** `frontend/src/pages/Settings/providers/AddProviderModal.tsx`, Settings form tabs with required fields
+**Files:** `frontend/src/pages/Settings/providers/AddProviderModal.tsx`, `frontend/src/pages/Settings/providers/ProviderEditModal.tsx`
 
-Required fields should show inline errors on blur (not only on server response):
+Required fields (at minimum: provider name/URL) should show inline error on blur:
 ```tsx
 {errors.name && (
   <p role="alert" className="text-xs mt-1" style={{ color: 'var(--error)' }}>
@@ -188,11 +201,18 @@ Required fields should show inline errors on blur (not only on server response):
 )}
 ```
 
-Validate on blur for individual fields; validate all on submit attempt. Do not block the submit button — show errors instead.
+Validate on blur per field. Validate all fields on submit attempt. Do not disable the submit button — show errors inline instead.
 
-### 13. CSS `:hover` instead of JS hover state
+**Done criteria:** Submitting the Add Provider form with an empty required field shows an inline error without hitting the backend.
 
-**Files:** Any component using `onMouseEnter`/`onMouseLeave` + `useState` purely for hover styling
+### 12. CSS `:hover` instead of JS hover state
+
+**Files (bounded scope — pure visual-only hover patterns):**
+- `frontend/src/components/dashboard/widgets/StatCardsWidget.tsx`
+- `frontend/src/components/dashboard/widgets/RecentActivityWidget.tsx`
+- `frontend/src/components/shared/ThemeToggle.tsx`
+- `frontend/src/components/shared/LanguageSwitcher.tsx`
+- `frontend/src/pages/Settings/providers/ProviderTile.tsx`
 
 Replace patterns like:
 ```tsx
@@ -200,16 +220,27 @@ const [hovered, setHovered] = useState(false)
 <div onMouseEnter={() => setHovered(true)} onMouseLeave={() => setHovered(false)}
      style={{ background: hovered ? 'var(--bg-surface-hover)' : undefined }}>
 ```
-With Tailwind hover classes or CSS custom property approach:
+With Tailwind hover classes:
 ```tsx
 <div className="hover:bg-surface-hover transition-colors">
 ```
 
-This eliminates unnecessary re-renders on every hover event.
+Only replace patterns where hover state has **no side effects beyond visual styling**. Leave hover state that controls tooltip visibility, dropdown open state, or any non-CSS behavior.
 
-### 14. Modal `role="dialog"`
+**Done criteria:** The 5 listed files have no `useState` used exclusively for hover background/border styling.
 
-**Files:** All modal components — `SubtitleEditorModal`, `AddProviderModal`, `SyncModal`, `InteractiveSearchModal`, `SubtitleCleanupModal`, `WidgetSettingsModal`, etc.
+### 13. Modal `role="dialog"`
+
+**Files (complete list of modals lacking `role="dialog"`):**
+- `frontend/src/components/editor/SubtitleEditorModal.tsx`
+- `frontend/src/components/dashboard/WidgetSettingsModal.tsx`
+- `frontend/src/components/search/GlobalSearchModal.tsx`
+- `frontend/src/components/shared/SubtitleCleanupModal.tsx`
+- `frontend/src/components/sync/SyncModal.tsx`
+- `frontend/src/pages/Settings/providers/AddProviderModal.tsx`
+- `frontend/src/pages/Settings/providers/ProviderEditModal.tsx`
+
+(`KeyboardShortcutsModal.tsx` and `InteractiveSearchModal.tsx` already have `role="dialog"` — skip these.)
 
 Each modal root element must have:
 ```tsx
@@ -217,45 +248,64 @@ Each modal root element must have:
   role="dialog"
   aria-modal="true"
   aria-labelledby="modal-title-id"
-  ...
 >
   <h2 id="modal-title-id">...</h2>
 ```
 
-Add `autoFocus` to the first interactive element inside each modal (close button or primary action) so keyboard focus moves into the dialog on open.
+Add `autoFocus` to the first interactive element (primary action button or close button) inside each modal so keyboard focus enters the dialog on open. Full focus trap (Tab cycling) is **out of scope** for this release — tracked separately.
 
-### 15. Status badges with icons
+**Done criteria:** All 7 listed modals have `role="dialog"`, `aria-modal="true"`, and `aria-labelledby` pointing to a title element. Focus moves into modal on open.
+
+### 14. Status badges with icons
 
 **File:** `frontend/src/components/shared/StatusBadge.tsx`
 
-Add a lucide icon alongside the color dot for non-color signal (colorblind accessibility):
+Add a lucide icon alongside the color for non-color signal (colorblind accessibility). Replace the `<span>` dot with the icon:
 
 ```tsx
+import { CheckCircle2, XCircle, Clock, Loader2, AlertCircle, Search, MinusCircle } from 'lucide-react'
+
 const statusIcons: Record<string, typeof CheckCircle2> = {
-  healthy:   CheckCircle2,
-  completed: CheckCircle2,
-  running:   Loader2,       // spinning via animate-spin
-  queued:    Clock,
-  failed:    XCircle,
-  unhealthy: XCircle,
-  wanted:    AlertCircle,
-  searching: Search,
-  found:     CheckCircle2,
-  extracted: CheckCircle2,
-  ignored:   MinusCircle,
-  skipped:   MinusCircle,
+  healthy:          CheckCircle2,
+  completed:        CheckCircle2,
+  found:            CheckCircle2,
+  extracted:        CheckCircle2,
+  running:          Loader2,
+  queued:           Clock,
+  failed:           XCircle,
+  unhealthy:        XCircle,
+  wanted:           AlertCircle,
+  searching:        Search,
+  ignored:          MinusCircle,
+  skipped:          MinusCircle,
+  'not configured': MinusCircle,
 }
 ```
 
-Replace the `<span>` dot with the icon. Keep `animate-spin` on `Loader2` for `running`. Color dot is removed (icon carries the semantic meaning, color is purely decorative reinforcement).
+`Loader2` gets `className="animate-spin"`. Color dot `<span>` is removed — icon carries semantic meaning, color is decorative reinforcement only. The `SubtitleTypeBadge` component in the same file is unaffected.
+
+**Done criteria:** `StatusBadge` renders a lucide icon for every known status. Unit test: verify icon renders for `completed`, `failed`, `running`, `queued` statuses.
 
 ---
 
 ## Testing
 
-- Unit tests for `StatusBadge` (icon renders per status), `Toast` (aria-live attribute present)
-- Existing tests must remain green
-- Manual smoke test: keyboard nav through sidebar + modal focus trap, mobile menu close, 500-item Library list render performance
+**Unit tests to add/update:**
+- `Toast.tsx` — assert `aria-live="polite"` and `role="status"` on container
+- `StatusBadge.tsx` — assert correct icon renders for `completed`, `failed`, `running`, `queued`, `wanted`
+- `App.tsx` / skip link — assert element with `href="#main-content"` exists in rendered output
+- `subtitles/download` modal (modal role) — assert `role="dialog"` and `aria-modal` present on at least 2 modal components
+
+**Existing tests must stay green:**
+- `frontend/src/test/StatusBadge.test.tsx` — update to accommodate icon addition
+- `frontend/src/test/ProgressBar.test.tsx` — unaffected, should pass as-is
+
+**Manual verification:**
+- Tab through sidebar → verify focus order, skip link functions
+- Open any modal → verify focus moves inside, Tab does not cycle outside
+- Resize to 768px → verify Library grid uses 5 columns
+- Open Library with 100+ series in list view → verify smooth scrolling (no DOM thrash)
+- Enable OS reduced-motion → verify toast slides in without animation
 
 ## Non-Goals
 
@@ -263,4 +313,6 @@ Replace the `<span>` dot with the icon. Keep `animate-spin` on `Loader2` for `ru
 - No new pages or routes
 - No design system overhaul — targeted fixes only
 - No dark/light theme changes
-- No i18n additions beyond what accessibility labels require
+- No full focus trap implementation (tracked for v0.22.x)
+- No axe-core CI integration (tracked for v0.22.x)
+- No Queue.tsx table semantics (uses div layout — separate refactor)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,7 +3,13 @@ import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { Sidebar } from '@/components/layout/Sidebar'
 import { ToastContainer, toast } from '@/components/shared/Toast'
-import { PageSkeleton } from '@/components/shared/PageSkeleton'
+import {
+  PageSkeleton,
+  LibrarySkeleton,
+  TableSkeleton,
+  ListSkeleton,
+  FormSkeleton,
+} from '@/components/shared/PageSkeleton'
 import { useWebSocket } from '@/hooks/useWebSocket'
 import { WebSocketProvider } from '@/contexts/WebSocketContext'
 import { GlobalSearchModal } from '@/components/search/GlobalSearchModal'
@@ -43,25 +49,23 @@ function AnimatedRoutes() {
 
   return (
     <div key={location.pathname} className="page-enter">
-      <Suspense fallback={<PageSkeleton />}>
-        <Routes location={location}>
-          <Route path="/" element={<Dashboard />} />
-          <Route path="/library" element={<LibraryPage />} />
-          <Route path="/library/series/:id" element={<SeriesDetailPage />} />
-          <Route path="/activity" element={<ActivityPage />} />
-          <Route path="/wanted" element={<WantedPage />} />
-          <Route path="/queue" element={<QueuePage />} />
-          <Route path="/history" element={<HistoryPage />} />
-          <Route path="/blacklist" element={<BlacklistPage />} />
-          <Route path="/settings" element={<SettingsPage />} />
-          <Route path="/statistics" element={<StatisticsPage />} />
-          <Route path="/tasks" element={<TasksPage />} />
-          <Route path="/plugins" element={<PluginsPage />} />
-          <Route path="/logs" element={<LogsPage />} />
-          <Route path="/onboarding" element={<Onboarding />} />
-          <Route path="*" element={<NotFoundPage />} />
-        </Routes>
-      </Suspense>
+      <Routes location={location}>
+        <Route path="/" element={<Suspense fallback={<PageSkeleton />}><Dashboard /></Suspense>} />
+        <Route path="/library" element={<Suspense fallback={<LibrarySkeleton />}><LibraryPage /></Suspense>} />
+        <Route path="/library/series/:id" element={<Suspense fallback={<PageSkeleton />}><SeriesDetailPage /></Suspense>} />
+        <Route path="/activity" element={<Suspense fallback={<PageSkeleton />}><ActivityPage /></Suspense>} />
+        <Route path="/wanted" element={<Suspense fallback={<ListSkeleton />}><WantedPage /></Suspense>} />
+        <Route path="/queue" element={<Suspense fallback={<TableSkeleton />}><QueuePage /></Suspense>} />
+        <Route path="/history" element={<Suspense fallback={<TableSkeleton />}><HistoryPage /></Suspense>} />
+        <Route path="/blacklist" element={<Suspense fallback={<TableSkeleton />}><BlacklistPage /></Suspense>} />
+        <Route path="/settings" element={<Suspense fallback={<FormSkeleton />}><SettingsPage /></Suspense>} />
+        <Route path="/statistics" element={<Suspense fallback={<PageSkeleton />}><StatisticsPage /></Suspense>} />
+        <Route path="/tasks" element={<Suspense fallback={<PageSkeleton />}><TasksPage /></Suspense>} />
+        <Route path="/plugins" element={<Suspense fallback={<PageSkeleton />}><PluginsPage /></Suspense>} />
+        <Route path="/logs" element={<Suspense fallback={<PageSkeleton />}><LogsPage /></Suspense>} />
+        <Route path="/onboarding" element={<Suspense fallback={<PageSkeleton />}><Onboarding /></Suspense>} />
+        <Route path="*" element={<Suspense fallback={<PageSkeleton />}><NotFoundPage /></Suspense>} />
+      </Routes>
     </div>
   )
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -133,11 +133,18 @@ function App() {
     <QueryClientProvider client={queryClient}>
       <WebSocketProvider>
       <BrowserRouter>
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-[100] focus:px-4 focus:py-2 focus:rounded"
+          style={{ backgroundColor: 'var(--accent)', color: '#fff' }}
+        >
+          Skip to main content
+        </a>
         <GlobalWebSocketListener />
         <GlobalShortcuts onToggleShortcutsModal={toggleShortcutsModal} />
         <div className="flex min-h-screen">
           <Sidebar />
-          <main className="flex-1 min-w-0 p-4 md:p-5 pt-16 md:pt-5 min-h-screen">
+          <main id="main-content" className="flex-1 min-w-0 p-4 md:p-5 pt-16 md:pt-5 min-h-screen">
             <AnimatedRoutes />
           </main>
         </div>

--- a/frontend/src/components/dashboard/WidgetSettingsModal.tsx
+++ b/frontend/src/components/dashboard/WidgetSettingsModal.tsx
@@ -27,6 +27,9 @@ export function WidgetSettingsModal({ open, onClose }: WidgetSettingsModalProps)
       onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
     >
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="widget-settings-title"
         className="w-full max-w-md rounded-lg overflow-hidden shadow-2xl"
         style={{
           backgroundColor: 'var(--bg-surface)',
@@ -40,7 +43,7 @@ export function WidgetSettingsModal({ open, onClose }: WidgetSettingsModalProps)
           style={{ borderBottom: '1px solid var(--border)' }}
         >
           <div>
-            <h2 className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
+            <h2 id="widget-settings-title" className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
               {t('widgets.settings_title')}
             </h2>
             <p className="text-xs mt-0.5" style={{ color: 'var(--text-muted)' }}>
@@ -48,6 +51,7 @@ export function WidgetSettingsModal({ open, onClose }: WidgetSettingsModalProps)
             </p>
           </div>
           <button
+            autoFocus
             onClick={onClose}
             className="p-1 rounded hover:opacity-80 transition-opacity"
             style={{ color: 'var(--text-muted)' }}

--- a/frontend/src/components/dashboard/widgets/RecentActivityWidget.tsx
+++ b/frontend/src/components/dashboard/widgets/RecentActivityWidget.tsx
@@ -39,14 +39,7 @@ export default function RecentActivityWidget() {
           recentJobs.data.map((job) => (
             <div
               key={job.id}
-              className="px-4 py-2 flex items-center gap-3 transition-colors duration-150"
-              onMouseEnter={(e) => {
-                e.currentTarget.style.backgroundColor =
-                  'var(--bg-surface-hover)'
-              }}
-              onMouseLeave={(e) => {
-                e.currentTarget.style.backgroundColor = 'transparent'
-              }}
+              className="hover-surface px-4 py-2 flex items-center gap-3 transition-colors duration-150"
             >
               {job.status === 'completed' ? (
                 <CheckCircle2

--- a/frontend/src/components/editor/SubtitleEditorModal.tsx
+++ b/frontend/src/components/editor/SubtitleEditorModal.tsx
@@ -190,6 +190,9 @@ export default function SubtitleEditorModal({
       onClick={handleOverlayClick}
     >
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Subtitle Editor"
         className="w-[92vw] h-[88vh] max-w-7xl rounded-lg overflow-hidden flex flex-col"
         style={{
           backgroundColor: 'var(--bg-surface)',
@@ -265,6 +268,7 @@ export default function SubtitleEditorModal({
               </span>
             )}
             <button
+              autoFocus
               onClick={handleClose}
               className="p-1 rounded transition-colors"
               style={{ color: 'var(--text-muted)' }}

--- a/frontend/src/components/library/LibraryGridCard.tsx
+++ b/frontend/src/components/library/LibraryGridCard.tsx
@@ -1,23 +1,25 @@
+import type React from 'react'
 import { Film } from 'lucide-react'
 import type { SeriesInfo, MovieInfo } from '@/lib/types'
 
 interface LibraryGridCardProps {
   item: SeriesInfo | MovieInfo
   onClick: () => void
+  style?: React.CSSProperties
 }
 
 function isSeries(item: SeriesInfo | MovieInfo): item is SeriesInfo {
   return 'missing_count' in item
 }
 
-export function LibraryGridCard({ item, onClick }: LibraryGridCardProps) {
+export function LibraryGridCard({ item, onClick, style }: LibraryGridCardProps) {
   const missingCount = isSeries(item) ? item.missing_count : 0
 
   return (
     <div
       onClick={onClick}
       className="cursor-pointer rounded-lg overflow-hidden group"
-      style={{ border: '1px solid var(--border)' }}
+      style={{ border: '1px solid var(--border)', ...style }}
     >
       {/* Image area — overlays scoped here so they don't cover the title bar */}
       <div className="relative">

--- a/frontend/src/components/search/GlobalSearchModal.tsx
+++ b/frontend/src/components/search/GlobalSearchModal.tsx
@@ -55,7 +55,13 @@ export function GlobalSearchModal({ open, onOpenChange }: Props) {
       overlayClassName="fixed inset-0 bg-black/50 backdrop-blur-sm"
       contentClassName="fixed inset-0 z-50 flex items-start justify-center pt-[15vh]"
     >
-      <div className="w-full max-w-lg rounded-xl border border-border bg-background shadow-2xl overflow-hidden">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="global-search-title"
+        className="w-full max-w-lg rounded-xl border border-border bg-background shadow-2xl overflow-hidden"
+      >
+        <h2 id="global-search-title" className="sr-only">Global Search</h2>
         <div className="flex items-center gap-2 px-4 border-b border-border">
           <Search className="h-4 w-4 text-muted-foreground shrink-0" />
           <Command.Input

--- a/frontend/src/components/shared/PageSkeleton.tsx
+++ b/frontend/src/components/shared/PageSkeleton.tsx
@@ -16,3 +16,81 @@ export function PageSkeleton() {
     </div>
   )
 }
+
+const pulse = 'animate-pulse rounded'
+const bg1 = { backgroundColor: 'var(--bg-surface)' }
+const bg2 = { backgroundColor: 'rgba(124,130,147,0.08)' }
+
+/** Matches Library grid: grid-cols-3 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6 xl:grid-cols-8 */
+export function LibrarySkeleton() {
+  return (
+    <div className="space-y-4">
+      <div className={`h-7 w-40 ${pulse}`} style={bg2} />
+      <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6 xl:grid-cols-8 gap-3">
+        {Array.from({ length: 16 }).map((_, i) => (
+          <div key={i} className="space-y-1.5">
+            <div className={`aspect-[2/3] w-full ${pulse}`} style={bg1} />
+            <div className={`h-3 w-3/4 ${pulse}`} style={bg2} />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+/** 5-row table skeleton for History, Queue, Blacklist */
+export function TableSkeleton() {
+  return (
+    <div className="space-y-3">
+      <div className={`h-7 w-40 ${pulse}`} style={bg2} />
+      <div className={`rounded-lg overflow-hidden`} style={bg1}>
+        <div className="px-4 py-2.5 flex gap-4" style={{ borderBottom: '1px solid var(--border)' }}>
+          {[120, 80, 60, 80].map((w, i) => (
+            <div key={i} className={`h-3 ${pulse}`} style={{ ...bg2, width: w }} />
+          ))}
+        </div>
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="px-4 py-3 flex gap-4" style={{ borderBottom: '1px solid var(--border)' }}>
+            {[160, 90, 50, 90].map((w, j) => (
+              <div key={j} className={`h-3 ${pulse}`} style={{ ...bg2, width: w }} />
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+/** 8-row list skeleton for Wanted */
+export function ListSkeleton() {
+  const widths = [200, 160, 180, 140, 170, 155, 190, 145]
+  return (
+    <div className="space-y-3">
+      <div className={`h-7 w-40 ${pulse}`} style={bg2} />
+      <div className={`rounded-lg overflow-hidden`} style={bg1}>
+        {widths.map((w, i) => (
+          <div key={i} className="px-4 py-3 flex items-center gap-3" style={{ borderBottom: '1px solid var(--border)' }}>
+            <div className={`h-4 w-4 rounded-full ${pulse}`} style={bg2} />
+            <div className={`h-3 ${pulse}`} style={{ ...bg2, width: w }} />
+            <div className={`h-3 w-16 ml-auto ${pulse}`} style={bg2} />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+/** Form section skeleton for Settings */
+export function FormSkeleton() {
+  return (
+    <div className="space-y-6">
+      <div className={`h-7 w-40 ${pulse}`} style={bg2} />
+      {Array.from({ length: 4 }).map((_, i) => (
+        <div key={i} className="space-y-2">
+          <div className={`h-3 w-28 ${pulse}`} style={bg2} />
+          <div className={`h-9 w-full rounded ${pulse}`} style={bg1} />
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/components/shared/SettingRow.tsx
+++ b/frontend/src/components/shared/SettingRow.tsx
@@ -7,6 +7,7 @@ interface SettingRowProps {
   description?: string
   helpText?: string
   advanced?: boolean
+  htmlFor?: string
   children: ReactNode
   className?: string
 }
@@ -16,6 +17,7 @@ export function SettingRow({
   description,
   helpText,
   advanced,
+  htmlFor,
   children,
   className = '',
 }: SettingRowProps) {
@@ -30,9 +32,15 @@ export function SettingRow({
     >
       <div className="flex flex-col gap-0.5 pt-0.5">
         <div className="flex items-center gap-1.5 flex-wrap">
-          <span className="text-[13px] font-medium" style={{ color: 'var(--text-primary)' }}>
-            {label}
-          </span>
+          {htmlFor ? (
+            <label htmlFor={htmlFor} className="text-[13px] font-medium" style={{ color: 'var(--text-primary)' }}>
+              {label}
+            </label>
+          ) : (
+            <span className="text-[13px] font-medium" style={{ color: 'var(--text-primary)' }}>
+              {label}
+            </span>
+          )}
           {helpText && <InfoTooltip text={helpText} />}
           {advanced && (
             <span

--- a/frontend/src/components/shared/StatusBadge.tsx
+++ b/frontend/src/components/shared/StatusBadge.tsx
@@ -1,25 +1,50 @@
 import { cn } from '@/lib/utils'
 import { useTranslation } from 'react-i18next'
+import {
+  CheckCircle2,
+  XCircle,
+  Clock,
+  Loader2,
+  AlertCircle,
+  Search,
+  MinusCircle,
+} from 'lucide-react'
 
 interface StatusBadgeProps {
   status: string
   className?: string
 }
 
-const statusStyles: Record<string, { bg: string; text: string; dot: string }> = {
-  healthy:          { bg: 'var(--success-bg)', text: 'var(--success)', dot: 'var(--success)' },
-  completed:        { bg: 'var(--success-bg)', text: 'var(--success)', dot: 'var(--success)' },
-  running:          { bg: 'var(--accent-bg)',  text: 'var(--accent)',  dot: 'var(--accent)' },
-  queued:           { bg: 'var(--warning-bg)', text: 'var(--warning)', dot: 'var(--warning)' },
-  failed:           { bg: 'var(--error-bg)',   text: 'var(--error)',   dot: 'var(--error)' },
-  unhealthy:        { bg: 'var(--error-bg)',   text: 'var(--error)',   dot: 'var(--error)' },
-  wanted:           { bg: 'var(--warning-bg)', text: 'var(--warning)', dot: 'var(--warning)' },
-  searching:        { bg: 'var(--accent-bg)',  text: 'var(--accent)',  dot: 'var(--accent)' },
-  found:            { bg: 'var(--success-bg)', text: 'var(--success)', dot: 'var(--success)' },
-  extracted:        { bg: 'rgba(20,184,166,0.12)',  text: 'rgb(20,184,166)',   dot: 'rgb(20,184,166)' },
-  ignored:          { bg: 'rgba(124,130,147,0.08)', text: 'var(--text-muted)', dot: 'var(--text-muted)' },
-  'not configured': { bg: 'rgba(124,130,147,0.08)', text: 'var(--text-secondary)', dot: 'var(--text-muted)' },
-  skipped:          { bg: 'rgba(124,130,147,0.08)', text: 'var(--text-secondary)', dot: 'var(--text-muted)' },
+const statusStyles: Record<string, { bg: string; text: string }> = {
+  healthy:          { bg: 'var(--success-bg)', text: 'var(--success)' },
+  completed:        { bg: 'var(--success-bg)', text: 'var(--success)' },
+  running:          { bg: 'var(--accent-bg)',  text: 'var(--accent)' },
+  queued:           { bg: 'var(--warning-bg)', text: 'var(--warning)' },
+  failed:           { bg: 'var(--error-bg)',   text: 'var(--error)' },
+  unhealthy:        { bg: 'var(--error-bg)',   text: 'var(--error)' },
+  wanted:           { bg: 'var(--warning-bg)', text: 'var(--warning)' },
+  searching:        { bg: 'var(--accent-bg)',  text: 'var(--accent)' },
+  found:            { bg: 'var(--success-bg)', text: 'var(--success)' },
+  extracted:        { bg: 'rgba(20,184,166,0.12)',  text: 'rgb(20,184,166)' },
+  ignored:          { bg: 'rgba(124,130,147,0.08)', text: 'var(--text-muted)' },
+  'not configured': { bg: 'rgba(124,130,147,0.08)', text: 'var(--text-secondary)' },
+  skipped:          { bg: 'rgba(124,130,147,0.08)', text: 'var(--text-secondary)' },
+}
+
+const statusIcons: Record<string, typeof CheckCircle2> = {
+  healthy:          CheckCircle2,
+  completed:        CheckCircle2,
+  found:            CheckCircle2,
+  extracted:        CheckCircle2,
+  running:          Loader2,
+  queued:           Clock,
+  failed:           XCircle,
+  unhealthy:        XCircle,
+  wanted:           AlertCircle,
+  searching:        Search,
+  ignored:          MinusCircle,
+  skipped:          MinusCircle,
+  'not configured': MinusCircle,
 }
 
 // Map API status strings to common:status translation keys
@@ -45,9 +70,11 @@ const statusTranslationKeys: Record<string, string> = {
 
 export function StatusBadge({ status, className }: StatusBadgeProps) {
   const { t } = useTranslation('common')
-  const style = statusStyles[status.toLowerCase()] || statusStyles['not configured']
-  const isRunning = status.toLowerCase() === 'running'
-  const translationKey = statusTranslationKeys[status.toLowerCase()]
+  const key = status.toLowerCase()
+  const style = statusStyles[key] || statusStyles['not configured']
+  const Icon = statusIcons[key] || MinusCircle
+  const isRunning = key === 'running'
+  const translationKey = statusTranslationKeys[key]
   const label = translationKey ? t(translationKey) : status
 
   return (
@@ -58,13 +85,11 @@ export function StatusBadge({ status, className }: StatusBadgeProps) {
       )}
       style={{ backgroundColor: style.bg, color: style.text }}
     >
-      <span
-        className="w-1.5 h-1.5 rounded-full shrink-0"
-        style={{
-          backgroundColor: style.dot,
-          color: style.dot,
-          animation: isRunning ? 'dotGlow 2s ease-in-out infinite' : undefined,
-        }}
+      <Icon
+        size={11}
+        strokeWidth={2.5}
+        className={isRunning ? 'animate-spin' : undefined}
+        aria-hidden="true"
       />
       {label}
     </span>

--- a/frontend/src/components/shared/SubtitleCleanupModal.tsx
+++ b/frontend/src/components/shared/SubtitleCleanupModal.tsx
@@ -99,15 +99,19 @@ export function SubtitleCleanupModal({ seriesId, targetLanguages, onClose }: Pro
       onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
     >
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="subtitle-cleanup-title"
         className="w-full max-w-md rounded-lg flex flex-col"
         style={{ backgroundColor: 'var(--bg-surface)', border: '1px solid var(--border)', maxHeight: '80vh' }}
       >
         {/* Header */}
         <div className="flex items-center justify-between px-4 py-3" style={{ borderBottom: '1px solid var(--border)' }}>
-          <span className="font-semibold text-sm" style={{ color: 'var(--text-primary)' }}>
+          <h2 id="subtitle-cleanup-title" className="font-semibold text-sm" style={{ color: 'var(--text-primary)' }}>
             Sidecar bereinigen
-          </span>
+          </h2>
           <button
+            autoFocus
             onClick={onClose}
             className="p-1 rounded"
             style={{ color: 'var(--text-muted)' }}

--- a/frontend/src/components/shared/Toast.tsx
+++ b/frontend/src/components/shared/Toast.tsx
@@ -65,7 +65,12 @@ export function ToastContainer() {
   if (toasts.length === 0) return null
 
   return (
-    <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2">
+    <div
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      className="fixed bottom-4 right-4 z-50 flex flex-col gap-2"
+    >
       {toasts.map((t) => {
         const Icon = icons[t.type]
         return (

--- a/frontend/src/components/sync/SyncModal.tsx
+++ b/frontend/src/components/sync/SyncModal.tsx
@@ -123,6 +123,9 @@ export function SyncModal({ episodeId, subtitlePath, videoPath, onClose, onCompl
       onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
     >
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="sync-modal-title"
         className="w-full max-w-md mx-4 rounded-lg overflow-hidden flex flex-col"
         style={{ backgroundColor: 'var(--bg-surface)', border: '1px solid var(--border)' }}
       >
@@ -132,14 +135,15 @@ export function SyncModal({ episodeId, subtitlePath, videoPath, onClose, onCompl
           style={{ borderBottom: '1px solid var(--border)', backgroundColor: 'var(--bg-elevated)' }}
         >
           <div>
-            <p className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
+            <h2 id="sync-modal-title" className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
               Untertitel synchronisieren
-            </p>
+            </h2>
             <p className="text-xs truncate max-w-xs mt-0.5" style={{ color: 'var(--text-muted)' }}>
               {fileName}
             </p>
           </div>
           <button
+            autoFocus
             onClick={onClose}
             className="p-1.5 rounded transition-colors"
             style={{ color: 'var(--text-muted)' }}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -231,6 +231,11 @@ h2 {
   border-radius: var(--radius-md);
 }
 
+/* Hover utilities for CSS custom property backgrounds */
+.hover-surface:hover {
+  background-color: var(--bg-surface-hover);
+}
+
 /* ---- Card (*arr-style flat) ---- */
 .card {
   background-color: var(--bg-surface);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -232,6 +232,10 @@ h2 {
 }
 
 /* Hover utilities for CSS custom property backgrounds */
+.bg-surface {
+  background-color: var(--bg-surface);
+}
+
 .hover-surface:hover {
   background-color: var(--bg-surface-hover);
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -305,3 +305,14 @@ a:hover {
     font-size: 14px;
   }
 }
+
+/* Respect user motion preferences */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/frontend/src/pages/Blacklist.tsx
+++ b/frontend/src/pages/Blacklist.tsx
@@ -96,13 +96,13 @@ export function BlacklistPage() {
           <table className="w-full min-w-[600px]">
             <thead>
               <tr style={{ borderBottom: '1px solid var(--border)' }}>
-                <th className="text-left text-[11px] font-semibold uppercase tracking-wider px-4 py-2.5" style={{ color: 'var(--text-muted)' }}>{t('blacklist.table.provider')}</th>
-                <th className="text-left text-[11px] font-semibold uppercase tracking-wider px-3 py-2.5" style={{ color: 'var(--text-muted)' }}>{t('blacklist.table.subtitle_id')}</th>
-                <th className="text-left text-[11px] font-semibold uppercase tracking-wider px-3 py-2.5" style={{ color: 'var(--text-muted)' }}>{t('blacklist.table.lang')}</th>
-                <th className="text-left text-[11px] font-semibold uppercase tracking-wider px-3 py-2.5 hidden sm:table-cell" style={{ color: 'var(--text-muted)' }}>{t('blacklist.table.title_path')}</th>
-                <th className="text-left text-[11px] font-semibold uppercase tracking-wider px-3 py-2.5 hidden md:table-cell" style={{ color: 'var(--text-muted)' }}>{t('blacklist.table.reason')}</th>
-                <th className="text-left text-[11px] font-semibold uppercase tracking-wider px-3 py-2.5 hidden lg:table-cell" style={{ color: 'var(--text-muted)' }}>{t('blacklist.table.added')}</th>
-                <th className="text-right text-[11px] font-semibold uppercase tracking-wider px-4 py-2.5" style={{ color: 'var(--text-muted)' }}>{t('blacklist.table.actions')}</th>
+                <th scope="col" className="text-left text-[11px] font-semibold uppercase tracking-wider px-4 py-2.5" style={{ color: 'var(--text-muted)' }}>{t('blacklist.table.provider')}</th>
+                <th scope="col" className="text-left text-[11px] font-semibold uppercase tracking-wider px-3 py-2.5" style={{ color: 'var(--text-muted)' }}>{t('blacklist.table.subtitle_id')}</th>
+                <th scope="col" className="text-left text-[11px] font-semibold uppercase tracking-wider px-3 py-2.5" style={{ color: 'var(--text-muted)' }}>{t('blacklist.table.lang')}</th>
+                <th scope="col" className="text-left text-[11px] font-semibold uppercase tracking-wider px-3 py-2.5 hidden sm:table-cell" style={{ color: 'var(--text-muted)' }}>{t('blacklist.table.title_path')}</th>
+                <th scope="col" className="text-left text-[11px] font-semibold uppercase tracking-wider px-3 py-2.5 hidden md:table-cell" style={{ color: 'var(--text-muted)' }}>{t('blacklist.table.reason')}</th>
+                <th scope="col" className="text-left text-[11px] font-semibold uppercase tracking-wider px-3 py-2.5 hidden lg:table-cell" style={{ color: 'var(--text-muted)' }}>{t('blacklist.table.added')}</th>
+                <th scope="col" className="text-right text-[11px] font-semibold uppercase tracking-wider px-4 py-2.5" style={{ color: 'var(--text-muted)' }}>{t('blacklist.table.actions')}</th>
               </tr>
             </thead>
             <tbody>

--- a/frontend/src/pages/History.tsx
+++ b/frontend/src/pages/History.tsx
@@ -422,7 +422,7 @@ export function HistoryPage() {
           <table className="w-full min-w-[600px]">
             <thead>
               <tr style={{ borderBottom: '1px solid var(--border)' }}>
-                <th className="text-left px-3 py-2.5 w-8">
+                <th scope="col" className="text-left px-3 py-2.5 w-8">
                   <button onClick={toggleSelectAll} className="p-0.5" style={{ color: 'var(--text-muted)' }}>
                     {allSelected ? (
                       <CheckSquare size={14} style={{ color: 'var(--accent)' }} />
@@ -433,13 +433,13 @@ export function HistoryPage() {
                     )}
                   </button>
                 </th>
-                <th className="text-left text-[11px] font-semibold uppercase tracking-wider px-4 py-2.5" style={{ color: 'var(--text-muted)' }}>{t('history.table.content')}</th>
-                <th className="text-left text-[11px] font-semibold uppercase tracking-wider px-3 py-2.5" style={{ color: 'var(--text-muted)' }}>{t('history.table.provider')}</th>
-                <th className="text-left text-[11px] font-semibold uppercase tracking-wider px-3 py-2.5" style={{ color: 'var(--text-muted)' }}>{t('history.table.lang')}</th>
-                <th className="text-left text-[11px] font-semibold uppercase tracking-wider px-3 py-2.5" style={{ color: 'var(--text-muted)' }}>{t('history.table.format')}</th>
-                <th className="text-left text-[11px] font-semibold uppercase tracking-wider px-3 py-2.5 hidden sm:table-cell" style={{ color: 'var(--text-muted)' }}>{t('history.table.score')}</th>
-                <th className="text-left text-[11px] font-semibold uppercase tracking-wider px-3 py-2.5 hidden md:table-cell" style={{ color: 'var(--text-muted)' }}>{t('history.table.date')}</th>
-                <th className="text-right text-[11px] font-semibold uppercase tracking-wider px-4 py-2.5" style={{ color: 'var(--text-muted)' }}>{t('history.table.actions')}</th>
+                <th scope="col" className="text-left text-[11px] font-semibold uppercase tracking-wider px-4 py-2.5" style={{ color: 'var(--text-muted)' }}>{t('history.table.content')}</th>
+                <th scope="col" className="text-left text-[11px] font-semibold uppercase tracking-wider px-3 py-2.5" style={{ color: 'var(--text-muted)' }}>{t('history.table.provider')}</th>
+                <th scope="col" className="text-left text-[11px] font-semibold uppercase tracking-wider px-3 py-2.5" style={{ color: 'var(--text-muted)' }}>{t('history.table.lang')}</th>
+                <th scope="col" className="text-left text-[11px] font-semibold uppercase tracking-wider px-3 py-2.5" style={{ color: 'var(--text-muted)' }}>{t('history.table.format')}</th>
+                <th scope="col" className="text-left text-[11px] font-semibold uppercase tracking-wider px-3 py-2.5 hidden sm:table-cell" style={{ color: 'var(--text-muted)' }}>{t('history.table.score')}</th>
+                <th scope="col" className="text-left text-[11px] font-semibold uppercase tracking-wider px-3 py-2.5 hidden md:table-cell" style={{ color: 'var(--text-muted)' }}>{t('history.table.date')}</th>
+                <th scope="col" className="text-right text-[11px] font-semibold uppercase tracking-wider px-4 py-2.5" style={{ color: 'var(--text-muted)' }}>{t('history.table.actions')}</th>
               </tr>
             </thead>
             <tbody>

--- a/frontend/src/pages/Library.tsx
+++ b/frontend/src/pages/Library.tsx
@@ -190,7 +190,7 @@ function LibraryTable({ items, type, profiles, onRowClick, onProfileChange, sort
         <thead>
           <tr style={{ backgroundColor: 'var(--bg-elevated)' }}>
             {isSeries && (
-              <th className="w-10 pl-3">
+              <th scope="col" className="w-10 pl-3">
                 <input
                   type="checkbox"
                   checked={allSelected}
@@ -202,6 +202,8 @@ function LibraryTable({ items, type, profiles, onRowClick, onProfileChange, sort
               </th>
             )}
             <th
+              scope="col"
+              aria-sort={sortKey === 'title' ? (sortDir === 'asc' ? 'ascending' : 'descending') : 'none'}
               className="text-left text-[11px] font-semibold uppercase tracking-wider px-4 py-2.5 cursor-pointer select-none"
               style={{ color: 'var(--text-secondary)' }}
               onClick={() => onSort('title')}
@@ -212,6 +214,8 @@ function LibraryTable({ items, type, profiles, onRowClick, onProfileChange, sort
             </th>
             {isSeries && (
               <th
+                scope="col"
+                aria-sort={sortKey === 'missing' ? (sortDir === 'asc' ? 'ascending' : 'descending') : 'none'}
                 className="text-left text-[11px] font-semibold uppercase tracking-wider px-4 py-2.5 w-20 cursor-pointer select-none"
                 style={{ color: 'var(--text-secondary)' }}
                 onClick={() => onSort('missing')}
@@ -222,12 +226,15 @@ function LibraryTable({ items, type, profiles, onRowClick, onProfileChange, sort
               </th>
             )}
             <th
+              scope="col"
               className="text-left text-[11px] font-semibold uppercase tracking-wider px-4 py-2.5 w-40"
               style={{ color: 'var(--text-secondary)' }}
             >
               {t('table.profile')}
             </th>
             <th
+              scope="col"
+              aria-sort={sortKey === 'episodes' ? (sortDir === 'asc' ? 'ascending' : 'descending') : 'none'}
               className="text-left text-[11px] font-semibold uppercase tracking-wider px-4 py-2.5 w-44 cursor-pointer select-none"
               style={{ color: 'var(--text-secondary)' }}
               onClick={() => onSort('episodes')}

--- a/frontend/src/pages/Library.tsx
+++ b/frontend/src/pages/Library.tsx
@@ -895,12 +895,13 @@ export function LibraryPage() {
             </div>
           )}
           {viewMode === 'grid' ? (
-            <div className="grid grid-cols-3 sm:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8 gap-3">
-              {paginatedItems.map((item) => (
+            <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6 xl:grid-cols-8 gap-3">
+              {paginatedItems.map((item, i) => (
                 <LibraryGridCard
                   key={item.id}
                   item={item}
                   onClick={() => handleRowClick(item.id)}
+                  style={{ animationDelay: `${Math.min(i * 30, 300)}ms` }}
                 />
               ))}
             </div>

--- a/frontend/src/pages/Settings/providers/AddProviderModal.tsx
+++ b/frontend/src/pages/Settings/providers/AddProviderModal.tsx
@@ -45,6 +45,9 @@ export function AddProviderModal({ availableProviders, onSelect, onClose }: AddP
       onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
     >
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="add-provider-title"
         className="w-full max-w-sm rounded-lg overflow-hidden"
         style={{
           backgroundColor: 'var(--bg-surface)',
@@ -61,11 +64,12 @@ export function AddProviderModal({ availableProviders, onSelect, onClose }: AddP
             <p className="text-[11px] font-medium mb-0.5" style={{ color: 'var(--text-muted)' }}>
               Schritt 1 von 2
             </p>
-            <p className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
+            <h2 id="add-provider-title" className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
               Provider hinzufügen
-            </p>
+            </h2>
           </div>
           <button
+            autoFocus
             onClick={onClose}
             className="p-1.5 rounded transition-colors"
             style={{ color: 'var(--text-muted)' }}

--- a/frontend/src/pages/Settings/providers/ProviderEditModal.tsx
+++ b/frontend/src/pages/Settings/providers/ProviderEditModal.tsx
@@ -86,6 +86,9 @@ export function ProviderEditModal({
       onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
     >
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="provider-edit-title"
         className="w-full max-w-lg flex flex-col rounded-lg overflow-hidden"
         style={{
           backgroundColor: 'var(--bg-surface)',
@@ -103,11 +106,12 @@ export function ProviderEditModal({
             <p className="text-[11px] font-medium mb-0.5" style={{ color: 'var(--text-muted)' }}>
               {isNew ? 'Schritt 2 von 2 · ' : ''}Provider bearbeiten
             </p>
-            <p className="text-sm font-semibold capitalize" style={{ color: 'var(--text-primary)' }}>
+            <h2 id="provider-edit-title" className="text-sm font-semibold capitalize" style={{ color: 'var(--text-primary)' }}>
               {provider.name.replace(/_/g, ' ')}
-            </p>
+            </h2>
           </div>
           <button
+            autoFocus
             onClick={onClose}
             className="p-1.5 rounded transition-colors"
             style={{ color: 'var(--text-muted)' }}

--- a/frontend/src/pages/Settings/providers/ProviderEditModal.tsx
+++ b/frontend/src/pages/Settings/providers/ProviderEditModal.tsx
@@ -253,33 +253,38 @@ export function ProviderEditModal({
           {/* ── Zugangsdaten ── */}
           {provider.config_fields.length > 0 ? (
             <div className="pt-1" style={{ borderTop: '1px solid var(--border)' }}>
-              {provider.config_fields.map((field) => (
-                <SettingRow
-                  key={field.key}
-                  label={field.label}
-                  description={getFieldDescription(field.key, field.label)}
-                >
-                  <input
-                    type={field.type}
-                    value={fieldValues[field.key] === '***configured***' ? '' : (fieldValues[field.key] ?? '')}
-                    onChange={(e) => onFieldChange(field.key, e.target.value)}
-                    placeholder={
-                      fieldValues[field.key] === '***configured***'
-                        ? '(configured)'
-                        : field.required
-                          ? 'Required'
-                          : 'Optional'
-                    }
-                    className="w-full px-2.5 py-1.5 rounded text-xs transition-all focus:outline-none"
-                    style={{
-                      backgroundColor: 'var(--bg-primary)',
-                      border: '1px solid var(--border)',
-                      color: 'var(--text-primary)',
-                      fontFamily: 'var(--font-mono)',
-                    }}
-                  />
-                </SettingRow>
-              ))}
+              {provider.config_fields.map((field) => {
+                const inputId = `provider-edit-${provider.name}-${field.key}`
+                return (
+                  <SettingRow
+                    key={field.key}
+                    label={field.label}
+                    description={getFieldDescription(field.key, field.label)}
+                    htmlFor={inputId}
+                  >
+                    <input
+                      id={inputId}
+                      type={field.type}
+                      value={fieldValues[field.key] === '***configured***' ? '' : (fieldValues[field.key] ?? '')}
+                      onChange={(e) => onFieldChange(field.key, e.target.value)}
+                      placeholder={
+                        fieldValues[field.key] === '***configured***'
+                          ? '(configured)'
+                          : field.required
+                            ? 'Required'
+                            : 'Optional'
+                      }
+                      className="w-full px-2.5 py-1.5 rounded text-xs transition-all focus:outline-none"
+                      style={{
+                        backgroundColor: 'var(--bg-primary)',
+                        border: '1px solid var(--border)',
+                        color: 'var(--text-primary)',
+                        fontFamily: 'var(--font-mono)',
+                      }}
+                    />
+                  </SettingRow>
+                )
+              })}
             </div>
           ) : (
             <div className="py-3 text-xs" style={{ color: 'var(--text-muted)', borderTop: '1px solid var(--border)' }}>

--- a/frontend/src/pages/Settings/providers/ProviderEditModal.tsx
+++ b/frontend/src/pages/Settings/providers/ProviderEditModal.tsx
@@ -35,6 +35,37 @@ export function ProviderEditModal({
   onClearCache, onReEnable, onRemove, isNew, onClose,
 }: ProviderEditModalProps) {
   const [confirmRemove, setConfirmRemove] = useState(false)
+  const [errors, setErrors] = useState<Record<string, string>>({})
+
+  const validateField = (fieldKey: string, value: string, label: string) => {
+    if (!value.trim()) {
+      setErrors(prev => ({ ...prev, [fieldKey]: `${label} is required` }))
+    } else {
+      setErrors(prev => {
+        const { [fieldKey]: _removed, ...rest } = prev
+        return rest
+      })
+    }
+  }
+
+  const handleTest = () => {
+    // Validate all required fields before running the test
+    const newErrors: Record<string, string> = {}
+    for (const field of provider.config_fields) {
+      if (field.required) {
+        const value = fieldValues[field.key] ?? ''
+        // '***configured***' means a value is already saved server-side — treat as valid
+        if (value !== '***configured***' && !value.trim()) {
+          newErrors[field.key] = `${field.label} is required`
+        }
+      }
+    }
+    if (Object.keys(newErrors).length > 0) {
+      setErrors(newErrors)
+      return
+    }
+    onTest()
+  }
 
   // Escape key closes modal
   useEffect(() => {
@@ -255,6 +286,8 @@ export function ProviderEditModal({
             <div className="pt-1" style={{ borderTop: '1px solid var(--border)' }}>
               {provider.config_fields.map((field) => {
                 const inputId = `provider-edit-${provider.name}-${field.key}`
+                const errorId = `${inputId}-error`
+                const hasError = !!errors[field.key]
                 return (
                   <SettingRow
                     key={field.key}
@@ -262,26 +295,40 @@ export function ProviderEditModal({
                     description={getFieldDescription(field.key, field.label)}
                     htmlFor={inputId}
                   >
-                    <input
-                      id={inputId}
-                      type={field.type}
-                      value={fieldValues[field.key] === '***configured***' ? '' : (fieldValues[field.key] ?? '')}
-                      onChange={(e) => onFieldChange(field.key, e.target.value)}
-                      placeholder={
-                        fieldValues[field.key] === '***configured***'
-                          ? '(configured)'
-                          : field.required
-                            ? 'Required'
-                            : 'Optional'
-                      }
-                      className="w-full px-2.5 py-1.5 rounded text-xs transition-all focus:outline-none"
-                      style={{
-                        backgroundColor: 'var(--bg-primary)',
-                        border: '1px solid var(--border)',
-                        color: 'var(--text-primary)',
-                        fontFamily: 'var(--font-mono)',
-                      }}
-                    />
+                    <div className="w-full">
+                      <input
+                        id={inputId}
+                        type={field.type}
+                        value={fieldValues[field.key] === '***configured***' ? '' : (fieldValues[field.key] ?? '')}
+                        onChange={(e) => onFieldChange(field.key, e.target.value)}
+                        onBlur={(e) => {
+                          if (field.required && fieldValues[field.key] !== '***configured***') {
+                            validateField(field.key, e.target.value, field.label)
+                          }
+                        }}
+                        placeholder={
+                          fieldValues[field.key] === '***configured***'
+                            ? '(configured)'
+                            : field.required
+                              ? 'Required'
+                              : 'Optional'
+                        }
+                        aria-describedby={hasError ? errorId : undefined}
+                        aria-invalid={hasError}
+                        className="w-full px-2.5 py-1.5 rounded text-xs transition-all focus:outline-none"
+                        style={{
+                          backgroundColor: 'var(--bg-primary)',
+                          border: `1px solid ${hasError ? 'var(--error)' : 'var(--border)'}`,
+                          color: 'var(--text-primary)',
+                          fontFamily: 'var(--font-mono)',
+                        }}
+                      />
+                      {hasError && (
+                        <p id={errorId} role="alert" className="text-xs mt-1" style={{ color: 'var(--error)' }}>
+                          {errors[field.key]}
+                        </p>
+                      )}
+                    </div>
                   </SettingRow>
                 )
               })}
@@ -352,7 +399,7 @@ export function ProviderEditModal({
           {/* Right: Test + Close */}
           <div className="flex items-center gap-2">
             <button
-              onClick={onTest}
+              onClick={handleTest}
               disabled={!provider.enabled || testResult === 'testing'}
               className="flex items-center gap-1.5 px-3 py-1.5 rounded text-xs font-medium transition-all hover:opacity-80"
               style={{

--- a/frontend/src/pages/Settings/providers/ProviderTile.tsx
+++ b/frontend/src/pages/Settings/providers/ProviderTile.tsx
@@ -27,9 +27,8 @@ export function ProviderTile({
 
   return (
     <div
-      className="hover-surface relative rounded overflow-hidden group cursor-pointer"
+      className="bg-surface hover-surface relative rounded overflow-hidden group cursor-pointer"
       style={{
-        backgroundColor: 'var(--bg-surface)',
         border: '1px solid var(--border)',
         borderLeft: `4px solid ${borderColor}`,
         minHeight: '7rem',

--- a/frontend/src/pages/Settings/providers/ProviderTile.tsx
+++ b/frontend/src/pages/Settings/providers/ProviderTile.tsx
@@ -27,7 +27,7 @@ export function ProviderTile({
 
   return (
     <div
-      className="relative rounded overflow-hidden group cursor-pointer"
+      className="hover-surface relative rounded overflow-hidden group cursor-pointer"
       style={{
         backgroundColor: 'var(--bg-surface)',
         border: '1px solid var(--border)',
@@ -37,8 +37,6 @@ export function ProviderTile({
         opacity: provider.enabled ? 1 : 0.5,
       }}
       onClick={onOpenEdit}
-      onMouseEnter={(e) => { e.currentTarget.style.backgroundColor = 'var(--bg-surface-hover)' }}
-      onMouseLeave={(e) => { e.currentTarget.style.backgroundColor = 'var(--bg-surface)' }}
     >
       <div className="p-3">
         {/* Provider name + rank */}

--- a/frontend/src/pages/Wanted.tsx
+++ b/frontend/src/pages/Wanted.tsx
@@ -858,12 +858,12 @@ export function WantedPage() {
                   </tr>
                 ))
               ) : filteredData?.length ? (
-                filteredData.map((item) => (
+                filteredData.map((item, i) => (
                   <Fragment key={item.id}>
                     <tr
                       data-testid="wanted-item"
                       className="transition-colors duration-100"
-                      style={{ borderBottom: '1px solid var(--border)' }}
+                      style={{ borderBottom: '1px solid var(--border)', animationDelay: `${Math.min(i * 30, 300)}ms` }}
                       onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = 'var(--bg-surface-hover)')}
                       onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = 'transparent')}
                     >

--- a/frontend/src/pages/Wanted.tsx
+++ b/frontend/src/pages/Wanted.tsx
@@ -821,7 +821,7 @@ export function WantedPage() {
           <table className="w-full min-w-[800px]">
             <thead>
               <tr style={{ borderBottom: '1px solid var(--border)' }}>
-                <th className="text-left px-3 py-2.5 w-8">
+                <th scope="col" className="text-left px-3 py-2.5 w-8">
                   <button onClick={toggleSelectAll} className="p-0.5" style={{ color: 'var(--text-muted)' }}>
                     {allSelected ? (
                       <CheckSquare size={14} style={{ color: 'var(--accent)' }} />
@@ -832,14 +832,14 @@ export function WantedPage() {
                     )}
                   </button>
                 </th>
-                <th className="text-left text-[11px] font-semibold uppercase tracking-wider px-3 py-2.5" style={{ color: 'var(--text-muted)' }}>{t('wanted.title_col')}</th>
-                <th className="text-left text-[11px] font-semibold uppercase tracking-wider px-3 py-2.5" style={{ color: 'var(--text-muted)' }}>{t('wanted.se_col')}</th>
-                <th className="text-left text-[11px] font-semibold uppercase tracking-wider px-3 py-2.5" style={{ color: 'var(--text-muted)' }}>{t('wanted.status_col')}</th>
-                <th className="text-left text-[11px] font-semibold uppercase tracking-wider px-3 py-2.5 hidden sm:table-cell" style={{ color: 'var(--text-muted)' }}>{t('wanted.existing_col')}</th>
-                <th className="text-left text-[11px] font-semibold uppercase tracking-wider px-3 py-2.5 hidden md:table-cell" style={{ color: 'var(--text-muted)' }}>{t('wanted.searches_col')}</th>
-                <th className="text-left text-[11px] font-semibold uppercase tracking-wider px-3 py-2.5 hidden lg:table-cell" style={{ color: 'var(--text-muted)' }}>{t('wanted.last_search_col')}</th>
-                <th className="text-left text-[11px] font-semibold uppercase tracking-wider px-3 py-2.5 hidden lg:table-cell" style={{ color: 'var(--text-muted)' }}>{t('wanted.added_col')}</th>
-                <th className="text-right text-[11px] font-semibold uppercase tracking-wider px-4 py-2.5" style={{ color: 'var(--text-muted)' }}>{t('wanted.actions_col')}</th>
+                <th scope="col" className="text-left text-[11px] font-semibold uppercase tracking-wider px-3 py-2.5" style={{ color: 'var(--text-muted)' }}>{t('wanted.title_col')}</th>
+                <th scope="col" className="text-left text-[11px] font-semibold uppercase tracking-wider px-3 py-2.5" style={{ color: 'var(--text-muted)' }}>{t('wanted.se_col')}</th>
+                <th scope="col" className="text-left text-[11px] font-semibold uppercase tracking-wider px-3 py-2.5" style={{ color: 'var(--text-muted)' }}>{t('wanted.status_col')}</th>
+                <th scope="col" className="text-left text-[11px] font-semibold uppercase tracking-wider px-3 py-2.5 hidden sm:table-cell" style={{ color: 'var(--text-muted)' }}>{t('wanted.existing_col')}</th>
+                <th scope="col" className="text-left text-[11px] font-semibold uppercase tracking-wider px-3 py-2.5 hidden md:table-cell" style={{ color: 'var(--text-muted)' }}>{t('wanted.searches_col')}</th>
+                <th scope="col" className="text-left text-[11px] font-semibold uppercase tracking-wider px-3 py-2.5 hidden lg:table-cell" style={{ color: 'var(--text-muted)' }}>{t('wanted.last_search_col')}</th>
+                <th scope="col" className="text-left text-[11px] font-semibold uppercase tracking-wider px-3 py-2.5 hidden lg:table-cell" style={{ color: 'var(--text-muted)' }}>{t('wanted.added_col')}</th>
+                <th scope="col" className="text-right text-[11px] font-semibold uppercase tracking-wider px-4 py-2.5" style={{ color: 'var(--text-muted)' }}>{t('wanted.actions_col')}</th>
               </tr>
             </thead>
             <tbody>

--- a/frontend/src/test/App.skiplink.test.tsx
+++ b/frontend/src/test/App.skiplink.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import React from 'react'
+
+// Mock WebSocket context and hook
+vi.mock('@/contexts/WebSocketContext', () => ({
+  WebSocketProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+vi.mock('@/hooks/useWebSocket', () => ({
+  useWebSocket: () => ({}),
+}))
+
+// Mock the Sidebar so we don't pull in all nav dependencies
+vi.mock('@/components/layout/Sidebar', () => ({
+  Sidebar: () => <nav data-testid="sidebar" />,
+}))
+
+// Mock global modals / FABs
+vi.mock('@/components/search/GlobalSearchModal', () => ({
+  GlobalSearchModal: () => null,
+}))
+vi.mock('@/components/quick-actions/QuickActionsFAB', () => ({
+  QuickActionsFAB: () => null,
+}))
+vi.mock('@/components/quick-actions/KeyboardShortcutsModal', () => ({
+  KeyboardShortcutsModal: () => null,
+}))
+
+// Mock keyboard shortcuts hook (used inside BrowserRouter context)
+vi.mock('@/hooks/useKeyboardShortcuts', () => ({
+  useKeyboardShortcuts: () => undefined,
+}))
+
+// Mock react-i18next
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'en', changeLanguage: vi.fn() },
+  }),
+  initReactI18next: { type: '3rdParty', init: vi.fn() },
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+// Mock all lazy-loaded pages to avoid dynamic import issues in tests
+vi.mock('@/pages/Dashboard', () => ({ Dashboard: () => <div>Dashboard</div> }))
+vi.mock('@/pages/Activity', () => ({ ActivityPage: () => <div>Activity</div> }))
+vi.mock('@/pages/Wanted', () => ({ WantedPage: () => <div>Wanted</div> }))
+vi.mock('@/pages/Queue', () => ({ QueuePage: () => <div>Queue</div> }))
+vi.mock('@/pages/Settings', () => ({ SettingsPage: () => <div>Settings</div> }))
+vi.mock('@/pages/Logs', () => ({ LogsPage: () => <div>Logs</div> }))
+vi.mock('@/pages/Statistics', () => ({ StatisticsPage: () => <div>Statistics</div> }))
+vi.mock('@/pages/Library', () => ({ LibraryPage: () => <div>Library</div> }))
+vi.mock('@/pages/SeriesDetail', () => ({ SeriesDetailPage: () => <div>SeriesDetail</div> }))
+vi.mock('@/pages/History', () => ({ HistoryPage: () => <div>History</div> }))
+vi.mock('@/pages/Blacklist', () => ({ BlacklistPage: () => <div>Blacklist</div> }))
+vi.mock('@/pages/Tasks', () => ({ TasksPage: () => <div>Tasks</div> }))
+vi.mock('@/pages/Plugins', () => ({ PluginsPage: () => <div>Plugins</div> }))
+vi.mock('@/pages/NotFound', () => ({ NotFoundPage: () => <div>NotFound</div> }))
+vi.mock('@/pages/Onboarding', () => ({ default: () => <div>Onboarding</div> }))
+
+describe('Skip link', () => {
+  it('has a skip-to-main-content link as first focusable element', async () => {
+    const { default: App } = await import('@/App')
+    const { container } = render(<App />)
+
+    const skipLink = container.querySelector('a[href="#main-content"]')
+    expect(skipLink).toBeInTheDocument()
+    expect(skipLink).toHaveTextContent(/skip/i)
+  })
+
+  it('has a main element with id="main-content" as the link target', async () => {
+    const { default: App } = await import('@/App')
+    const { container } = render(<App />)
+
+    const mainContent = container.querySelector('#main-content')
+    expect(mainContent).toBeInTheDocument()
+    expect(mainContent?.tagName.toLowerCase()).toBe('main')
+  })
+
+  it('skip link appears before sidebar in DOM order', async () => {
+    const { default: App } = await import('@/App')
+    const { container } = render(<App />)
+
+    const skipLink = container.querySelector('a[href="#main-content"]')
+    const sidebar = container.querySelector('[data-testid="sidebar"]')
+    expect(skipLink).toBeInTheDocument()
+    expect(sidebar).toBeInTheDocument()
+
+    // compareDocumentPosition: DOCUMENT_POSITION_FOLLOWING = 4 means sidebar comes after skipLink
+    const position = skipLink!.compareDocumentPosition(sidebar!)
+    expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+})

--- a/frontend/src/test/ModalAccessibility.test.tsx
+++ b/frontend/src/test/ModalAccessibility.test.tsx
@@ -1,0 +1,38 @@
+/**
+ * ModalAccessibility.test.tsx — Verify role="dialog" and aria-modal attributes
+ * on modal components that were updated in the v0.21.1 UI/UX polish pass.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key.split('.').pop() ?? key,
+    i18n: { language: 'en', changeLanguage: vi.fn() },
+  }),
+}))
+
+vi.mock('@/hooks/useApi', () => ({
+  useGlobalSearch: () => ({ data: undefined, isFetching: false }),
+  useProviders: () => ({ data: [] }),
+  useLibrary: () => ({ data: [] }),
+}))
+
+vi.mock('@/hooks/useWebSocket', () => ({
+  useWebSocket: () => ({}),
+}))
+
+describe('Modal accessibility attributes', () => {
+  it('GlobalSearchModal has role=dialog and aria-modal when open', async () => {
+    const { GlobalSearchModal } = await import('@/components/search/GlobalSearchModal')
+    const { container } = render(
+      <MemoryRouter>
+        <GlobalSearchModal open={true} onOpenChange={() => {}} />
+      </MemoryRouter>
+    )
+    const dialog = container.querySelector('[role="dialog"]')
+    expect(dialog).toBeInTheDocument()
+    expect(dialog).toHaveAttribute('aria-modal', 'true')
+  })
+})

--- a/frontend/src/test/ModalAccessibility.test.tsx
+++ b/frontend/src/test/ModalAccessibility.test.tsx
@@ -4,7 +4,7 @@
  */
 import { describe, it, expect, vi } from 'vitest'
 import { render } from '@testing-library/react'
-import { MemoryRouter } from 'react-router-dom'
+import { WidgetSettingsModal } from '@/components/dashboard/WidgetSettingsModal'
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -13,23 +13,15 @@ vi.mock('react-i18next', () => ({
   }),
 }))
 
-vi.mock('@/hooks/useApi', () => ({
-  useGlobalSearch: () => ({ data: undefined, isFetching: false }),
-  useProviders: () => ({ data: [] }),
-  useLibrary: () => ({ data: [] }),
-}))
-
-vi.mock('@/hooks/useWebSocket', () => ({
-  useWebSocket: () => ({}),
+vi.mock('@/stores/dashboardStore', () => ({
+  useDashboardStore: (selector: (s: { hiddenWidgets: string[]; toggleWidget: () => void; resetToDefault: () => void }) => unknown) =>
+    selector({ hiddenWidgets: [], toggleWidget: vi.fn(), resetToDefault: vi.fn() }),
 }))
 
 describe('Modal accessibility attributes', () => {
-  it('GlobalSearchModal has role=dialog and aria-modal when open', async () => {
-    const { GlobalSearchModal } = await import('@/components/search/GlobalSearchModal')
+  it('WidgetSettingsModal has role=dialog and aria-modal when open', () => {
     const { container } = render(
-      <MemoryRouter>
-        <GlobalSearchModal open={true} onOpenChange={() => {}} />
-      </MemoryRouter>
+      <WidgetSettingsModal open={true} onClose={() => {}} />
     )
     const dialog = container.querySelector('[role="dialog"]')
     expect(dialog).toBeInTheDocument()

--- a/frontend/src/test/StatusBadge.test.tsx
+++ b/frontend/src/test/StatusBadge.test.tsx
@@ -18,7 +18,6 @@ describe('StatusBadge', () => {
   it('renders different statuses', () => {
     const { rerender } = render(<StatusBadge status="running" />)
     expect(screen.getByText('running')).toBeInTheDocument()
-
     rerender(<StatusBadge status="failed" />)
     expect(screen.getByText('failed')).toBeInTheDocument()
   })
@@ -26,5 +25,30 @@ describe('StatusBadge', () => {
   it('applies custom className', () => {
     const { container } = render(<StatusBadge status="completed" className="custom-class" />)
     expect(container.firstChild).toHaveClass('custom-class')
+  })
+
+  it('renders an SVG icon for completed status', () => {
+    const { container } = render(<StatusBadge status="completed" />)
+    expect(container.querySelector('svg')).toBeInTheDocument()
+  })
+
+  it('renders an SVG icon for failed status', () => {
+    const { container } = render(<StatusBadge status="failed" />)
+    expect(container.querySelector('svg')).toBeInTheDocument()
+  })
+
+  it('renders an SVG icon for running status', () => {
+    const { container } = render(<StatusBadge status="running" />)
+    expect(container.querySelector('svg')).toBeInTheDocument()
+  })
+
+  it('renders an SVG icon for queued status', () => {
+    const { container } = render(<StatusBadge status="queued" />)
+    expect(container.querySelector('svg')).toBeInTheDocument()
+  })
+
+  it('renders an SVG icon for wanted status', () => {
+    const { container } = render(<StatusBadge status="wanted" />)
+    expect(container.querySelector('svg')).toBeInTheDocument()
   })
 })

--- a/frontend/src/test/Toast.test.tsx
+++ b/frontend/src/test/Toast.test.tsx
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { act } from '@testing-library/react'
+import { render } from '@testing-library/react'
+import { ToastContainer, toast } from '@/components/shared/Toast'
+
+describe('ToastContainer', () => {
+  it('renders a region with role=status and aria-live=polite when a toast fires', async () => {
+    const { getByRole } = render(<ToastContainer />)
+    await act(async () => {
+      toast('Hello world', 'success')
+    })
+    const statusEl = getByRole('status')
+    expect(statusEl).toHaveAttribute('aria-live', 'polite')
+    expect(statusEl).toHaveAttribute('aria-atomic', 'true')
+  })
+})

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -10,12 +10,7 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: './src/test/setup.ts',
-    pool: 'threads',
-    poolOptions: {
-      threads: {
-        singleThread: true,
-      },
-    },
+    pool: 'forks',
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html', 'lcov'],


### PR DESCRIPTION
## Summary

- **Accessibility:** aria-live on toasts, skip-to-main link, scope+aria-sort on all table headers, role=dialog on 7 modals, form labels wired in provider edit modal, lucide icons on StatusBadge (colorblind support)
- **Performance:** prefers-reduced-motion support, stagger animation cap (300ms max), page-specific loading skeletons
- **Mobile/Tablet:** Library grid md:grid-cols-5 breakpoint fix (closes jump from 4→6 columns at 768px)
- **Code quality:** Replace JS hover state (onMouseEnter/onMouseLeave) with CSS hover utilities in 5 components, client-side validation in ProviderEditModal with inline errors + aria-invalid

**Note — Task 11 (list virtualization) deferred:** Library list view and Wanted both use \`<table>/<tr>\` structure and server-side pagination (25 and 50 items respectively). Applying \`useVirtualizer\` with absolute-positioned div wrappers is incompatible with HTML table layout. Deferred to a dedicated refactor that converts to div-based layout first.

## Changes (12 commits)

| Commit | Task |
|--------|------|
| feat: add icons to StatusBadge | Icons per status, colorblind accessibility |
| feat: add aria-live to ToastContainer | Screen reader toast announcements |
| feat: add skip-to-main-content link | Keyboard navigation (first Tab stop) |
| feat: add accessible labels to provider edit form | htmlFor/id wiring via SettingRow |
| feat: add scope and aria-sort to table headers | Library, History, Blacklist, Wanted |
| feat: add client-side validation UI to provider modal | Inline errors, no backend hit |
| refactor: replace JS hover state with CSS hover + role=dialog | CSS hover utilities + 7 modals |
| feat: add page-specific loading skeletons per route | LibrarySkeleton, TableSkeleton, ListSkeleton, FormSkeleton |
| fix: add md tablet breakpoint to Library grid | md:grid-cols-5 |
| feat: add prefers-reduced-motion support and stagger cap | OS preference respected, 300ms max stagger |
| chore: fix vitest config for v4 compatibility | Remove deprecated poolOptions |

## Test plan

- [ ] All vitest tests pass in CI (Ubuntu + Node 20)
- [ ] TypeScript: zero errors (`npx tsc --noEmit`)
- [ ] ESLint: zero errors (8 pre-existing warnings unchanged)
- [ ] Manual: Tab through page → skip link appears on first Tab, activating it moves focus to main content
- [ ] Manual: Open any modal → focus enters modal, Tab stays within visible area
- [ ] Manual: Resize to 768px → Library shows 5 columns
- [ ] Manual: Screen reader on page with toast → toast text announced without interrupting focus
- [ ] Manual: OS reduced-motion enabled → no animations/transitions on Sublarr pages
- [ ] Manual: Add provider, click Test with empty required field → inline error appears without API call