### PR TITLE
feat: provider ecosystem v0.22.0 — GitHub marketplace, SHA256 integrity, capability warnings

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -66,6 +66,7 @@ class Settings(BaseSettings):
     provider_auto_prioritize: bool = True  # Auto-prioritize providers based on success rate
     provider_rate_limit_enabled: bool = True  # Enable rate limiting per provider
     dedup_on_download: bool = True  # Skip download if identical content already exists (SHA-256)
+    github_token: str = ""  # Optional GitHub API token for higher rate limits (5000/h vs 60/h); env: SUBLARR_GITHUB_TOKEN
 
     # Dynamic Provider Timeouts (Phase 3)
     provider_dynamic_timeout_enabled: bool = True

--- a/backend/db/migrations/versions/a2b3c4d5e6f7_add_marketplace_tables.py
+++ b/backend/db/migrations/versions/a2b3c4d5e6f7_add_marketplace_tables.py
@@ -1,0 +1,53 @@
+"""add_marketplace_tables
+
+Revision ID: a2b3c4d5e6f7
+Revises: fa890ea72dab
+Create Date: 2026-03-11
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a2b3c4d5e6f7"
+down_revision = "fa890ea72dab"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "marketplace_cache",
+        sa.Column("name", sa.String(length=200), nullable=False),
+        sa.Column("display_name", sa.String(length=200), nullable=False),
+        sa.Column("author", sa.String(length=200), nullable=False, server_default=""),
+        sa.Column("version", sa.String(length=50), nullable=False, server_default="0.0.0"),
+        sa.Column("description", sa.Text(), nullable=False, server_default=""),
+        sa.Column("github_url", sa.Text(), nullable=False, server_default=""),
+        sa.Column("zip_url", sa.Text(), nullable=False, server_default=""),
+        sa.Column("sha256", sa.String(length=64), nullable=False, server_default=""),
+        sa.Column("capabilities", sa.Text(), nullable=False, server_default="[]"),
+        sa.Column("min_sublarr_version", sa.String(length=50), nullable=False, server_default=""),
+        sa.Column("is_official", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("last_fetched", sa.Text(), nullable=False),
+        sa.PrimaryKeyConstraint("name"),
+    )
+
+    op.create_table(
+        "installed_plugins",
+        sa.Column("name", sa.String(length=200), nullable=False),
+        sa.Column("display_name", sa.String(length=200), nullable=False, server_default=""),
+        sa.Column("version", sa.String(length=50), nullable=False, server_default="0.0.0"),
+        sa.Column("plugin_dir", sa.Text(), nullable=False, server_default=""),
+        sa.Column("sha256", sa.String(length=64), nullable=False, server_default=""),
+        sa.Column("capabilities", sa.Text(), nullable=False, server_default="[]"),
+        sa.Column("enabled", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("installed_at", sa.Text(), nullable=False),
+        sa.PrimaryKeyConstraint("name"),
+    )
+
+
+def downgrade():
+    op.drop_table("installed_plugins")
+    op.drop_table("marketplace_cache")

--- a/backend/db/migrations/versions/a2b3c4d5e6f7_add_marketplace_tables.py
+++ b/backend/db/migrations/versions/a2b3c4d5e6f7_add_marketplace_tables.py
@@ -30,7 +30,9 @@ def upgrade():
         sa.Column("capabilities", sa.Text(), nullable=False, server_default="[]"),
         sa.Column("min_sublarr_version", sa.String(length=50), nullable=False, server_default=""),
         sa.Column("is_official", sa.Integer(), nullable=False, server_default="0"),
-        sa.Column("last_fetched", sa.Text(), nullable=False, server_default=sa.text("current_timestamp")),
+        sa.Column(
+            "last_fetched", sa.Text(), nullable=False, server_default=sa.text("current_timestamp")
+        ),
         sa.PrimaryKeyConstraint("name"),
     )
 
@@ -43,7 +45,9 @@ def upgrade():
         sa.Column("sha256", sa.String(length=64), nullable=False, server_default=""),
         sa.Column("capabilities", sa.Text(), nullable=False, server_default="[]"),
         sa.Column("enabled", sa.Integer(), nullable=False, server_default="1"),
-        sa.Column("installed_at", sa.Text(), nullable=False, server_default=sa.text("current_timestamp")),
+        sa.Column(
+            "installed_at", sa.Text(), nullable=False, server_default=sa.text("current_timestamp")
+        ),
         sa.PrimaryKeyConstraint("name"),
     )
 

--- a/backend/db/migrations/versions/a2b3c4d5e6f7_add_marketplace_tables.py
+++ b/backend/db/migrations/versions/a2b3c4d5e6f7_add_marketplace_tables.py
@@ -1,7 +1,7 @@
 """add_marketplace_tables
 
 Revision ID: a2b3c4d5e6f7
-Revises: fa890ea72dab
+Revises: d1e2f3a4b5c6
 Create Date: 2026-03-11
 
 """
@@ -11,7 +11,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "a2b3c4d5e6f7"
-down_revision = "fa890ea72dab"
+down_revision = "d1e2f3a4b5c6"
 branch_labels = None
 depends_on = None
 
@@ -30,7 +30,7 @@ def upgrade():
         sa.Column("capabilities", sa.Text(), nullable=False, server_default="[]"),
         sa.Column("min_sublarr_version", sa.String(length=50), nullable=False, server_default=""),
         sa.Column("is_official", sa.Integer(), nullable=False, server_default="0"),
-        sa.Column("last_fetched", sa.Text(), nullable=False),
+        sa.Column("last_fetched", sa.Text(), nullable=False, server_default=sa.text("current_timestamp")),
         sa.PrimaryKeyConstraint("name"),
     )
 
@@ -43,7 +43,7 @@ def upgrade():
         sa.Column("sha256", sa.String(length=64), nullable=False, server_default=""),
         sa.Column("capabilities", sa.Text(), nullable=False, server_default="[]"),
         sa.Column("enabled", sa.Integer(), nullable=False, server_default="1"),
-        sa.Column("installed_at", sa.Text(), nullable=False),
+        sa.Column("installed_at", sa.Text(), nullable=False, server_default=sa.text("current_timestamp")),
         sa.PrimaryKeyConstraint("name"),
     )
 

--- a/backend/db/models/__init__.py
+++ b/backend/db/models/__init__.py
@@ -32,16 +32,16 @@ from db.models.notifications import (
     NotificationTemplate,
     QuietHoursConfig,
 )
+from db.models.plugins import (
+    InstalledPlugin,
+    MarketplaceCache,
+)
 from db.models.providers import (
     ProviderCache,
     ProviderScoreModifier,
     ProviderStats,
     ScoringWeights,
     SubtitleDownload,
-)
-from db.models.plugins import (
-    InstalledPlugin,
-    MarketplaceCache,
 )
 from db.models.quality import SubtitleHealthResult
 from db.models.standalone import (

--- a/backend/db/models/__init__.py
+++ b/backend/db/models/__init__.py
@@ -39,6 +39,10 @@ from db.models.providers import (
     ScoringWeights,
     SubtitleDownload,
 )
+from db.models.plugins import (
+    InstalledPlugin,
+    MarketplaceCache,
+)
 from db.models.quality import SubtitleHealthResult
 from db.models.standalone import (
     AnidbMapping,
@@ -101,4 +105,7 @@ __all__ = [
     "NotificationTemplate",
     "NotificationHistory",
     "QuietHoursConfig",
+    # plugins / marketplace
+    "MarketplaceCache",
+    "InstalledPlugin",
 ]

--- a/backend/db/models/plugins.py
+++ b/backend/db/models/plugins.py
@@ -1,0 +1,40 @@
+"""SQLAlchemy models for plugin marketplace."""
+
+from sqlalchemy import Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from extensions import db
+
+
+class MarketplaceCache(db.Model):
+    """Cached plugin entries fetched from the marketplace registry."""
+
+    __tablename__ = "marketplace_cache"
+
+    name: Mapped[str] = mapped_column(String(200), primary_key=True)
+    display_name: Mapped[str] = mapped_column(String(200), nullable=False, default="")
+    author: Mapped[str] = mapped_column(String(200), nullable=False, default="")
+    version: Mapped[str] = mapped_column(String(50), nullable=False, default="0.0.0")
+    description: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    github_url: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    zip_url: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    sha256: Mapped[str] = mapped_column(String(64), nullable=False, default="")
+    capabilities: Mapped[str] = mapped_column(Text, nullable=False, default="[]")
+    min_sublarr_version: Mapped[str] = mapped_column(String(50), nullable=False, default="")
+    is_official: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    last_fetched: Mapped[str] = mapped_column(Text, nullable=False)
+
+
+class InstalledPlugin(db.Model):
+    """Record of locally installed plugins."""
+
+    __tablename__ = "installed_plugins"
+
+    name: Mapped[str] = mapped_column(String(200), primary_key=True)
+    display_name: Mapped[str] = mapped_column(String(200), nullable=False, default="")
+    version: Mapped[str] = mapped_column(String(50), nullable=False, default="0.0.0")
+    plugin_dir: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    sha256: Mapped[str] = mapped_column(String(64), nullable=False, default="")
+    capabilities: Mapped[str] = mapped_column(Text, nullable=False, default="[]")
+    enabled: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    installed_at: Mapped[str] = mapped_column(Text, nullable=False)

--- a/backend/routes/marketplace.py
+++ b/backend/routes/marketplace.py
@@ -139,14 +139,16 @@ def get_installed_plugins():
     rows = InstalledPlugin.query.order_by(InstalledPlugin.name).all()
     installed = []
     for row in rows:
-        installed.append({
-            "name": row.name,
-            "display_name": row.display_name,
-            "version": row.version,
-            "capabilities": json.loads(row.capabilities or "[]"),
-            "enabled": bool(row.enabled),
-            "installed_at": row.installed_at,
-        })
+        installed.append(
+            {
+                "name": row.name,
+                "display_name": row.display_name,
+                "version": row.version,
+                "capabilities": json.loads(row.capabilities or "[]"),
+                "enabled": bool(row.enabled),
+                "installed_at": row.installed_at,
+            }
+        )
     return jsonify({"installed": installed})
 
 
@@ -267,16 +269,18 @@ def install_marketplace_plugin():
             existing.capabilities = capabilities
             existing.installed_at = now
         else:
-            sa_db.session.add(InstalledPlugin(
-                name=name,
-                display_name=data.get("display_name", name),
-                version=data.get("version", "0.0.0"),
-                plugin_dir=result["path"],
-                sha256=sha256,
-                capabilities=capabilities,
-                enabled=1,
-                installed_at=now,
-            ))
+            sa_db.session.add(
+                InstalledPlugin(
+                    name=name,
+                    display_name=data.get("display_name", name),
+                    version=data.get("version", "0.0.0"),
+                    plugin_dir=result["path"],
+                    sha256=sha256,
+                    capabilities=capabilities,
+                    enabled=1,
+                    installed_at=now,
+                )
+            )
         sa_db.session.commit()
 
         # Hot-reload plugins

--- a/backend/routes/marketplace.py
+++ b/backend/routes/marketplace.py
@@ -108,6 +108,77 @@ def get_marketplace_plugin(plugin_name: str):
         return jsonify({"error": str(e)}), 500
 
 
+@bp.route("/marketplace/installed", methods=["GET"])
+def get_installed_plugins():
+    """List installed plugins from the local database.
+    ---
+    get:
+      tags:
+        - Marketplace
+      summary: List installed plugins
+      description: Returns all locally installed plugins from the installed_plugins DB table.
+      security:
+        - apiKeyAuth: []
+      responses:
+        200:
+          description: Installed plugin list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  installed:
+                    type: array
+                    items:
+                      type: object
+    """
+    import json
+
+    from db.models.plugins import InstalledPlugin
+
+    rows = InstalledPlugin.query.order_by(InstalledPlugin.name).all()
+    installed = []
+    for row in rows:
+        installed.append({
+            "name": row.name,
+            "display_name": row.display_name,
+            "version": row.version,
+            "capabilities": json.loads(row.capabilities or "[]"),
+            "enabled": bool(row.enabled),
+            "installed_at": row.installed_at,
+        })
+    return jsonify({"installed": installed})
+
+
+@bp.route("/marketplace/refresh", methods=["POST"])
+def refresh_marketplace():
+    """Force-refresh the marketplace cache from GitHub.
+    ---
+    post:
+      tags:
+        - Marketplace
+      summary: Refresh marketplace cache
+      description: Force-fetches the latest plugin list from GitHub, bypassing the 1h cache TTL.
+      security:
+        - apiKeyAuth: []
+      responses:
+        200:
+          description: Refreshed plugin list
+        500:
+          description: GitHub fetch error
+    """
+    try:
+        from services.github_registry import GitHubRegistry
+
+        github_token = getattr(get_settings(), "github_token", "")
+        registry = GitHubRegistry(github_token=github_token)
+        plugins = registry.search(force_refresh=True)
+        return jsonify({"plugins": plugins, "count": len(plugins)})
+    except Exception as e:
+        logger.exception("Failed to refresh marketplace from GitHub")
+        return jsonify({"error": str(e)}), 500
+
+
 @bp.route("/marketplace/install", methods=["POST"])
 def install_marketplace_plugin():
     """Install a plugin from the marketplace.
@@ -116,7 +187,8 @@ def install_marketplace_plugin():
       tags:
         - Marketplace
       summary: Install plugin
-      description: Installs a plugin from the marketplace to the plugins directory.
+      description: Downloads a plugin ZIP, verifies its SHA256, extracts it, persists the
+        record to installed_plugins, and hot-reloads the plugin manager.
       security:
         - apiKeyAuth: []
       requestBody:
@@ -125,39 +197,97 @@ def install_marketplace_plugin():
           application/json:
             schema:
               type: object
+              required:
+                - name
+                - zip_url
               properties:
+                name:
+                  type: string
                 plugin_name:
+                  type: string
+                  description: Alias for name (either field is accepted)
+                zip_url:
+                  type: string
+                sha256:
                   type: string
                 version:
                   type: string
+                display_name:
+                  type: string
+                capabilities:
+                  type: array
+                  items:
+                    type: string
       responses:
         200:
           description: Installation successful
         400:
-          description: Invalid request
+          description: Invalid request — name/zip_url missing
         500:
-          description: Installation error
+          description: Installation error (download failed, SHA256 mismatch, etc.)
     """
-    data = request.get_json(silent=True) or {}
-    plugin_name = data.get("plugin_name")
+    import json
+    from datetime import UTC, datetime
 
-    if not plugin_name:
-        return jsonify({"error": "plugin_name is required"}), 400
+    from db.models.plugins import InstalledPlugin
+    from extensions import db as sa_db
+    from providers import invalidate_manager
+    from providers.plugins import get_plugin_manager
+    from services.marketplace import PluginMarketplace
+
+    data = request.get_json(silent=True) or {}
+    name = data.get("plugin_name") or data.get("name")
+    zip_url = data.get("zip_url")
+    sha256 = data.get("sha256", "")
+
+    if not name or not zip_url:
+        return jsonify({"error": "name (or plugin_name) and zip_url are required"}), 400
 
     try:
-        settings = get_settings()
-        plugins_dir = getattr(settings, "plugins_dir", "/config/plugins")
+        plugins_dir = getattr(get_settings(), "plugins_dir", "/config/plugins")
+        marketplace = PluginMarketplace()
+        result = marketplace.install_plugin_from_zip(
+            plugin_name=name,
+            zip_url=zip_url,
+            expected_sha256=sha256,
+            plugins_dir=plugins_dir,
+        )
 
-        marketplace = get_marketplace()
-        version = data.get("version")
-        result = marketplace.install_plugin(plugin_name, plugins_dir, version)
+        # Persist to installed_plugins
+        now = datetime.now(UTC).isoformat()
+        capabilities = json.dumps(data.get("capabilities", []))
+        existing = InstalledPlugin.query.get(name)
+        if existing:
+            existing.version = data.get("version", existing.version)
+            existing.plugin_dir = result["path"]
+            existing.sha256 = sha256
+            existing.capabilities = capabilities
+            existing.installed_at = now
+        else:
+            sa_db.session.add(InstalledPlugin(
+                name=name,
+                display_name=data.get("display_name", name),
+                version=data.get("version", "0.0.0"),
+                plugin_dir=result["path"],
+                sha256=sha256,
+                capabilities=capabilities,
+                enabled=1,
+                installed_at=now,
+            ))
+        sa_db.session.commit()
 
-        return jsonify(result), 200
+        # Hot-reload plugins
+        manager = get_plugin_manager()
+        if manager:
+            manager.reload()
+            invalidate_manager()
+
+        return jsonify({"status": "installed", "name": name})
     except RuntimeError as e:
-        logger.error("Plugin installation failed: %s", e)
+        logger.error("Plugin install failed: %s", e)
         return jsonify({"error": str(e)}), 500
     except Exception:
-        logger.exception("Unexpected error during plugin installation")
+        logger.exception("Plugin install unexpected error")
         return jsonify({"error": "Internal server error"}), 500
 
 

--- a/backend/routes/marketplace.py
+++ b/backend/routes/marketplace.py
@@ -243,6 +243,9 @@ def install_marketplace_plugin():
     if not name or not zip_url:
         return jsonify({"error": "name (or plugin_name) and zip_url are required"}), 400
 
+    if not sha256:
+        return jsonify({"error": "sha256 is required for plugin installation"}), 400
+
     try:
         plugins_dir = getattr(get_settings(), "plugins_dir", "/config/plugins")
         marketplace = PluginMarketplace()

--- a/backend/services/github_registry.py
+++ b/backend/services/github_registry.py
@@ -107,9 +107,7 @@ class GitHubRegistry:
             existing = db.session.get(MarketplaceCache, manifest["name"])
             if existing is not None:
                 existing.display_name = manifest["display_name"]
-                existing.author = manifest.get(
-                    "author", repo.get("owner", {}).get("login", "")
-                )
+                existing.author = manifest.get("author", repo.get("owner", {}).get("login", ""))
                 existing.version = manifest["version"]
                 existing.description = manifest.get("description", repo.get("description", ""))
                 existing.github_url = repo.get("html_url", "")

--- a/backend/services/github_registry.py
+++ b/backend/services/github_registry.py
@@ -1,0 +1,173 @@
+"""GitHub-based plugin registry with DB cache.
+
+Searches GitHub for repos with topic 'sublarr-provider', fetches each
+repo's manifest.json, and caches results in marketplace_cache with 1h TTL.
+Uses SUBLARR_GITHUB_TOKEN for higher rate limits when configured.
+"""
+
+import json
+import logging
+import pathlib
+from datetime import UTC, datetime, timedelta
+
+import requests
+from sqlalchemy import select
+
+from db.models.plugins import MarketplaceCache
+from extensions import db
+
+logger = logging.getLogger(__name__)
+
+GITHUB_SEARCH_URL = "https://api.github.com/search/repositories"
+CACHE_TTL_HOURS = 1
+
+
+class GitHubRegistry:
+    def __init__(self, github_token: str = ""):
+        self.session = requests.Session()
+        self.session.headers["Accept"] = "application/vnd.github+json"
+        self.session.headers["X-GitHub-Api-Version"] = "2022-11-28"
+        if github_token:
+            self.session.headers["Authorization"] = f"Bearer {github_token}"
+
+    def search(self, force_refresh: bool = False) -> list[dict]:
+        """Return plugins from cache (if fresh) or GitHub API."""
+        if not force_refresh:
+            cached = self._load_from_cache()
+            if cached is not None:
+                return cached
+        return self._fetch_from_github()
+
+    def _load_from_cache(self) -> list[dict] | None:
+        """Return cached entries if any are fresher than CACHE_TTL_HOURS. None = stale/empty."""
+        cutoff = (datetime.now(UTC) - timedelta(hours=CACHE_TTL_HOURS)).isoformat()
+        stmt = select(MarketplaceCache).where(MarketplaceCache.last_fetched > cutoff)
+        rows = db.session.execute(stmt).scalars().all()
+        if not rows:
+            return None
+        return [self._model_to_dict(row) for row in rows]
+
+    def _fetch_from_github(self) -> list[dict]:
+        """Fetch from GitHub and store in cache. Falls back to stale cache on error."""
+        try:
+            resp = self.session.get(
+                GITHUB_SEARCH_URL,
+                params={"q": "topic:sublarr-provider", "per_page": 100},
+                timeout=10,
+            )
+            resp.raise_for_status()
+            repos = resp.json().get("items", [])
+        except Exception as e:
+            logger.warning("GitHub registry fetch failed: %s", e)
+            rows = db.session.execute(select(MarketplaceCache)).scalars().all()
+            return [self._model_to_dict(row) for row in rows]
+
+        official_names = self._load_official_names()
+        plugins = []
+        for repo in repos:
+            manifest = self._fetch_manifest(repo)
+            if manifest is None:
+                continue
+            plugin = self._store_plugin(repo, manifest, official_names)
+            if plugin:
+                plugins.append(plugin)
+        return plugins
+
+    def _fetch_manifest(self, repo: dict) -> dict | None:
+        """Fetch manifest.json from repo's main or master branch."""
+        full_name = repo.get("full_name", "")
+        for branch in ("main", "master"):
+            url = f"https://raw.githubusercontent.com/{full_name}/{branch}/manifest.json"
+            try:
+                resp = self.session.get(url, timeout=5)
+                resp.raise_for_status()
+                return resp.json()
+            except Exception:
+                continue
+        logger.debug("No manifest.json found in %s", full_name)
+        return None
+
+    def _store_plugin(self, repo: dict, manifest: dict, official_names: set[str]) -> dict | None:
+        """Validate manifest fields, upsert into marketplace_cache, return dict."""
+        required = ["name", "display_name", "version", "entry_point", "class_name"]
+        for field in required:
+            if not manifest.get(field):
+                logger.debug(
+                    "Skipping %s: missing manifest field '%s'",
+                    repo.get("full_name"),
+                    field,
+                )
+                return None
+
+        now = datetime.now(UTC).isoformat()
+        capabilities = manifest.get("capabilities", [])
+        is_official = 1 if manifest["name"] in official_names else 0
+
+        try:
+            existing = db.session.get(MarketplaceCache, manifest["name"])
+            if existing is not None:
+                existing.display_name = manifest["display_name"]
+                existing.author = manifest.get(
+                    "author", repo.get("owner", {}).get("login", "")
+                )
+                existing.version = manifest["version"]
+                existing.description = manifest.get("description", repo.get("description", ""))
+                existing.github_url = repo.get("html_url", "")
+                existing.zip_url = manifest.get("zip_url", "")
+                existing.sha256 = manifest.get("sha256", "")
+                existing.capabilities = json.dumps(capabilities)
+                existing.min_sublarr_version = manifest.get("min_sublarr_version", "")
+                existing.is_official = is_official
+                existing.last_fetched = now
+                entry = existing
+            else:
+                entry = MarketplaceCache(
+                    name=manifest["name"],
+                    display_name=manifest["display_name"],
+                    author=manifest.get("author", repo.get("owner", {}).get("login", "")),
+                    version=manifest["version"],
+                    description=manifest.get("description", repo.get("description", "")),
+                    github_url=repo.get("html_url", ""),
+                    zip_url=manifest.get("zip_url", ""),
+                    sha256=manifest.get("sha256", ""),
+                    capabilities=json.dumps(capabilities),
+                    min_sublarr_version=manifest.get("min_sublarr_version", ""),
+                    is_official=is_official,
+                    last_fetched=now,
+                )
+                db.session.add(entry)
+            db.session.commit()
+        except Exception as e:
+            logger.error("Failed to cache plugin %s: %s", manifest["name"], e)
+            db.session.rollback()
+            return None
+
+        row = db.session.get(MarketplaceCache, manifest["name"])
+        return self._model_to_dict(row)
+
+    def _load_official_names(self) -> set[str]:
+        """Load curated official plugin names from official-registry.json at repo root."""
+        root = pathlib.Path(__file__).parent.parent.parent
+        registry_path = root / "official-registry.json"
+        try:
+            data = json.loads(registry_path.read_text())
+            return set(data.get("official_plugins", []))
+        except Exception:
+            return set()
+
+    def _model_to_dict(self, row: MarketplaceCache) -> dict:
+        d = {
+            "name": row.name,
+            "display_name": row.display_name,
+            "author": row.author,
+            "version": row.version,
+            "description": row.description,
+            "github_url": row.github_url,
+            "zip_url": row.zip_url,
+            "sha256": row.sha256,
+            "capabilities": json.loads(row.capabilities or "[]"),
+            "min_sublarr_version": row.min_sublarr_version,
+            "is_official": bool(row.is_official),
+            "last_fetched": row.last_fetched,
+        }
+        return d

--- a/backend/services/marketplace.py
+++ b/backend/services/marketplace.py
@@ -11,10 +11,11 @@ import os
 import shutil
 import subprocess
 import zipfile
+from urllib.parse import urlparse
 
 import requests
 
-from security_utils import safe_zip_extract, validate_git_url
+from security_utils import is_safe_path, safe_zip_extract, validate_git_url
 
 logger = logging.getLogger(__name__)
 
@@ -160,6 +161,8 @@ class PluginMarketplace:
             Installation result dict
         """
         plugin_path = os.path.join(plugins_dir, plugin_name)
+        if not is_safe_path(plugin_path, plugins_dir):
+            raise RuntimeError("Invalid plugin name — path traversal detected")
 
         # Remove existing plugin if present
         if os.path.exists(plugin_path):
@@ -215,10 +218,15 @@ class PluginMarketplace:
             Installation result dict
         """
         try:
+            if urlparse(zip_url).scheme != "https":
+                raise RuntimeError("Only HTTPS zip_url is allowed for plugin installation")
+
             response = requests.get(zip_url, timeout=60)
             response.raise_for_status()
 
             plugin_path = os.path.join(plugins_dir, plugin_name)
+            if not is_safe_path(plugin_path, plugins_dir):
+                raise RuntimeError("Invalid plugin name — path traversal detected")
 
             # Remove existing plugin if present
             if os.path.exists(plugin_path):
@@ -262,6 +270,9 @@ class PluginMarketplace:
         Raises:
             RuntimeError: If the HTTP request fails or the SHA256 does not match.
         """
+        if urlparse(zip_url).scheme != "https":
+            raise RuntimeError("Only HTTPS zip_url is allowed for plugin installation")
+
         response = requests.get(zip_url, timeout=60)
         response.raise_for_status()
         data = response.content
@@ -270,6 +281,8 @@ class PluginMarketplace:
             raise RuntimeError(f"SHA256 mismatch for {plugin_name}: download may be corrupted or tampered")
 
         plugin_path = os.path.join(plugins_dir, plugin_name)
+        if not is_safe_path(plugin_path, plugins_dir):
+            raise RuntimeError("Invalid plugin name — path traversal detected")
 
         if os.path.exists(plugin_path):
             shutil.rmtree(plugin_path)
@@ -348,6 +361,8 @@ class PluginMarketplace:
             Uninstallation result
         """
         plugin_path = os.path.join(plugins_dir, plugin_name)
+        if not is_safe_path(plugin_path, plugins_dir):
+            raise RuntimeError("Invalid plugin name — path traversal detected")
 
         if not os.path.exists(plugin_path):
             raise RuntimeError(f"Plugin not found: {plugin_name}")

--- a/backend/services/marketplace.py
+++ b/backend/services/marketplace.py
@@ -4,16 +4,36 @@ Manages GitHub-based plugin registry, installation, updates, and validation.
 Inspired by Bazarr's provider ecosystem but with better architecture.
 """
 
+import hashlib
+import io
 import logging
 import os
 import shutil
 import subprocess
+import zipfile
 
 import requests
 
 from security_utils import safe_zip_extract, validate_git_url
 
 logger = logging.getLogger(__name__)
+
+
+def verify_zip_sha256(data: bytes, expected_sha256: str) -> bool:
+    """Verify the SHA256 checksum of downloaded ZIP data.
+
+    Args:
+        data: Raw bytes of the downloaded file.
+        expected_sha256: Expected hex digest. Empty/falsy value skips the check.
+
+    Returns:
+        True if the hash matches or if expected_sha256 is empty/falsy.
+        False on mismatch.
+    """
+    if not expected_sha256:
+        return True
+    actual = hashlib.sha256(data).hexdigest()
+    return actual.lower() == expected_sha256.lower()
 
 
 class PluginMarketplace:
@@ -194,9 +214,6 @@ class PluginMarketplace:
         Returns:
             Installation result dict
         """
-        import io
-        import zipfile
-
         try:
             response = requests.get(zip_url, timeout=60)
             response.raise_for_status()
@@ -223,6 +240,46 @@ class PluginMarketplace:
             }
         except Exception as e:
             raise RuntimeError(f"ZIP installation failed: {e}")
+
+    def install_plugin_from_zip(
+        self,
+        plugin_name: str,
+        zip_url: str,
+        expected_sha256: str,
+        plugins_dir: str,
+    ) -> dict:
+        """Download zip, verify SHA256, extract to plugins_dir/<plugin_name>.
+
+        Args:
+            plugin_name: Name for the installed plugin directory.
+            zip_url: URL of the ZIP file to download.
+            expected_sha256: Expected SHA256 hex digest. Empty string skips verification.
+            plugins_dir: Parent directory under which the plugin will be extracted.
+
+        Returns:
+            Dict with {"status": "installed", "path": plugin_path}.
+
+        Raises:
+            RuntimeError: If the HTTP request fails or the SHA256 does not match.
+        """
+        response = requests.get(zip_url, timeout=60)
+        response.raise_for_status()
+        data = response.content
+
+        if not verify_zip_sha256(data, expected_sha256):
+            raise RuntimeError(f"SHA256 mismatch for {plugin_name}: download may be corrupted or tampered")
+
+        plugin_path = os.path.join(plugins_dir, plugin_name)
+
+        if os.path.exists(plugin_path):
+            shutil.rmtree(plugin_path)
+
+        os.makedirs(plugin_path, exist_ok=True)
+
+        with zipfile.ZipFile(io.BytesIO(data)) as zf:
+            safe_zip_extract(zf, plugin_path)
+
+        return {"status": "installed", "path": plugin_path}
 
     def _validate_plugin(self, plugin_path: str) -> dict:
         """Validate installed plugin.

--- a/backend/services/marketplace.py
+++ b/backend/services/marketplace.py
@@ -278,7 +278,9 @@ class PluginMarketplace:
         data = response.content
 
         if not verify_zip_sha256(data, expected_sha256):
-            raise RuntimeError(f"SHA256 mismatch for {plugin_name}: download may be corrupted or tampered")
+            raise RuntimeError(
+                f"SHA256 mismatch for {plugin_name}: download may be corrupted or tampered"
+            )
 
         plugin_path = os.path.join(plugins_dir, plugin_name)
         if not is_safe_path(plugin_path, plugins_dir):

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -72,3 +72,11 @@ def test_safe_config():
     assert "api_key" in safe
     # API keys should be masked or empty
     assert safe.get("api_key") == "" or "***" in str(safe.get("api_key"))
+
+
+def test_github_token_defaults_empty():
+    """Test that github_token defaults to empty string."""
+    from config import Settings
+
+    s = Settings()
+    assert s.github_token == ""

--- a/backend/tests/test_github_registry.py
+++ b/backend/tests/test_github_registry.py
@@ -1,0 +1,258 @@
+"""Tests for GitHubRegistry — GitHub topic search + DB cache."""
+
+import json
+import os
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app import create_app
+from extensions import db as sa_db
+
+
+@pytest.fixture()
+def app(tmp_path):
+    """Flask app with isolated SQLite DB."""
+    db_path = str(tmp_path / "test.db")
+    os.environ["SUBLARR_DB_PATH"] = db_path
+    os.environ["SUBLARR_API_KEY"] = ""
+    os.environ["SUBLARR_LOG_LEVEL"] = "ERROR"
+
+    from config import reload_settings
+
+    reload_settings()
+
+    application = create_app(testing=True)
+    application.config["TESTING"] = True
+
+    with application.app_context():
+        sa_db.create_all()
+        yield application
+
+    os.environ.pop("SUBLARR_DB_PATH", None)
+    os.environ.pop("SUBLARR_API_KEY", None)
+    os.environ.pop("SUBLARR_LOG_LEVEL", None)
+
+
+def _make_registry(github_token: str = "") -> "GitHubRegistry":  # noqa: F821
+    from services.github_registry import GitHubRegistry
+
+    return GitHubRegistry(github_token=github_token)
+
+
+def _fresh_timestamp() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _stale_timestamp() -> str:
+    return (datetime.now(UTC) - timedelta(hours=2)).isoformat()
+
+
+def _insert_cache_entry(app_ctx, name: str, last_fetched: str) -> None:
+    from db.models.plugins import MarketplaceCache
+
+    with app_ctx.app_context():
+        entry = MarketplaceCache(
+            name=name,
+            display_name="Test Plugin",
+            author="testauthor",
+            version="1.0.0",
+            description="A test plugin",
+            github_url="https://github.com/testauthor/test-plugin",
+            zip_url="https://github.com/testauthor/test-plugin/archive/v1.0.0.zip",
+            sha256="abc123",
+            capabilities=json.dumps(["provider"]),
+            min_sublarr_version="0.22.0",
+            is_official=0,
+            last_fetched=last_fetched,
+        )
+        sa_db.session.add(entry)
+        sa_db.session.commit()
+
+
+# ---------------------------------------------------------------------------
+# Test 1: cache hit — GitHub API NOT called when cache is fresh
+# ---------------------------------------------------------------------------
+
+
+def test_search_uses_cache_when_fresh(app):
+    with app.app_context():
+        _insert_cache_entry(app, "cached-plugin", _fresh_timestamp())
+
+        registry = _make_registry()
+        with patch.object(registry.session, "get") as mock_get:
+            results = registry.search(force_refresh=False)
+
+        mock_get.assert_not_called()
+        assert len(results) == 1
+        assert results[0]["name"] == "cached-plugin"
+
+
+# ---------------------------------------------------------------------------
+# Test 2: cache miss — GitHub API fetched, results stored in DB
+# ---------------------------------------------------------------------------
+
+
+def _make_search_response(repos: list[dict]) -> MagicMock:
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = {"items": repos}
+    return resp
+
+
+def _make_manifest_response(manifest: dict) -> MagicMock:
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = manifest
+    return resp
+
+
+def test_search_fetches_github_when_stale(app):
+    repo = {
+        "full_name": "testauthor/my-provider",
+        "html_url": "https://github.com/testauthor/my-provider",
+        "description": "A great provider",
+        "owner": {"login": "testauthor"},
+    }
+    manifest = {
+        "name": "my-provider",
+        "display_name": "My Provider",
+        "version": "1.2.0",
+        "entry_point": "provider.py",
+        "class_name": "MyProvider",
+        "author": "testauthor",
+        "capabilities": ["provider"],
+        "min_sublarr_version": "0.22.0",
+        "zip_url": "https://example.com/my-provider.zip",
+        "sha256": "deadbeef",
+    }
+
+    search_resp = _make_search_response([repo])
+    manifest_resp = _make_manifest_response(manifest)
+
+    with app.app_context():
+        registry = _make_registry()
+        # Map side_effect: first call = GitHub search, second = manifest fetch
+        registry.session.get = MagicMock(side_effect=[search_resp, manifest_resp])
+
+        with patch.object(registry, "_load_official_names", return_value=set()):
+            results = registry.search(force_refresh=True)
+
+        assert len(results) == 1
+        assert results[0]["name"] == "my-provider"
+        assert results[0]["version"] == "1.2.0"
+
+        # Verify stored in DB
+        from db.models.plugins import MarketplaceCache
+
+        row = sa_db.session.get(MarketplaceCache, "my-provider")
+        assert row is not None
+        assert row.version == "1.2.0"
+
+
+# ---------------------------------------------------------------------------
+# Test 3: sha256 flows from manifest into result dict
+# ---------------------------------------------------------------------------
+
+
+def test_sha256_included_in_result(app):
+    repo = {
+        "full_name": "author/sha-plugin",
+        "html_url": "https://github.com/author/sha-plugin",
+        "description": "",
+        "owner": {"login": "author"},
+    }
+    manifest = {
+        "name": "sha-plugin",
+        "display_name": "SHA Plugin",
+        "version": "0.1.0",
+        "entry_point": "provider.py",
+        "class_name": "ShaPlugin",
+        "sha256": "cafebabe1234567890abcdef",
+    }
+
+    search_resp = _make_search_response([repo])
+    manifest_resp = _make_manifest_response(manifest)
+
+    with app.app_context():
+        registry = _make_registry()
+        registry.session.get = MagicMock(side_effect=[search_resp, manifest_resp])
+
+        with patch.object(registry, "_load_official_names", return_value=set()):
+            results = registry.search(force_refresh=True)
+
+        assert len(results) == 1
+        assert results[0]["sha256"] == "cafebabe1234567890abcdef"
+
+
+# ---------------------------------------------------------------------------
+# Test 4: manifest missing required field — plugin skipped
+# ---------------------------------------------------------------------------
+
+
+def test_missing_required_field_skipped(app):
+    repo = {
+        "full_name": "author/bad-plugin",
+        "html_url": "https://github.com/author/bad-plugin",
+        "description": "",
+        "owner": {"login": "author"},
+    }
+    # Missing 'class_name'
+    manifest = {
+        "name": "bad-plugin",
+        "display_name": "Bad Plugin",
+        "version": "0.1.0",
+        "entry_point": "provider.py",
+        # class_name intentionally absent
+    }
+
+    search_resp = _make_search_response([repo])
+    manifest_resp = _make_manifest_response(manifest)
+
+    with app.app_context():
+        registry = _make_registry()
+        registry.session.get = MagicMock(side_effect=[search_resp, manifest_resp])
+
+        with patch.object(registry, "_load_official_names", return_value=set()):
+            results = registry.search(force_refresh=True)
+
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# Test 5: official badge — is_official=True for names in official registry
+# ---------------------------------------------------------------------------
+
+
+def test_official_badge(app):
+    repo = {
+        "full_name": "community/opensubtitles-enhanced",
+        "html_url": "https://github.com/community/opensubtitles-enhanced",
+        "description": "Enhanced OpenSubtitles provider",
+        "owner": {"login": "community"},
+    }
+    manifest = {
+        "name": "opensubtitles-enhanced",
+        "display_name": "OpenSubtitles Enhanced",
+        "version": "2.0.0",
+        "entry_point": "provider.py",
+        "class_name": "OpenSubtitlesEnhancedProvider",
+    }
+
+    search_resp = _make_search_response([repo])
+    manifest_resp = _make_manifest_response(manifest)
+
+    with app.app_context():
+        registry = _make_registry()
+        registry.session.get = MagicMock(side_effect=[search_resp, manifest_resp])
+
+        with patch.object(
+            registry,
+            "_load_official_names",
+            return_value={"opensubtitles-enhanced"},
+        ):
+            results = registry.search(force_refresh=True)
+
+        assert len(results) == 1
+        assert results[0]["is_official"] is True

--- a/backend/tests/test_marketplace_db.py
+++ b/backend/tests/test_marketplace_db.py
@@ -1,0 +1,150 @@
+"""Tests for marketplace_cache and installed_plugins DB tables."""
+
+import os
+
+import pytest
+
+from app import create_app
+from extensions import db as sa_db
+
+
+@pytest.fixture()
+def app(tmp_path):
+    """Create a Flask app with an isolated SQLite DB for testing."""
+    db_path = str(tmp_path / "test.db")
+    os.environ["SUBLARR_DB_PATH"] = db_path
+    os.environ["SUBLARR_API_KEY"] = ""
+    os.environ["SUBLARR_LOG_LEVEL"] = "ERROR"
+
+    from config import reload_settings
+
+    reload_settings()
+
+    application = create_app(testing=True)
+    application.config["TESTING"] = True
+
+    with application.app_context():
+        sa_db.create_all()
+        yield application
+
+    os.environ.pop("SUBLARR_DB_PATH", None)
+    os.environ.pop("SUBLARR_API_KEY", None)
+    os.environ.pop("SUBLARR_LOG_LEVEL", None)
+
+
+def test_marketplace_cache_table_exists(app):
+    """marketplace_cache table is created by create_all."""
+    from db.models.plugins import MarketplaceCache
+
+    with app.app_context():
+        # inspect via SQLAlchemy — table must be present in metadata
+        assert MarketplaceCache.__table__ is not None
+        assert MarketplaceCache.__tablename__ == "marketplace_cache"
+
+
+def test_installed_plugins_table_exists(app):
+    """installed_plugins table is created by create_all."""
+    from db.models.plugins import InstalledPlugin
+
+    with app.app_context():
+        assert InstalledPlugin.__table__ is not None
+        assert InstalledPlugin.__tablename__ == "installed_plugins"
+
+
+def test_insert_marketplace_cache_row(app):
+    """Can insert a row into marketplace_cache and retrieve it."""
+    from db.models.plugins import MarketplaceCache
+
+    with app.app_context():
+        entry = MarketplaceCache(
+            name="test-provider",
+            display_name="Test Provider",
+            author="testauthor",
+            version="1.2.3",
+            description="A test subtitle provider plugin.",
+            github_url="https://github.com/testauthor/test-provider",
+            zip_url="https://github.com/testauthor/test-provider/archive/v1.2.3.zip",
+            sha256="a" * 64,
+            capabilities='["provider"]',
+            min_sublarr_version="0.22.0",
+            is_official=0,
+            last_fetched="2026-03-11T00:00:00Z",
+        )
+        sa_db.session.add(entry)
+        sa_db.session.commit()
+
+        fetched = sa_db.session.get(MarketplaceCache, "test-provider")
+        assert fetched is not None
+        assert fetched.display_name == "Test Provider"
+        assert fetched.author == "testauthor"
+        assert fetched.version == "1.2.3"
+        assert fetched.is_official == 0
+        assert fetched.sha256 == "a" * 64
+
+
+def test_insert_installed_plugin_row(app):
+    """Can insert a row into installed_plugins and retrieve it."""
+    from db.models.plugins import InstalledPlugin
+
+    with app.app_context():
+        plugin = InstalledPlugin(
+            name="test-provider",
+            display_name="Test Provider",
+            version="1.2.3",
+            plugin_dir="/config/plugins/test-provider",
+            sha256="b" * 64,
+            capabilities='["provider"]',
+            enabled=1,
+            installed_at="2026-03-11T00:00:00Z",
+        )
+        sa_db.session.add(plugin)
+        sa_db.session.commit()
+
+        fetched = sa_db.session.get(InstalledPlugin, "test-provider")
+        assert fetched is not None
+        assert fetched.display_name == "Test Provider"
+        assert fetched.version == "1.2.3"
+        assert fetched.plugin_dir == "/config/plugins/test-provider"
+        assert fetched.enabled == 1
+        assert fetched.sha256 == "b" * 64
+
+
+def test_marketplace_cache_defaults(app):
+    """marketplace_cache columns with defaults produce expected values."""
+    from db.models.plugins import MarketplaceCache
+
+    with app.app_context():
+        entry = MarketplaceCache(
+            name="minimal-plugin",
+            display_name="Minimal Plugin",
+            last_fetched="2026-03-11T00:00:00Z",
+        )
+        sa_db.session.add(entry)
+        sa_db.session.commit()
+
+        fetched = sa_db.session.get(MarketplaceCache, "minimal-plugin")
+        assert fetched.author == ""
+        assert fetched.version == "0.0.0"
+        assert fetched.description == ""
+        assert fetched.capabilities == "[]"
+        assert fetched.is_official == 0
+
+
+def test_installed_plugin_defaults(app):
+    """installed_plugins columns with defaults produce expected values."""
+    from db.models.plugins import InstalledPlugin
+
+    with app.app_context():
+        plugin = InstalledPlugin(
+            name="minimal-plugin",
+            installed_at="2026-03-11T00:00:00Z",
+        )
+        sa_db.session.add(plugin)
+        sa_db.session.commit()
+
+        fetched = sa_db.session.get(InstalledPlugin, "minimal-plugin")
+        assert fetched.display_name == ""
+        assert fetched.version == "0.0.0"
+        assert fetched.plugin_dir == ""
+        assert fetched.capabilities == "[]"
+        assert fetched.enabled == 1

--- a/backend/tests/test_marketplace_routes.py
+++ b/backend/tests/test_marketplace_routes.py
@@ -1,0 +1,149 @@
+"""Tests for marketplace routes — /installed, /refresh, /install."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app import create_app
+from extensions import db as sa_db
+
+
+@pytest.fixture()
+def app(tmp_path):
+    """Flask app with isolated SQLite DB and SQLAlchemy tables created."""
+    db_path = str(tmp_path / "test.db")
+    os.environ["SUBLARR_DB_PATH"] = db_path
+    os.environ["SUBLARR_API_KEY"] = ""
+    os.environ["SUBLARR_LOG_LEVEL"] = "ERROR"
+
+    from config import reload_settings
+
+    reload_settings()
+
+    application = create_app(testing=True)
+    application.config["TESTING"] = True
+
+    with application.app_context():
+        sa_db.create_all()
+        yield application
+
+    os.environ.pop("SUBLARR_DB_PATH", None)
+    os.environ.pop("SUBLARR_API_KEY", None)
+    os.environ.pop("SUBLARR_LOG_LEVEL", None)
+
+
+@pytest.fixture()
+def client(app):
+    """Test client bound to the SQLAlchemy-aware app fixture."""
+    return app.test_client()
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/marketplace/installed
+# ---------------------------------------------------------------------------
+
+
+def test_get_installed_empty(client):
+    """GET /marketplace/installed returns empty list when no rows exist."""
+    resp = client.get("/api/v1/marketplace/installed")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data == {"installed": []}
+
+
+def test_get_installed_with_data(app, client):
+    """GET /marketplace/installed returns inserted plugin rows."""
+    from db.models.plugins import InstalledPlugin
+
+    with app.app_context():
+        plugin = InstalledPlugin(
+            name="my-provider",
+            display_name="My Provider",
+            version="1.0.0",
+            plugin_dir="/config/plugins/my-provider",
+            sha256="a" * 64,
+            capabilities='["provider"]',
+            enabled=1,
+            installed_at="2026-03-11T00:00:00+00:00",
+        )
+        sa_db.session.add(plugin)
+        sa_db.session.commit()
+
+    resp = client.get("/api/v1/marketplace/installed")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert len(data["installed"]) == 1
+    entry = data["installed"][0]
+    assert entry["name"] == "my-provider"
+    assert entry["display_name"] == "My Provider"
+    assert entry["version"] == "1.0.0"
+    assert entry["capabilities"] == ["provider"]
+    assert entry["enabled"] is True
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/marketplace/refresh
+# ---------------------------------------------------------------------------
+
+
+def test_refresh_calls_github_registry(client):
+    """POST /marketplace/refresh calls GitHubRegistry.search(force_refresh=True)."""
+    fake_plugins = [{"name": "plugin-a", "version": "1.0.0"}]
+
+    mock_instance = MagicMock()
+    mock_instance.search.return_value = fake_plugins
+
+    with patch("routes.marketplace.GitHubRegistry", return_value=mock_instance, create=True):
+        # Patch within the module namespace where it is imported at call time
+        with patch("services.github_registry.GitHubRegistry") as mock_cls:
+            mock_cls.return_value = mock_instance
+            # The route does a local import, so patch the source module
+            resp = client.post("/api/v1/marketplace/refresh")
+
+    # Verify via a direct patch of the route's import path
+    mock_registry = MagicMock()
+    mock_registry.search.return_value = fake_plugins
+    with patch("services.github_registry.GitHubRegistry", return_value=mock_registry):
+        resp = client.post("/api/v1/marketplace/refresh")
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "plugins" in data
+    assert "count" in data
+    mock_registry.search.assert_called_once_with(force_refresh=True)
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/marketplace/install
+# ---------------------------------------------------------------------------
+
+
+def test_install_rejects_missing_fields(client):
+    """POST /marketplace/install with no body returns 400."""
+    resp = client.post("/api/v1/marketplace/install", json={})
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert "error" in data
+    assert "zip_url" in data["error"] or "name" in data["error"]
+
+
+def test_install_sha256_mismatch_returns_500(client):
+    """Mock install_plugin_from_zip to raise RuntimeError; route must return 500."""
+    with patch(
+        "services.marketplace.PluginMarketplace.install_plugin_from_zip",
+        side_effect=RuntimeError("SHA256 mismatch"),
+    ):
+        resp = client.post(
+            "/api/v1/marketplace/install",
+            json={
+                "name": "bad-plugin",
+                "zip_url": "https://example.com/bad-plugin.zip",
+                "sha256": "wronghash",
+            },
+        )
+
+    assert resp.status_code == 500
+    data = resp.get_json()
+    assert "error" in data
+    assert "SHA256 mismatch" in data["error"]

--- a/backend/tests/test_marketplace_routes.py
+++ b/backend/tests/test_marketplace_routes.py
@@ -94,12 +94,14 @@ def test_refresh_calls_github_registry(client):
     mock_instance = MagicMock()
     mock_instance.search.return_value = fake_plugins
 
-    with patch("routes.marketplace.GitHubRegistry", return_value=mock_instance, create=True):
+    with (
+        patch("routes.marketplace.GitHubRegistry", return_value=mock_instance, create=True),
+        patch("services.github_registry.GitHubRegistry") as mock_cls,
+    ):
         # Patch within the module namespace where it is imported at call time
-        with patch("services.github_registry.GitHubRegistry") as mock_cls:
-            mock_cls.return_value = mock_instance
-            # The route does a local import, so patch the source module
-            resp = client.post("/api/v1/marketplace/refresh")
+        mock_cls.return_value = mock_instance
+        # The route does a local import, so patch the source module
+        resp = client.post("/api/v1/marketplace/refresh")
 
     # Verify via a direct patch of the route's import path
     mock_registry = MagicMock()

--- a/backend/tests/test_marketplace_service.py
+++ b/backend/tests/test_marketplace_service.py
@@ -3,9 +3,9 @@
 import hashlib
 import io
 import zipfile
+from unittest.mock import MagicMock, patch
 
 import pytest
-from unittest.mock import patch, MagicMock
 
 
 def make_zip_bytes() -> bytes:

--- a/backend/tests/test_marketplace_service.py
+++ b/backend/tests/test_marketplace_service.py
@@ -1,0 +1,105 @@
+"""Tests for SHA256 integrity verification in the marketplace service."""
+
+import hashlib
+import io
+import zipfile
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+def make_zip_bytes() -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("provider.py", "class P: pass")
+    return buf.getvalue()
+
+
+def test_sha256_passes_on_match():
+    from services.marketplace import verify_zip_sha256
+
+    data = make_zip_bytes()
+    expected = hashlib.sha256(data).hexdigest()
+    assert verify_zip_sha256(data, expected) is True
+
+
+def test_sha256_fails_on_mismatch():
+    from services.marketplace import verify_zip_sha256
+
+    data = make_zip_bytes()
+    assert verify_zip_sha256(data, "wrong") is False
+
+
+def test_sha256_skipped_when_empty():
+    from services.marketplace import verify_zip_sha256
+
+    assert verify_zip_sha256(b"anything", "") is True
+
+
+def test_sha256_case_insensitive():
+    from services.marketplace import verify_zip_sha256
+
+    data = make_zip_bytes()
+    expected = hashlib.sha256(data).hexdigest().upper()
+    assert verify_zip_sha256(data, expected) is True
+
+
+def test_install_raises_on_sha256_mismatch(tmp_path):
+    from services.marketplace import PluginMarketplace
+
+    data = make_zip_bytes()
+    with patch("requests.get") as mock_get:
+        resp = MagicMock()
+        resp.content = data
+        resp.raise_for_status = MagicMock()
+        mock_get.return_value = resp
+        marketplace = PluginMarketplace()
+        with pytest.raises(RuntimeError, match="SHA256 mismatch"):
+            marketplace.install_plugin_from_zip(
+                plugin_name="test",
+                zip_url="https://example.com/plugin.zip",
+                expected_sha256="0" * 64,
+                plugins_dir=str(tmp_path),
+            )
+
+
+def test_install_succeeds_on_correct_sha256(tmp_path):
+    from services.marketplace import PluginMarketplace
+
+    data = make_zip_bytes()
+    correct_sha = hashlib.sha256(data).hexdigest()
+    with patch("requests.get") as mock_get:
+        resp = MagicMock()
+        resp.content = data
+        resp.raise_for_status = MagicMock()
+        mock_get.return_value = resp
+        with patch("services.marketplace.safe_zip_extract"):
+            marketplace = PluginMarketplace()
+            result = marketplace.install_plugin_from_zip(
+                plugin_name="test",
+                zip_url="https://example.com/plugin.zip",
+                expected_sha256=correct_sha,
+                plugins_dir=str(tmp_path),
+            )
+    assert result["status"] == "installed"
+    assert "test" in result["path"]
+
+
+def test_install_skips_sha256_when_empty(tmp_path):
+    from services.marketplace import PluginMarketplace
+
+    data = make_zip_bytes()
+    with patch("requests.get") as mock_get:
+        resp = MagicMock()
+        resp.content = data
+        resp.raise_for_status = MagicMock()
+        mock_get.return_value = resp
+        with patch("services.marketplace.safe_zip_extract"):
+            marketplace = PluginMarketplace()
+            result = marketplace.install_plugin_from_zip(
+                plugin_name="test",
+                zip_url="https://example.com/plugin.zip",
+                expected_sha256="",
+                plugins_dir=str(tmp_path),
+            )
+    assert result["status"] == "installed"

--- a/docs/superpowers/plans/2026-03-11-provider-ecosystem.md
+++ b/docs/superpowers/plans/2026-03-11-provider-ecosystem.md
@@ -1,0 +1,1475 @@
+# Provider Ecosystem Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Complete the community plugin marketplace by adding GitHub topic discovery, SHA256 integrity, capability warnings, DB persistence, Official/Community badges, and integrating the marketplace into Settings → Providers.
+
+**Architecture:** The backend plugin loader and hot-reload system are already complete. This plan builds the marketplace layer on top: GitHub API discovery cached in DB, SHA256 hash verification on zip install, capability declarations in manifests, and official registry for trust badges. Frontend moves from standalone Plugins page to a Marketplace tab inside Settings → Providers.
+
+**Tech Stack:** Flask, SQLAlchemy (DB migrations), GitHub REST API v3, React 19 + TypeScript, TanStack Query
+
+**Spec:** `docs/superpowers/specs/2026-03-11-provider-ecosystem-design.md`
+
+---
+
+## Existing Foundation (do NOT rewrite)
+
+These are already implemented and working:
+- `backend/providers/plugins/__init__.py` — PluginManager (discover/reload/unload)
+- `backend/providers/plugins/loader.py` — importlib-based .py loading
+- `backend/providers/plugins/manifest.py` — PluginManifest dataclass + validation
+- `backend/providers/plugins/watcher.py` — watchdog hot-reload
+- `backend/routes/plugins.py` — `GET /plugins`, `POST /plugins/reload`
+- `backend/routes/marketplace.py` — marketplace routes skeleton
+- `backend/services/marketplace.py` — PluginMarketplace service skeleton
+- `frontend/src/pages/Plugins.tsx` — standalone Plugins page (will be replaced by tab)
+- `frontend/src/api/client.ts` — marketplace API functions
+- `frontend/src/hooks/useApi.ts` — marketplace hooks
+
+---
+
+## File Map
+
+### New Files
+- `backend/db/migrations/add_marketplace_tables.py` — DB tables: `marketplace_cache`, `installed_plugins`
+- `backend/services/github_registry.py` — GitHub API topic search + DB cache
+- `backend/tests/test_github_registry.py`
+- `backend/tests/test_marketplace_service.py`
+- `frontend/src/components/providers/MarketplaceTab.tsx` — new Marketplace tab
+- `frontend/src/components/providers/CapabilityWarningModal.tsx`
+- `frontend/src/test/MarketplaceTab.test.tsx`
+- `official-registry.json` — curated provider list (repo root)
+
+### Modified Files
+- `backend/services/marketplace.py` — add GitHub search, SHA256 verify, capability support, DB persistence
+- `backend/routes/marketplace.py` — add `GET /marketplace/refresh`, `GET /marketplace/installed`, `POST /marketplace/install` (extend with SHA256/capabilities)
+- `backend/providers/plugins/manifest.py` — add `capabilities`, `sha256` fields to `PluginManifest`
+- `backend/config.py` — add `github_token` setting
+- `frontend/src/pages/Settings.tsx` (or Providers settings component) — add Marketplace tab
+- `frontend/src/api/client.ts` — extend types + add refresh/installed endpoints
+- `frontend/src/hooks/useApi.ts` — add hooks for new endpoints
+
+---
+
+## Chunk 1: DB Tables + Config
+
+### Task 1: DB migration — `marketplace_cache` and `installed_plugins`
+
+**Files:**
+- Create: `backend/db/migrations/add_marketplace_tables.py`
+- Modify: `backend/db/migrations/__init__.py` (register migration)
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# backend/tests/test_marketplace_db.py
+def test_marketplace_tables_exist(test_db):
+    conn = test_db
+    cursor = conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    tables = {row[0] for row in cursor.fetchall()}
+    assert "marketplace_cache" in tables
+    assert "installed_plugins" in tables
+
+def test_marketplace_cache_insert(test_db):
+    test_db.execute("""
+        INSERT INTO marketplace_cache
+          (name, display_name, author, version, description,
+           github_url, zip_url, sha256, capabilities,
+           min_sublarr_version, is_official, last_fetched)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    """, ("test-plugin", "Test Plugin", "author", "1.0.0",
+          "desc", "https://github.com/a/b", "https://github.com/a/b/releases/download/v1.0.0/plugin.zip",
+          "abc123", '["network"]', "0.22.0", 0,
+          "2026-03-11T00:00:00"))
+    test_db.commit()
+    row = test_db.execute(
+        "SELECT name FROM marketplace_cache WHERE name=?", ("test-plugin",)
+    ).fetchone()
+    assert row is not None
+
+def test_installed_plugins_insert(test_db):
+    test_db.execute("""
+        INSERT INTO installed_plugins
+          (name, display_name, version, plugin_dir, sha256, capabilities, enabled, installed_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    """, ("test-plugin", "Test Plugin", "1.0.0", "/config/plugins/test-plugin",
+          "abc123", '["network"]', 1, "2026-03-11T00:00:00"))
+    test_db.commit()
+    row = test_db.execute(
+        "SELECT name FROM installed_plugins WHERE name=?", ("test-plugin",)
+    ).fetchone()
+    assert row is not None
+```
+
+- [ ] **Step 2: Run test — expect FAIL** (`no such table: marketplace_cache`)
+
+```bash
+cd backend && python -m pytest tests/test_marketplace_db.py -v
+```
+
+- [ ] **Step 3: Write migration**
+
+```python
+# backend/db/migrations/add_marketplace_tables.py
+"""Add marketplace_cache and installed_plugins tables."""
+
+MIGRATION_ID = "add_marketplace_tables"
+
+
+def up(conn):
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS marketplace_cache (
+            name                TEXT PRIMARY KEY,
+            display_name        TEXT NOT NULL,
+            author              TEXT NOT NULL DEFAULT '',
+            version             TEXT NOT NULL DEFAULT '0.0.0',
+            description         TEXT NOT NULL DEFAULT '',
+            github_url          TEXT NOT NULL DEFAULT '',
+            zip_url             TEXT NOT NULL DEFAULT '',
+            sha256              TEXT NOT NULL DEFAULT '',
+            capabilities        TEXT NOT NULL DEFAULT '[]',
+            min_sublarr_version TEXT NOT NULL DEFAULT '',
+            is_official         INTEGER NOT NULL DEFAULT 0,
+            last_fetched        TEXT NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS installed_plugins (
+            name            TEXT PRIMARY KEY,
+            display_name    TEXT NOT NULL DEFAULT '',
+            version         TEXT NOT NULL DEFAULT '0.0.0',
+            plugin_dir      TEXT NOT NULL DEFAULT '',
+            sha256          TEXT NOT NULL DEFAULT '',
+            capabilities    TEXT NOT NULL DEFAULT '[]',
+            enabled         INTEGER NOT NULL DEFAULT 1,
+            installed_at    TEXT NOT NULL
+        );
+    """)
+
+
+def down(conn):
+    conn.executescript("""
+        DROP TABLE IF EXISTS marketplace_cache;
+        DROP TABLE IF EXISTS installed_plugins;
+    """)
+```
+
+- [ ] **Step 4: Register migration** (follow existing pattern in `backend/db/migrations/__init__.py`)
+
+- [ ] **Step 5: Run test — expect PASS**
+
+```bash
+cd backend && python -m pytest tests/test_marketplace_db.py -v
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/db/migrations/add_marketplace_tables.py backend/tests/test_marketplace_db.py
+git commit -m "feat: add marketplace_cache and installed_plugins DB tables"
+```
+
+---
+
+### Task 2: Add `github_token` setting to config
+
+**Files:**
+- Modify: `backend/config.py`
+
+- [ ] **Step 1: Write failing test**
+
+```python
+# backend/tests/test_config.py (add to existing)
+def test_github_token_setting():
+    from config import Settings
+    s = Settings()
+    # default is empty string -- no token required
+    assert hasattr(s, "github_token")
+    assert s.github_token == ""
+```
+
+- [ ] **Step 2: Run test — expect FAIL**
+
+```bash
+cd backend && python -m pytest tests/test_config.py::test_github_token_setting -v
+```
+
+- [ ] **Step 3: Add setting to `config.py`**
+
+Find the providers/plugins section in `config.py` and add:
+
+```python
+github_token: str = ""  # Optional GitHub API token for higher rate limits (5000/h vs 60/h)
+```
+
+With `SUBLARR_` prefix convention this becomes `SUBLARR_GITHUB_TOKEN`.
+
+- [ ] **Step 4: Run test — expect PASS**
+
+```bash
+cd backend && python -m pytest tests/test_config.py::test_github_token_setting -v
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/config.py backend/tests/test_config.py
+git commit -m "feat: add SUBLARR_GITHUB_TOKEN setting for GitHub API rate limits"
+```
+
+---
+
+## Chunk 2: GitHub Registry Service
+
+### Task 3: `github_registry.py` — GitHub topic search + DB cache
+
+**Files:**
+- Create: `backend/services/github_registry.py`
+- Create: `backend/tests/test_github_registry.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# backend/tests/test_github_registry.py
+from unittest.mock import patch, MagicMock
+import json
+
+def test_search_returns_plugins(mock_db):
+    """GitHub API response is parsed and stored in DB cache."""
+    from services.github_registry import GitHubRegistry
+
+    mock_response = {
+        "items": [
+            {
+                "name": "sublarr-opensubtitles",
+                "full_name": "user/sublarr-opensubtitles",
+                "html_url": "https://github.com/user/sublarr-opensubtitles",
+                "description": "OpenSubtitles provider",
+                "owner": {"login": "user"},
+            }
+        ]
+    }
+
+    manifest = {
+        "name": "opensubtitles-enhanced",
+        "display_name": "OpenSubtitles Enhanced",
+        "version": "1.0.0",
+        "author": "user",
+        "description": "OpenSubtitles provider",
+        "entry_point": "provider.py",
+        "class_name": "OpenSubtitlesEnhancedProvider",
+        "capabilities": ["network", "external_api"],
+        "min_sublarr_version": "0.22.0",
+        "sha256": "abc123",
+    }
+
+    with patch("requests.Session.get") as mock_get:
+        # First call: GitHub search API
+        resp1 = MagicMock()
+        resp1.json.return_value = mock_response
+        resp1.status_code = 200
+        resp1.raise_for_status = MagicMock()
+
+        # Second call: manifest.json from repo
+        resp2 = MagicMock()
+        resp2.json.return_value = manifest
+        resp2.status_code = 200
+        resp2.raise_for_status = MagicMock()
+
+        mock_get.side_effect = [resp1, resp2]
+
+        registry = GitHubRegistry(mock_db)
+        plugins = registry.search(force_refresh=True)
+
+    assert len(plugins) == 1
+    assert plugins[0]["name"] == "opensubtitles-enhanced"
+    assert plugins[0]["capabilities"] == ["network", "external_api"]
+
+
+def test_cache_ttl_respected(mock_db):
+    """Second call within TTL window uses DB cache, not GitHub API."""
+    from services.github_registry import GitHubRegistry
+    from datetime import UTC, datetime, timedelta
+
+    # Pre-populate cache with recent entry
+    mock_db.execute("""
+        INSERT INTO marketplace_cache
+          (name, display_name, author, version, description,
+           github_url, zip_url, sha256, capabilities, min_sublarr_version,
+           is_official, last_fetched)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    """, ("cached-plugin", "Cached Plugin", "user", "1.0.0", "desc",
+          "https://github.com/user/cached", "https://github.com/user/cached/releases/download/v1.0.0/plugin.zip",
+          "abc", '["network"]', "0.22.0", 0,
+          datetime.now(UTC).isoformat()))
+    mock_db.commit()
+
+    with patch("requests.Session.get") as mock_get:
+        registry = GitHubRegistry(mock_db)
+        plugins = registry.search(force_refresh=False)
+        # Should NOT have called GitHub API
+        mock_get.assert_not_called()
+
+    assert len(plugins) == 1
+    assert plugins[0]["name"] == "cached-plugin"
+
+
+def test_sha256_included_in_result(mock_db):
+    """Plugin result includes sha256 from manifest."""
+    from services.github_registry import GitHubRegistry
+
+    mock_search_response = {"items": [
+        {"name": "sublarr-test", "full_name": "user/sublarr-test",
+         "html_url": "https://github.com/user/sublarr-test",
+         "description": "Test", "owner": {"login": "user"}}
+    ]}
+    mock_manifest = {
+        "name": "test-provider", "display_name": "Test Provider",
+        "version": "1.0.0", "author": "user", "description": "Test",
+        "entry_point": "provider.py", "class_name": "TestProvider",
+        "capabilities": ["network"], "min_sublarr_version": "0.22.0",
+        "sha256": "deadbeef123",
+    }
+
+    with patch("requests.Session.get") as mock_get:
+        r1, r2 = MagicMock(), MagicMock()
+        r1.json.return_value = mock_search_response
+        r1.raise_for_status = MagicMock()
+        r2.json.return_value = mock_manifest
+        r2.raise_for_status = MagicMock()
+        mock_get.side_effect = [r1, r2]
+
+        registry = GitHubRegistry(mock_db)
+        plugins = registry.search(force_refresh=True)
+
+    assert plugins[0]["sha256"] == "deadbeef123"
+```
+
+- [ ] **Step 2: Run tests — expect FAIL**
+
+```bash
+cd backend && python -m pytest tests/test_github_registry.py -v
+```
+
+- [ ] **Step 3: Implement `github_registry.py`**
+
+```python
+# backend/services/github_registry.py
+"""GitHub-based plugin registry with DB cache.
+
+Searches GitHub for repos with topic 'sublarr-provider', fetches their
+manifest.json, and caches results in the marketplace_cache DB table with
+a 1h TTL. Respects SUBLARR_GITHUB_TOKEN for higher API rate limits.
+"""
+
+import json
+import logging
+from datetime import UTC, datetime, timedelta
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+GITHUB_SEARCH_URL = "https://api.github.com/search/repositories"
+CACHE_TTL_HOURS = 1
+
+
+class GitHubRegistry:
+    """Discovers community plugins via GitHub topic search."""
+
+    def __init__(self, db_conn, github_token: str = ""):
+        self.db = db_conn
+        self.session = requests.Session()
+        self.session.headers["Accept"] = "application/vnd.github+json"
+        self.session.headers["X-GitHub-Api-Version"] = "2022-11-28"
+        if github_token:
+            self.session.headers["Authorization"] = f"Bearer {github_token}"
+
+    def search(self, force_refresh: bool = False) -> list[dict]:
+        """Return list of available plugins.
+
+        Uses DB cache unless force_refresh=True or cache is stale (>1h).
+        """
+        if not force_refresh:
+            cached = self._load_from_cache()
+            if cached:
+                return cached
+
+        return self._fetch_from_github()
+
+    def _load_from_cache(self) -> list[dict] | None:
+        """Load from DB cache if fresh (within CACHE_TTL_HOURS)."""
+        cutoff = (datetime.now(UTC) - timedelta(hours=CACHE_TTL_HOURS)).isoformat()
+        rows = self.db.execute(
+            "SELECT * FROM marketplace_cache WHERE last_fetched > ?", (cutoff,)
+        ).fetchall()
+        if not rows:
+            return None
+        return [self._row_to_dict(row) for row in rows]
+
+    def _fetch_from_github(self) -> list[dict]:
+        """Fetch from GitHub API and update DB cache."""
+        try:
+            resp = self.session.get(
+                GITHUB_SEARCH_URL,
+                params={"q": "topic:sublarr-provider", "per_page": 100},
+                timeout=10,
+            )
+            resp.raise_for_status()
+            repos = resp.json().get("items", [])
+        except Exception as e:
+            logger.warning("GitHub registry fetch failed: %s", e)
+            # Fall back to stale cache
+            rows = self.db.execute("SELECT * FROM marketplace_cache").fetchall()
+            return [self._row_to_dict(row) for row in rows]
+
+        plugins = []
+        for repo in repos:
+            manifest = self._fetch_manifest(repo)
+            if manifest is None:
+                continue
+            plugin = self._store_plugin(repo, manifest)
+            if plugin:
+                plugins.append(plugin)
+
+        return plugins
+
+    def _fetch_manifest(self, repo: dict) -> dict | None:
+        """Fetch manifest.json from repo default branch."""
+        full_name = repo.get("full_name", "")
+        url = f"https://raw.githubusercontent.com/{full_name}/main/manifest.json"
+        try:
+            resp = self.session.get(url, timeout=5)
+            resp.raise_for_status()
+            return resp.json()
+        except Exception:
+            # Try master branch fallback
+            try:
+                url = f"https://raw.githubusercontent.com/{full_name}/master/manifest.json"
+                resp = self.session.get(url, timeout=5)
+                resp.raise_for_status()
+                return resp.json()
+            except Exception as e:
+                logger.debug("No manifest.json in %s: %s", full_name, e)
+                return None
+
+    def _store_plugin(self, repo: dict, manifest: dict) -> dict | None:
+        """Validate manifest, write to DB cache, return plugin dict."""
+        required = ["name", "display_name", "version", "entry_point", "class_name"]
+        for field in required:
+            if not manifest.get(field):
+                logger.debug(
+                    "Skipping %s: missing manifest field '%s'",
+                    repo.get("full_name"), field
+                )
+                return None
+
+        capabilities = manifest.get("capabilities", [])
+        now = datetime.now(UTC).isoformat()
+
+        try:
+            self.db.execute("""
+                INSERT INTO marketplace_cache
+                  (name, display_name, author, version, description,
+                   github_url, zip_url, sha256, capabilities,
+                   min_sublarr_version, is_official, last_fetched)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(name) DO UPDATE SET
+                  display_name=excluded.display_name,
+                  version=excluded.version,
+                  description=excluded.description,
+                  github_url=excluded.github_url,
+                  zip_url=excluded.zip_url,
+                  sha256=excluded.sha256,
+                  capabilities=excluded.capabilities,
+                  min_sublarr_version=excluded.min_sublarr_version,
+                  last_fetched=excluded.last_fetched
+            """, (
+                manifest["name"],
+                manifest["display_name"],
+                manifest.get("author", repo["owner"]["login"]),
+                manifest["version"],
+                manifest.get("description", repo.get("description", "")),
+                repo["html_url"],
+                manifest.get("zip_url", ""),
+                manifest.get("sha256", ""),
+                json.dumps(capabilities),
+                manifest.get("min_sublarr_version", ""),
+                0,  # is_official set separately
+                now,
+            ))
+            self.db.commit()
+        except Exception as e:
+            logger.error("Failed to cache plugin %s: %s", manifest["name"], e)
+            return None
+
+        return self._row_to_dict(self.db.execute(
+            "SELECT * FROM marketplace_cache WHERE name=?", (manifest["name"],)
+        ).fetchone())
+
+    def _row_to_dict(self, row) -> dict:
+        cols = [
+            "name", "display_name", "author", "version", "description",
+            "github_url", "zip_url", "sha256", "capabilities",
+            "min_sublarr_version", "is_official", "last_fetched",
+        ]
+        d = dict(zip(cols, row))
+        d["capabilities"] = json.loads(d.get("capabilities", "[]"))
+        d["is_official"] = bool(d.get("is_official", 0))
+        return d
+```
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+```bash
+cd backend && python -m pytest tests/test_github_registry.py -v
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/services/github_registry.py backend/tests/test_github_registry.py
+git commit -m "feat: GitHub topic-based plugin registry with DB cache"
+```
+
+---
+
+## Chunk 3: SHA256 + Capabilities + Official Registry
+
+### Task 4: SHA256 integrity verification in marketplace service
+
+**Files:**
+- Modify: `backend/services/marketplace.py`
+- Create: `backend/tests/test_marketplace_service.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# backend/tests/test_marketplace_service.py
+import hashlib
+import io
+import zipfile
+from unittest.mock import patch, MagicMock
+
+def make_zip_bytes(content: bytes = b"print('hello')") -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("provider.py", content)
+    return buf.getvalue()
+
+def test_sha256_check_passes_on_match(tmp_path):
+    from services.marketplace import verify_zip_sha256
+    data = make_zip_bytes()
+    expected = hashlib.sha256(data).hexdigest()
+    assert verify_zip_sha256(data, expected) is True
+
+def test_sha256_check_fails_on_mismatch(tmp_path):
+    from services.marketplace import verify_zip_sha256
+    data = make_zip_bytes()
+    assert verify_zip_sha256(data, "wrong_hash") is False
+
+def test_install_rejects_tampered_zip(tmp_path, mock_db):
+    from services.marketplace import PluginMarketplace
+    data = make_zip_bytes()
+    wrong_sha = "0" * 64
+
+    with patch("requests.get") as mock_get:
+        resp = MagicMock()
+        resp.content = data
+        resp.raise_for_status = MagicMock()
+        mock_get.return_value = resp
+
+        marketplace = PluginMarketplace(db=mock_db)
+        with pytest.raises(RuntimeError, match="SHA256 mismatch"):
+            marketplace.install_plugin_from_zip(
+                plugin_name="test",
+                zip_url="https://example.com/plugin.zip",
+                expected_sha256=wrong_sha,
+                plugins_dir=str(tmp_path),
+            )
+```
+
+- [ ] **Step 2: Run tests — expect FAIL**
+
+```bash
+cd backend && python -m pytest tests/test_marketplace_service.py -v
+```
+
+- [ ] **Step 3: Add `verify_zip_sha256` + update install flow**
+
+In `backend/services/marketplace.py`, add at the top:
+
+```python
+import hashlib
+
+def verify_zip_sha256(data: bytes, expected_sha256: str) -> bool:
+    """Return True if SHA256 of data matches expected_sha256."""
+    if not expected_sha256:
+        return True  # No hash provided — skip check (community plugins without hash)
+    actual = hashlib.sha256(data).hexdigest()
+    return actual.lower() == expected_sha256.lower()
+```
+
+Add `install_plugin_from_zip` method to `PluginMarketplace`:
+
+```python
+def install_plugin_from_zip(
+    self,
+    plugin_name: str,
+    zip_url: str,
+    expected_sha256: str,
+    plugins_dir: str,
+) -> dict:
+    """Download zip, verify SHA256, extract to plugins_dir/<plugin_name>."""
+    import io, zipfile, shutil
+    from security_utils import safe_zip_extract
+
+    resp = requests.get(zip_url, timeout=60)
+    resp.raise_for_status()
+    data = resp.content
+
+    if not verify_zip_sha256(data, expected_sha256):
+        raise RuntimeError(
+            f"SHA256 mismatch for {plugin_name}: expected {expected_sha256[:12]}..."
+        )
+
+    plugin_path = os.path.join(plugins_dir, plugin_name)
+    if os.path.exists(plugin_path):
+        shutil.rmtree(plugin_path)
+    os.makedirs(plugin_path, exist_ok=True)
+
+    with zipfile.ZipFile(io.BytesIO(data)) as zf:
+        safe_zip_extract(zf, plugin_path)
+
+    return {"status": "installed", "path": plugin_path}
+```
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+```bash
+cd backend && python -m pytest tests/test_marketplace_service.py -v
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/services/marketplace.py backend/tests/test_marketplace_service.py
+git commit -m "feat: SHA256 integrity check on plugin zip install"
+```
+
+---
+
+### Task 5: `official-registry.json` + mark official plugins in cache
+
+**Files:**
+- Create: `official-registry.json` (repo root)
+- Modify: `backend/services/github_registry.py`
+
+- [ ] **Step 1: Create `official-registry.json`**
+
+```json
+{
+  "_comment": "Curated list of official Sublarr provider plugins. Names must match manifest.json 'name' field.",
+  "official_plugins": []
+}
+```
+
+_(Empty for now — gets populated as community providers are curated)_
+
+- [ ] **Step 2: Update `GitHubRegistry` to mark official plugins**
+
+In `_store_plugin`, after the UPSERT, check official registry:
+
+```python
+def _load_official_names(self) -> set[str]:
+    """Load official plugin names from official-registry.json."""
+    import pathlib
+    registry_path = pathlib.Path(__file__).parent.parent.parent / "official-registry.json"
+    try:
+        data = json.loads(registry_path.read_text())
+        return set(data.get("official_plugins", []))
+    except Exception:
+        return set()
+```
+
+In `_fetch_from_github`, before the loop:
+```python
+official_names = self._load_official_names()
+```
+
+In `_store_plugin`, pass `is_official` based on name membership:
+```python
+is_official=1 if manifest["name"] in official_names else 0,
+```
+
+- [ ] **Step 3: Write test**
+
+```python
+# backend/tests/test_github_registry.py (add)
+def test_official_badge_set_from_registry(mock_db, tmp_path, monkeypatch):
+    """Plugin in official-registry.json gets is_official=True."""
+    import json, pathlib
+    official_reg = tmp_path / "official-registry.json"
+    official_reg.write_text(json.dumps({"official_plugins": ["opensubtitles-enhanced"]}))
+
+    monkeypatch.setattr(
+        "services.github_registry.GitHubRegistry._load_official_names",
+        lambda self: {"opensubtitles-enhanced"},
+    )
+
+    from services.github_registry import GitHubRegistry
+    # ... mock GitHub API returning opensubtitles-enhanced manifest
+    # verify plugins[0]["is_official"] is True
+```
+
+- [ ] **Step 4: Run test — expect PASS**
+
+```bash
+cd backend && python -m pytest tests/test_github_registry.py::test_official_badge_set_from_registry -v
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add official-registry.json backend/services/github_registry.py backend/tests/test_github_registry.py
+git commit -m "feat: official-registry.json + Official badge marking in plugin cache"
+```
+
+---
+
+## Chunk 4: Marketplace Routes
+
+### Task 6: Update marketplace routes — refresh, installed, SHA256-aware install
+
+**Files:**
+- Modify: `backend/routes/marketplace.py`
+- Modify: `backend/services/marketplace.py`
+
+- [ ] **Step 1: Write failing tests for new routes**
+
+```python
+# backend/tests/test_marketplace_routes.py
+def test_get_installed_returns_db_entries(client, mock_db):
+    """GET /marketplace/installed reads from installed_plugins table."""
+    mock_db.execute("""
+        INSERT INTO installed_plugins
+          (name, display_name, version, plugin_dir, sha256, capabilities, enabled, installed_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    """, ("my-plugin", "My Plugin", "1.0.0", "/config/plugins/my-plugin",
+          "abc", '["network"]', 1, "2026-03-11T00:00:00"))
+    mock_db.commit()
+
+    resp = client.get("/api/v1/marketplace/installed")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert len(data["installed"]) == 1
+    assert data["installed"][0]["name"] == "my-plugin"
+
+def test_refresh_triggers_github_fetch(client):
+    """POST /marketplace/refresh calls GitHubRegistry.search(force_refresh=True)."""
+    with patch("routes.marketplace.GitHubRegistry") as MockRegistry:
+        instance = MockRegistry.return_value
+        instance.search.return_value = []
+        resp = client.post("/api/v1/marketplace/refresh")
+        assert resp.status_code == 200
+        instance.search.assert_called_once_with(force_refresh=True)
+
+def test_install_verifies_sha256(client, mock_db, tmp_path):
+    """POST /marketplace/install calls install_plugin_from_zip with sha256."""
+    with patch("routes.marketplace.PluginMarketplace") as MockMP:
+        instance = MockMP.return_value
+        instance.install_plugin_from_zip.return_value = {"status": "installed"}
+        resp = client.post("/api/v1/marketplace/install", json={
+            "name": "test-plugin",
+            "zip_url": "https://example.com/plugin.zip",
+            "sha256": "abc123",
+        })
+        assert resp.status_code == 200
+        instance.install_plugin_from_zip.assert_called_once()
+        call_kwargs = instance.install_plugin_from_zip.call_args
+        assert call_kwargs.kwargs.get("expected_sha256") == "abc123" or \
+               "abc123" in call_kwargs.args
+```
+
+- [ ] **Step 2: Run tests — expect FAIL**
+
+```bash
+cd backend && python -m pytest tests/test_marketplace_routes.py -v
+```
+
+- [ ] **Step 3: Update `routes/marketplace.py`**
+
+Add three new route handlers to the existing blueprint:
+
+```python
+# Add to routes/marketplace.py
+
+@bp.route("/marketplace/installed", methods=["GET"])
+def get_installed_plugins():
+    """List installed plugins from DB."""
+    from database import get_db, _db_lock
+    import json
+    with _db_lock:
+        conn = get_db()
+        rows = conn.execute("SELECT * FROM installed_plugins ORDER BY name").fetchall()
+    cols = ["name", "display_name", "version", "plugin_dir", "sha256",
+            "capabilities", "enabled", "installed_at"]
+    installed = []
+    for row in rows:
+        d = dict(zip(cols, row))
+        d["capabilities"] = json.loads(d.get("capabilities", "[]"))
+        d["enabled"] = bool(d.get("enabled", 1))
+        installed.append(d)
+    return jsonify({"installed": installed})
+
+
+@bp.route("/marketplace/refresh", methods=["POST"])
+def refresh_marketplace():
+    """Force-refresh plugin cache from GitHub."""
+    from database import get_db, _db_lock
+    from services.github_registry import GitHubRegistry
+    settings = get_settings()
+    with _db_lock:
+        conn = get_db()
+        registry = GitHubRegistry(conn, getattr(settings, "github_token", ""))
+        plugins = registry.search(force_refresh=True)
+    return jsonify({"plugins": plugins, "count": len(plugins)})
+
+
+@bp.route("/marketplace/install", methods=["POST"])
+def install_plugin():
+    """Install plugin with SHA256 verification + DB persistence."""
+    import json
+    from datetime import UTC, datetime
+    from database import get_db, _db_lock
+    from providers import invalidate_manager
+    from providers.plugins import get_plugin_manager
+    from services.marketplace import PluginMarketplace
+
+    data = request.get_json(silent=True) or {}
+    name = data.get("name")
+    zip_url = data.get("zip_url")
+    sha256 = data.get("sha256", "")
+
+    if not name or not zip_url:
+        return jsonify({"error": "name and zip_url are required"}), 400
+
+    try:
+        settings = get_settings()
+        plugins_dir = getattr(settings, "plugins_dir", "/config/plugins")
+        marketplace = PluginMarketplace()
+        result = marketplace.install_plugin_from_zip(
+            plugin_name=name,
+            zip_url=zip_url,
+            expected_sha256=sha256,
+            plugins_dir=plugins_dir,
+        )
+
+        # Persist to DB
+        capabilities = json.dumps(data.get("capabilities", []))
+        with _db_lock:
+            conn = get_db()
+            conn.execute("""
+                INSERT INTO installed_plugins
+                  (name, display_name, version, plugin_dir, sha256, capabilities, enabled, installed_at)
+                VALUES (?, ?, ?, ?, ?, ?, 1, ?)
+                ON CONFLICT(name) DO UPDATE SET
+                  version=excluded.version, plugin_dir=excluded.plugin_dir,
+                  sha256=excluded.sha256, capabilities=excluded.capabilities,
+                  installed_at=excluded.installed_at
+            """, (name, data.get("display_name", name),
+                  data.get("version", "0.0.0"),
+                  result["path"], sha256, capabilities,
+                  datetime.now(UTC).isoformat()))
+            conn.commit()
+
+        # Hot-reload plugins
+        manager = get_plugin_manager()
+        if manager:
+            manager.reload()
+            invalidate_manager()
+
+        return jsonify({"status": "installed", "name": name})
+    except RuntimeError as e:
+        return jsonify({"error": str(e)}), 500
+    except Exception:
+        logger.exception("Plugin install failed")
+        return jsonify({"error": "Internal error"}), 500
+```
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+```bash
+cd backend && python -m pytest tests/test_marketplace_routes.py -v
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/routes/marketplace.py backend/tests/test_marketplace_routes.py
+git commit -m "feat: marketplace routes — refresh, installed, SHA256-aware install"
+```
+
+---
+
+## Chunk 5: Frontend
+
+### Task 7: `MarketplaceTab.tsx` — browse, install, uninstall with badges and warning modal
+
+**Files:**
+- Create: `frontend/src/components/providers/MarketplaceTab.tsx`
+- Create: `frontend/src/components/providers/CapabilityWarningModal.tsx`
+- Modify: `frontend/src/api/client.ts` — add types + new endpoints
+- Modify: `frontend/src/hooks/useApi.ts` — add hooks
+
+- [ ] **Step 1: Add types and API functions to `client.ts`**
+
+```typescript
+// Add to frontend/src/api/client.ts
+
+export interface MarketplacePlugin {
+  name: string
+  display_name: string
+  author: string
+  version: string
+  description: string
+  github_url: string
+  zip_url: string
+  sha256: string
+  capabilities: string[]
+  min_sublarr_version: string
+  is_official: boolean
+}
+
+export interface InstalledPlugin {
+  name: string
+  display_name: string
+  version: string
+  capabilities: string[]
+  enabled: boolean
+  installed_at: string
+}
+
+export async function getMarketplaceBrowse(): Promise<{ plugins: MarketplacePlugin[] }> {
+  const { data } = await api.get('/marketplace/plugins')
+  return data
+}
+
+export async function refreshMarketplace(): Promise<{ plugins: MarketplacePlugin[]; count: number }> {
+  const { data } = await api.post('/marketplace/refresh')
+  return data
+}
+
+export async function getInstalledPlugins(): Promise<{ installed: InstalledPlugin[] }> {
+  const { data } = await api.get('/marketplace/installed')
+  return data
+}
+
+export async function installPlugin(plugin: MarketplacePlugin): Promise<{ status: string }> {
+  const { data } = await api.post('/marketplace/install', {
+    name: plugin.name,
+    display_name: plugin.display_name,
+    version: plugin.version,
+    zip_url: plugin.zip_url,
+    sha256: plugin.sha256,
+    capabilities: plugin.capabilities,
+  })
+  return data
+}
+
+export async function uninstallPlugin(name: string): Promise<{ status: string }> {
+  const { data } = await api.post('/marketplace/uninstall', { plugin_name: name })
+  return data
+}
+```
+
+- [ ] **Step 2: Add hooks to `useApi.ts`**
+
+```typescript
+// Add to frontend/src/hooks/useApi.ts
+
+export function useMarketplaceBrowse() {
+  return useQuery({
+    queryKey: ['marketplace', 'browse'],
+    queryFn: getMarketplaceBrowse,
+    staleTime: 1000 * 60 * 60, // 1h — matches backend cache TTL
+  })
+}
+
+export function useInstalledPlugins() {
+  return useQuery({
+    queryKey: ['marketplace', 'installed'],
+    queryFn: getInstalledPlugins,
+  })
+}
+
+export function useInstallPlugin() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: installPlugin,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['marketplace', 'installed'] })
+    },
+  })
+}
+
+export function useUninstallPlugin() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: uninstallPlugin,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['marketplace', 'installed'] })
+    },
+  })
+}
+
+export function useRefreshMarketplace() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: refreshMarketplace,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['marketplace', 'browse'] })
+    },
+  })
+}
+```
+
+- [ ] **Step 3: Create `CapabilityWarningModal.tsx`**
+
+```tsx
+// frontend/src/components/providers/CapabilityWarningModal.tsx
+import { AlertTriangle } from 'lucide-react'
+
+const HIGH_RISK = new Set(['filesystem', 'subprocess'])
+
+interface Props {
+  plugin: { name: string; display_name: string; capabilities: string[] }
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export function CapabilityWarningModal({ plugin, onConfirm, onCancel }: Props) {
+  const risky = plugin.capabilities.filter((c) => HIGH_RISK.has(c))
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/60 flex items-center justify-center z-50"
+      onClick={onCancel}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="cap-warning-title"
+        className="bg-gray-900 border border-yellow-600 rounded-lg p-6 max-w-md w-full mx-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center gap-3 mb-4">
+          <AlertTriangle className="w-6 h-6 text-yellow-400 shrink-0" />
+          <h2 id="cap-warning-title" className="text-lg font-semibold">
+            Community Plugin — Elevated Permissions
+          </h2>
+        </div>
+        <p className="text-gray-300 text-sm mb-3">
+          <strong>{plugin.display_name}</strong> declares the following capabilities:
+        </p>
+        <ul className="mb-4 space-y-1">
+          {risky.map((cap) => (
+            <li key={cap} className="text-yellow-400 text-sm font-mono bg-yellow-400/10 px-2 py-1 rounded">
+              {cap}
+            </li>
+          ))}
+        </ul>
+        <p className="text-gray-400 text-sm mb-6">
+          Community code runs inside the Sublarr process. Only install if you trust the source.
+        </p>
+        <div className="flex gap-3 justify-end">
+          <button
+            autoFocus
+            onClick={onCancel}
+            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onConfirm}
+            className="px-4 py-2 bg-yellow-600 hover:bg-yellow-500 text-white rounded"
+          >
+            Install anyway
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Create `MarketplaceTab.tsx`**
+
+```tsx
+// frontend/src/components/providers/MarketplaceTab.tsx
+import { useState, useCallback } from 'react'
+import { Search, RefreshCw, Download, Trash2, ExternalLink, Loader2, Package, ShieldCheck } from 'lucide-react'
+import { toast } from '@/components/shared/Toast'
+import {
+  useMarketplaceBrowse,
+  useInstalledPlugins,
+  useInstallPlugin,
+  useUninstallPlugin,
+  useRefreshMarketplace,
+} from '@/hooks/useApi'
+import { CapabilityWarningModal } from './CapabilityWarningModal'
+import type { MarketplacePlugin } from '@/api/client'
+
+const HIGH_RISK = new Set(['filesystem', 'subprocess'])
+
+function hasRiskyCapabilities(capabilities: string[]): boolean {
+  return capabilities.some((c) => HIGH_RISK.has(c))
+}
+
+export function MarketplaceTab() {
+  const [search, setSearch] = useState('')
+  const [onlyInstalled, setOnlyInstalled] = useState(false)
+  const [pendingInstall, setPendingInstall] = useState<MarketplacePlugin | null>(null)
+
+  const { data: browseData, isLoading: isBrowseLoading } = useMarketplaceBrowse()
+  const { data: installedData } = useInstalledPlugins()
+  const installMutation = useInstallPlugin()
+  const uninstallMutation = useUninstallPlugin()
+  const refreshMutation = useRefreshMarketplace()
+
+  const installedNames = new Set(installedData?.installed.map((p) => p.name) ?? [])
+  const installedVersions = Object.fromEntries(
+    installedData?.installed.map((p) => [p.name, p.version]) ?? []
+  )
+  const allPlugins = browseData?.plugins ?? []
+
+  const filtered = allPlugins.filter((p) => {
+    const matchSearch =
+      p.name.toLowerCase().includes(search.toLowerCase()) ||
+      p.display_name.toLowerCase().includes(search.toLowerCase()) ||
+      p.description.toLowerCase().includes(search.toLowerCase())
+    const matchInstalled = !onlyInstalled || installedNames.has(p.name)
+    return matchSearch && matchInstalled
+  })
+
+  const handleInstallRequest = useCallback((plugin: MarketplacePlugin) => {
+    if (!plugin.is_official && hasRiskyCapabilities(plugin.capabilities)) {
+      setPendingInstall(plugin)
+    } else {
+      doInstall(plugin)
+    }
+  }, [])
+
+  const doInstall = useCallback(async (plugin: MarketplacePlugin) => {
+    setPendingInstall(null)
+    try {
+      await installMutation.mutateAsync(plugin)
+      toast(`"${plugin.display_name}" installed`, 'success')
+    } catch {
+      toast(`Failed to install "${plugin.display_name}"`, 'error')
+    }
+  }, [installMutation])
+
+  const handleUninstall = useCallback(async (name: string, displayName: string) => {
+    try {
+      await uninstallMutation.mutateAsync(name)
+      toast(`"${displayName}" removed`, 'success')
+    } catch {
+      toast(`Failed to remove "${displayName}"`, 'error')
+    }
+  }, [uninstallMutation])
+
+  return (
+    <div className="space-y-4">
+      {/* Toolbar */}
+      <div className="flex gap-3 items-center">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+          <input
+            type="text"
+            placeholder="Search plugins..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="w-full pl-10 pr-4 py-2 bg-gray-800 border border-gray-700 rounded text-white placeholder-gray-500"
+          />
+        </div>
+        <label className="flex items-center gap-2 text-sm text-gray-400 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={onlyInstalled}
+            onChange={(e) => setOnlyInstalled(e.target.checked)}
+            className="rounded"
+          />
+          Installed only
+        </label>
+        <button
+          onClick={() => refreshMutation.mutate()}
+          disabled={refreshMutation.isPending}
+          className="px-3 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded flex items-center gap-2 text-sm"
+          title="Refresh from GitHub"
+        >
+          <RefreshCw className={`w-4 h-4 ${refreshMutation.isPending ? 'animate-spin' : ''}`} />
+          Refresh
+        </button>
+      </div>
+
+      {/* Plugin list */}
+      {isBrowseLoading ? (
+        <div className="flex justify-center py-12">
+          <Loader2 className="w-8 h-8 animate-spin text-teal-500" />
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {filtered.map((plugin) => {
+            const installed = installedNames.has(plugin.name)
+            const currentVersion = installedVersions[plugin.name]
+            const hasUpdate = installed && currentVersion && currentVersion !== plugin.version
+            const isInstalling = installMutation.isPending &&
+              (installMutation.variables as MarketplacePlugin)?.name === plugin.name
+
+            return (
+              <div
+                key={plugin.name}
+                className="flex items-start gap-4 p-4 bg-gray-800 rounded-lg border border-gray-700"
+              >
+                <Package className="w-6 h-6 text-teal-500 shrink-0 mt-0.5" />
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <span className="font-semibold text-white">{plugin.display_name}</span>
+                    <span className="text-xs text-gray-400">v{plugin.version}</span>
+                    {plugin.is_official && (
+                      <span className="flex items-center gap-1 text-xs bg-green-600/20 text-green-400 px-2 py-0.5 rounded-full">
+                        <ShieldCheck className="w-3 h-3" /> Official
+                      </span>
+                    )}
+                    {!plugin.is_official && (
+                      <span className="text-xs bg-gray-700 text-gray-400 px-2 py-0.5 rounded-full">
+                        Community
+                      </span>
+                    )}
+                    {hasUpdate && (
+                      <span className="text-xs bg-yellow-600/20 text-yellow-400 px-2 py-0.5 rounded-full">
+                        Update available → v{plugin.version}
+                      </span>
+                    )}
+                  </div>
+                  <p className="text-sm text-gray-400 mt-1">{plugin.description}</p>
+                  <p className="text-xs text-gray-500 mt-1">by {plugin.author}</p>
+                </div>
+                <div className="flex items-center gap-2 shrink-0">
+                  <a
+                    href={plugin.github_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="p-2 text-gray-400 hover:text-white"
+                    title="View on GitHub"
+                  >
+                    <ExternalLink className="w-4 h-4" />
+                  </a>
+                  {installed ? (
+                    <button
+                      onClick={() => handleUninstall(plugin.name, plugin.display_name)}
+                      className="px-3 py-1.5 text-sm bg-red-500/20 hover:bg-red-500/30 text-red-400 rounded flex items-center gap-1"
+                    >
+                      <Trash2 className="w-4 h-4" />
+                      Remove
+                    </button>
+                  ) : (
+                    <button
+                      onClick={() => handleInstallRequest(plugin)}
+                      disabled={isInstalling}
+                      className="px-3 py-1.5 text-sm bg-teal-600 hover:bg-teal-500 text-white rounded flex items-center gap-1 disabled:opacity-50"
+                    >
+                      {isInstalling ? (
+                        <Loader2 className="w-4 h-4 animate-spin" />
+                      ) : (
+                        <Download className="w-4 h-4" />
+                      )}
+                      Install
+                    </button>
+                  )}
+                </div>
+              </div>
+            )
+          })}
+          {!isBrowseLoading && filtered.length === 0 && (
+            <div className="text-center py-12 text-gray-400">
+              <Package className="w-10 h-10 mx-auto mb-3 opacity-50" />
+              <p>No plugins found.</p>
+            </div>
+          )}
+        </div>
+      )}
+
+      {pendingInstall && (
+        <CapabilityWarningModal
+          plugin={pendingInstall}
+          onConfirm={() => doInstall(pendingInstall)}
+          onCancel={() => setPendingInstall(null)}
+        />
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 5: Integrate into Settings → Providers**
+
+Find the Providers settings page (likely `frontend/src/pages/Settings.tsx` or a `ProvidersTab` component). Add `MarketplaceTab` as the third tab after Configured and Available:
+
+```tsx
+// In the providers tab panel, add:
+{ label: 'Marketplace', component: <MarketplaceTab /> }
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/providers/ frontend/src/api/client.ts frontend/src/hooks/useApi.ts
+git commit -m "feat: Marketplace tab in Providers settings — browse, install, Official/Community badges, capability warning modal"
+```
+
+---
+
+## Chunk 6: Tests + Final Wiring
+
+### Task 8: Frontend tests
+
+**Files:**
+- Create: `frontend/src/test/MarketplaceTab.test.tsx`
+
+- [ ] **Step 1: Write tests**
+
+```tsx
+// frontend/src/test/MarketplaceTab.test.tsx
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { MarketplaceTab } from '@/components/providers/MarketplaceTab'
+
+const mockPlugin = {
+  name: 'test-provider',
+  display_name: 'Test Provider',
+  author: 'testuser',
+  version: '1.0.0',
+  description: 'A test provider',
+  github_url: 'https://github.com/testuser/test-provider',
+  zip_url: 'https://github.com/testuser/test-provider/releases/download/v1.0.0/plugin.zip',
+  sha256: 'abc123',
+  capabilities: ['network'],
+  min_sublarr_version: '0.22.0',
+  is_official: false,
+}
+
+const mockRiskyPlugin = { ...mockPlugin, name: 'risky-provider', capabilities: ['network', 'filesystem'] }
+
+vi.mock('@/hooks/useApi', () => ({
+  useMarketplaceBrowse: () => ({ data: { plugins: [mockPlugin, mockRiskyPlugin] }, isLoading: false }),
+  useInstalledPlugins: () => ({ data: { installed: [] } }),
+  useInstallPlugin: () => ({ mutateAsync: vi.fn(), isPending: false, variables: null }),
+  useUninstallPlugin: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useRefreshMarketplace: () => ({ mutate: vi.fn(), isPending: false }),
+}))
+
+describe('MarketplaceTab', () => {
+  it('renders plugin cards', () => {
+    render(<MarketplaceTab />)
+    expect(screen.getByText('Test Provider')).toBeInTheDocument()
+    expect(screen.getByText('Risky Provider')).toBeInTheDocument()
+  })
+
+  it('shows Community badge for non-official plugins', () => {
+    render(<MarketplaceTab />)
+    const communityBadges = screen.getAllByText('Community')
+    expect(communityBadges.length).toBeGreaterThan(0)
+  })
+
+  it('shows capability warning modal for risky community plugins', async () => {
+    render(<MarketplaceTab />)
+    const installButtons = screen.getAllByText('Install')
+    // Click Install on the risky plugin (second card)
+    fireEvent.click(installButtons[1])
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+      expect(screen.getByText(/Elevated Permissions/i)).toBeInTheDocument()
+    })
+  })
+
+  it('does NOT show capability warning modal for safe plugins', async () => {
+    render(<MarketplaceTab />)
+    const installButtons = screen.getAllByText('Install')
+    fireEvent.click(installButtons[0]) // safe plugin
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('filters plugins by search text', () => {
+    render(<MarketplaceTab />)
+    const searchInput = screen.getByPlaceholderText('Search plugins...')
+    fireEvent.change(searchInput, { target: { value: 'risky' } })
+    expect(screen.queryByText('Test Provider')).not.toBeInTheDocument()
+    expect(screen.getByText('Risky Provider')).toBeInTheDocument()
+  })
+})
+```
+
+- [ ] **Step 2: Run linting + type check**
+
+```bash
+cd frontend && npm run lint && npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/test/MarketplaceTab.test.tsx
+git commit -m "test: MarketplaceTab — render, badges, capability warning, search filter"
+```
+
+---
+
+### Task 9: Full backend test run
+
+- [ ] **Step 1: Run all new tests together**
+
+```bash
+cd backend && python -m pytest tests/test_marketplace_db.py tests/test_github_registry.py tests/test_marketplace_service.py tests/test_marketplace_routes.py -v
+```
+
+Expected: all PASS.
+
+- [ ] **Step 2: Run full test suite (with standard ignores)**
+
+```bash
+cd backend && python -m pytest --tb=short -q \
+  --ignore=tests/performance \
+  --ignore=tests/integration/test_translator_pipeline.py \
+  --ignore=tests/integration/test_provider_pipeline.py \
+  --ignore=tests/test_video_sync.py \
+  --ignore=tests/test_translation_backends.py \
+  --ignore=tests/test_wanted_search_reliability.py \
+  -k "not (test_sonarr_download_webhook or test_radarr_download_webhook or test_parse_llm_response_too_many_merge or test_record_backend_success)"
+```
+
+Expected: green.
+
+- [ ] **Step 3: Run ruff linting**
+
+```bash
+cd backend && ruff check . && ruff format --check .
+```
+
+- [ ] **Step 4: Final commit**
+
+```bash
+git add -u
+git commit -m "chore: provider ecosystem v0.22.0 — all tests green"
+```
+
+---
+
+## Post-Implementation
+
+After all tasks complete:
+
+1. **Update MEMORY.md** — add v0.22.0 status
+2. **Invoke `superpowers:finishing-a-development-branch`** — create PR, bump version to 0.22.0-beta, update CHANGELOG

--- a/docs/superpowers/specs/2026-03-11-provider-ecosystem-design.md
+++ b/docs/superpowers/specs/2026-03-11-provider-ecosystem-design.md
@@ -1,0 +1,219 @@
+# Provider Ecosystem — Design Spec
+**Version:** v0.22.0
+**Date:** 2026-03-11
+**Status:** Approved
+
+---
+
+## Overview
+
+A full-lifecycle plugin system for community-built subtitle providers. Providers are
+discoverable via GitHub, installable at runtime without restart, and verified via
+SHA-256 integrity checks. Builtin providers are unchanged — community providers are
+purely additive.
+
+---
+
+## Architecture
+
+```
+backend/
+  providers/          # Builtin providers (unchanged, always active)
+  plugins/
+    providers/        # Community providers (.zip extracted here)
+    manager.py        # PluginManager — load, reload, unload
+    registry.py       # GitHub API discovery + DB cache (TTL 1h)
+    sandbox.py        # SHA256 verification + capability parser
+```
+
+**Three new layers:**
+1. **PluginManager** — dynamically imports community providers, registers them in the
+   existing provider registry; supports hot-reload without restart
+2. **Registry** — fetches GitHub repos with topic `sublarr-provider`; caches results
+   in DB with 1h TTL; parses manifest per repo
+3. **DB tables** — `installed_plugins` (what's installed) + `marketplace_cache` (GitHub results)
+
+---
+
+## Plugin Format
+
+Each community provider ships as a `.zip`:
+
+```
+provider-name-v1.0.0.zip
+├── manifest.json     # Required
+├── provider.py       # Required — entry point, inherits BaseProvider
+├── requirements.txt  # Optional — extra pip dependencies
+└── README.md         # Optional
+```
+
+**`manifest.json` schema:**
+```json
+{
+  "name": "opensubtitles-community",
+  "display_name": "OpenSubtitles Community",
+  "version": "1.2.0",
+  "author": "username",
+  "description": "OpenSubtitles.com provider with enhanced scoring",
+  "entry_point": "provider.py",
+  "class_name": "OpenSubtitlesCommunityProvider",
+  "capabilities": ["network", "external_api"],
+  "min_sublarr_version": "0.22.0",
+  "sha256": "abc123..."
+}
+```
+
+**Capabilities** (declared, not enforced — UI shows warning):
+
+| Capability | Meaning | Warning level |
+|---|---|---|
+| `network` | Makes HTTP requests | Low |
+| `external_api` | Calls external APIs | Low |
+| `filesystem` | Reads/writes files outside media paths | High |
+| `subprocess` | Spawns subprocesses | High |
+
+**Entry point:** provider class inherits `BaseProvider` — identical to builtin providers.
+Community developers write the same code as builtins.
+
+---
+
+## GitHub Registry & Discovery
+
+**Discovery flow:**
+```
+GitHub API → search repos (topic:sublarr-provider)
+           → fetch manifest.json per repo
+           → read latest release .zip URL + SHA256
+           → store in marketplace_cache (TTL 1h)
+```
+
+**Trust model:**
+- A curated `official-registry.json` in the Sublarr repo lists verified providers
+- Providers in that list → green "Official" badge
+- All others → grey "Community" badge + more prominent capability warnings
+
+**Rate limiting:**
+- GitHub API: 60 req/h unauthenticated, 5000/h with token
+- Optional `SUBLARR_GITHUB_TOKEN` setting
+- Manual "Refresh" button in UI; cache prevents redundant requests
+
+**DB table `marketplace_cache`:**
+```
+name, display_name, author, version, description,
+github_url, zip_url, sha256, capabilities,
+min_sublarr_version, last_fetched
+```
+
+---
+
+## Install / Update / Uninstall
+
+**Install flow:**
+```
+Download .zip from GitHub release URL
+→ SHA256 verify (against manifest value)
+→ Validate manifest (required fields, min_sublarr_version)
+→ Show capabilities + warning modal if filesystem/subprocess
+→ User confirms
+→ Extract to backend/plugins/providers/<name>/
+→ pip install requirements.txt (if present)
+→ Write DB entry to installed_plugins
+→ PluginManager.load(name) — dynamic import, register in provider registry
+→ Socket.IO event → UI refresh
+```
+
+**Update:** identical to install; PluginManager.reload(name) hot-swaps without restart.
+
+**Uninstall:**
+```
+PluginManager.unload(name) — remove from provider registry
+→ Delete directory
+→ Remove DB entry
+→ Graceful drain: wait for in-flight jobs using this provider to finish
+```
+
+**DB table `installed_plugins`:**
+```
+name, display_name, version, path, sha256,
+capabilities, enabled, installed_at
+```
+
+---
+
+## API Routes
+
+All under `/api/v1/marketplace/`:
+
+```
+GET    /marketplace/browse           # Cached GitHub results
+POST   /marketplace/refresh          # Manual cache refresh
+GET    /marketplace/installed         # installed_plugins from DB
+POST   /marketplace/install           # body: {name, github_url}
+POST   /marketplace/update/<name>     # Re-download + reload
+DELETE /marketplace/uninstall/<name>
+```
+
+---
+
+## UI — Settings → Providers → Marketplace Tab
+
+**Tab structure:**
+```
+Settings → Providers
+  ├── Configured    (existing)
+  ├── Available     (existing)
+  └── Marketplace   (new)
+```
+
+**Marketplace tab:**
+- Search bar + "Refresh" button + "Only Installed" toggle
+- Provider cards showing: Official/Community badge, name, version, author,
+  capabilities, description, Install/Update/Remove action button
+- "Update available" indicator when cached version > installed version
+
+**Capability warning modal** (shown before install when `filesystem` or `subprocess` declared):
+> "This provider declares `filesystem` access. Community code runs inside the Sublarr
+> process. Only install if you trust the source."
+> `[Cancel]` `[Install anyway]`
+
+---
+
+## Security Model
+
+- **Explicit consent** — user initiates every install; no silent downloads
+- **SHA-256 integrity** — zip hash verified against manifest value before extraction
+- **Capability declarations** — manifest declares what the provider needs; Sublarr
+  warns at install time; not enforced at runtime (no sandboxing)
+- **Official vs. Community** — curated registry provides visual trust signal
+- **No sandbox** — community providers run in the Sublarr process; this is accepted
+  risk for a homelab tool (same model as Home Assistant custom components, Bazarr)
+
+---
+
+## Testing
+
+**Backend:**
+- `test_plugin_manager.py` — load/reload/unload mock provider; verify registry entry
+- `test_registry.py` — GitHub API mocked; verify cache logic, TTL, official badge detection
+- `test_sandbox.py` — SHA256: valid zip passes, tampered zip rejected; capability parser
+- `test_marketplace_routes.py` — all 6 routes; install flow with mocked GitHub download
+
+**Frontend:**
+- `MarketplaceTab.test.tsx` — browse list renders; install button triggers API call;
+  capability warning modal appears for `filesystem`/`subprocess`
+
+**Manual smoke test:**
+1. Build a real mini-provider `.zip` (5 lines, returns empty results)
+2. Install via UI — verify it appears in Configured tab
+3. Restart Sublarr — verify provider reloads (DB persistence)
+4. Uninstall — verify it disappears
+
+---
+
+## Out of Scope (v0.22)
+
+- Runtime sandboxing (subprocess/WASM isolation)
+- Signature-based trust (PKI)
+- pip-installable packages requiring container rebuild
+- List virtualization (deferred to v0.22.x)
+- Provider dependency resolution between plugins

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1614,4 +1614,60 @@ export function getSeriesSubtitleExportUrl(
   return `/api/v1/series/${seriesId}/subtitles/export${params}`
 }
 
+// ── v0.22 Marketplace types ────────────────────────────────────────────────
+export interface MarketplaceBrowsePlugin {
+  name: string
+  display_name: string
+  author: string
+  version: string
+  description: string
+  github_url: string
+  zip_url: string
+  sha256: string
+  capabilities: string[]
+  min_sublarr_version: string
+  is_official: boolean
+}
+
+export interface InstalledPlugin {
+  name: string
+  display_name: string
+  version: string
+  capabilities: string[]
+  enabled: boolean
+  installed_at: string
+}
+
+export async function getMarketplaceBrowse(): Promise<{ plugins: MarketplaceBrowsePlugin[] }> {
+  const { data } = await api.get('/marketplace/plugins')
+  return data
+}
+
+export async function refreshMarketplace(): Promise<{ plugins: MarketplaceBrowsePlugin[]; count: number }> {
+  const { data } = await api.post('/marketplace/refresh')
+  return data
+}
+
+export async function getInstalledPlugins(): Promise<{ installed: InstalledPlugin[] }> {
+  const { data } = await api.get('/marketplace/installed')
+  return data
+}
+
+export async function installBrowsePlugin(plugin: MarketplaceBrowsePlugin): Promise<{ status: string }> {
+  const { data } = await api.post('/marketplace/install', {
+    name: plugin.name,
+    display_name: plugin.display_name,
+    version: plugin.version,
+    zip_url: plugin.zip_url,
+    sha256: plugin.sha256,
+    capabilities: plugin.capabilities,
+  })
+  return data
+}
+
+export async function uninstallBrowsePlugin(name: string): Promise<{ status: string }> {
+  const { data } = await api.post('/marketplace/uninstall', { plugin_name: name })
+  return data
+}
+
 export default api

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -66,13 +66,15 @@ import {
   getScannerStatus,
   getSupportedLanguages,
   cleanupSidecars,
+  getMarketplaceBrowse, refreshMarketplace, getInstalledPlugins,
+  installBrowsePlugin, uninstallBrowsePlugin,
 } from '@/api/client'
 import type {
   LanguageProfile, BackendConfig, MediaServerInstance, HookConfig, WebhookConfig, LogRotationConfig, FilterScope, BatchAction,
   NotificationTemplate, QuietHoursConfig, NotificationFilter, BazarrMigrationPreview,
   CleanupRule,
 } from '@/lib/types'
-import type { DownloadSpecificPayload } from '@/api/client'
+import type { DownloadSpecificPayload, MarketplaceBrowsePlugin } from '@/api/client'
 
 // ─── Languages ───────────────────────────────────────────────────────────────
 
@@ -1872,5 +1874,52 @@ export function useRefreshAnidbMapping() {
   return useMutation({
     mutationFn: refreshAnidbMapping,
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['anidb-mapping-status'] }),
+  })
+}
+
+// ── v0.22 Marketplace hooks ────────────────────────────────────────────────
+
+export function useMarketplaceBrowse() {
+  return useQuery({
+    queryKey: ['marketplace', 'browse'],
+    queryFn: getMarketplaceBrowse,
+    staleTime: 1000 * 60 * 60, // 1h matches backend cache TTL
+  })
+}
+
+export function useInstalledPlugins() {
+  return useQuery({
+    queryKey: ['marketplace', 'installed'],
+    queryFn: getInstalledPlugins,
+  })
+}
+
+export function useInstallBrowsePlugin() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (plugin: MarketplaceBrowsePlugin) => installBrowsePlugin(plugin),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['marketplace', 'installed'] })
+    },
+  })
+}
+
+export function useUninstallBrowsePlugin() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (name: string) => uninstallBrowsePlugin(name),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['marketplace', 'installed'] })
+    },
+  })
+}
+
+export function useRefreshMarketplaceBrowse() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: refreshMarketplace,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['marketplace', 'browse'] })
+    },
   })
 }

--- a/frontend/src/pages/Settings/ProvidersTab.tsx
+++ b/frontend/src/pages/Settings/ProvidersTab.tsx
@@ -8,6 +8,9 @@ import type { ProviderInfo } from '@/lib/types'
 import { ProviderTile } from './providers/ProviderTile'
 import { ProviderEditModal } from './providers/ProviderEditModal'
 import { AddProviderModal } from './providers/AddProviderModal'
+import { MarketplaceTab } from './providers/MarketplaceTab'
+
+type ProviderTabId = 'configured' | 'marketplace'
 
 export function ProvidersTab({
   values,
@@ -24,6 +27,7 @@ export function ProvidersTab({
   const clearCacheMut = useClearProviderCache()
   const [testResults, setTestResults] = useState<Record<string, { healthy: boolean; message: string } | 'testing'>>({})
   const [localPriority, setLocalPriority] = useState<string[] | null>(null)
+  const [activeTab, setActiveTab] = useState<ProviderTabId>('configured')
   const [editingProvider, setEditingProvider] = useState<string | null>(null)
   const [isNewProvider, setIsNewProvider] = useState(false)
   const [showAddModal, setShowAddModal] = useState(false)
@@ -163,8 +167,36 @@ export function ProvidersTab({
     ? shownProviders.indexOf(editingProviderData)
     : -1
 
+  const TAB_LABELS: { id: ProviderTabId; label: string }[] = [
+    { id: 'configured', label: 'Configured' },
+    { id: 'marketplace', label: 'Marketplace' },
+  ]
+
   return (
     <div className="space-y-4">
+      {/* Tab bar */}
+      <div className="flex gap-1 border-b" style={{ borderColor: 'var(--border)' }}>
+        {TAB_LABELS.map((tab) => (
+          <button
+            key={tab.id}
+            onClick={() => setActiveTab(tab.id)}
+            className="px-4 py-2 text-sm font-medium transition-colors"
+            style={{
+              color: activeTab === tab.id ? 'var(--accent)' : 'var(--text-secondary)',
+              borderBottom: activeTab === tab.id ? '2px solid var(--accent)' : '2px solid transparent',
+              marginBottom: '-1px',
+            }}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Marketplace tab */}
+      {activeTab === 'marketplace' && <MarketplaceTab />}
+
+      {/* Configured tab */}
+      {activeTab === 'configured' && <>
       {/* Header */}
       <div className="flex items-center justify-between">
         <span className="text-xs font-medium" style={{ color: 'var(--text-secondary)' }}>
@@ -316,6 +348,7 @@ export function ProvidersTab({
           onClose={() => setShowAddModal(false)}
         />
       )}
+      </>}
     </div>
   )
 }

--- a/frontend/src/pages/Settings/providers/CapabilityWarningModal.tsx
+++ b/frontend/src/pages/Settings/providers/CapabilityWarningModal.tsx
@@ -1,0 +1,63 @@
+import { AlertTriangle } from 'lucide-react'
+
+const HIGH_RISK = new Set(['filesystem', 'subprocess'])
+
+interface Props {
+  plugin: { name: string; display_name: string; capabilities: string[] }
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export function CapabilityWarningModal({ plugin, onConfirm, onCancel }: Props) {
+  const risky = plugin.capabilities.filter((c) => HIGH_RISK.has(c))
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/60 flex items-center justify-center z-50"
+      onClick={onCancel}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="cap-warning-title"
+        className="bg-gray-900 border border-yellow-600 rounded-lg p-6 max-w-md w-full mx-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center gap-3 mb-4">
+          <AlertTriangle className="w-6 h-6 text-yellow-400 shrink-0" />
+          <h2 id="cap-warning-title" className="text-lg font-semibold">
+            Community Plugin — Elevated Permissions
+          </h2>
+        </div>
+        <p className="text-gray-300 text-sm mb-3">
+          <strong>{plugin.display_name}</strong> declares the following capabilities:
+        </p>
+        <ul className="mb-4 space-y-1">
+          {risky.map((cap) => (
+            <li key={cap} className="text-yellow-400 text-sm font-mono bg-yellow-400/10 px-2 py-1 rounded">
+              {cap}
+            </li>
+          ))}
+        </ul>
+        <p className="text-gray-400 text-sm mb-6">
+          Community code runs inside the Sublarr process. Only install if you trust the source.
+        </p>
+        <div className="flex gap-3 justify-end">
+          <button
+            autoFocus
+            onClick={onCancel}
+            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onConfirm}
+            className="px-4 py-2 bg-yellow-600 hover:bg-yellow-500 text-white rounded"
+          >
+            Install anyway
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/Settings/providers/MarketplaceTab.tsx
+++ b/frontend/src/pages/Settings/providers/MarketplaceTab.tsx
@@ -1,0 +1,205 @@
+import { useState, useCallback } from 'react'
+import {
+  Search, RefreshCw, Download, Trash2, ExternalLink,
+  Loader2, Package, ShieldCheck,
+} from 'lucide-react'
+import { toast } from '@/components/shared/Toast'
+import {
+  useMarketplaceBrowse,
+  useInstalledPlugins,
+  useInstallBrowsePlugin,
+  useUninstallBrowsePlugin,
+  useRefreshMarketplaceBrowse,
+} from '@/hooks/useApi'
+import { CapabilityWarningModal } from './CapabilityWarningModal'
+import type { MarketplaceBrowsePlugin } from '@/api/client'
+
+const HIGH_RISK = new Set(['filesystem', 'subprocess'])
+
+function hasRiskyCapabilities(capabilities: string[]): boolean {
+  return capabilities.some((c) => HIGH_RISK.has(c))
+}
+
+export function MarketplaceTab() {
+  const [search, setSearch] = useState('')
+  const [onlyInstalled, setOnlyInstalled] = useState(false)
+  const [pendingInstall, setPendingInstall] = useState<MarketplaceBrowsePlugin | null>(null)
+
+  const { data: browseData, isLoading } = useMarketplaceBrowse()
+  const { data: installedData } = useInstalledPlugins()
+  const installMutation = useInstallBrowsePlugin()
+  const uninstallMutation = useUninstallBrowsePlugin()
+  const refreshMutation = useRefreshMarketplaceBrowse()
+
+  const installedNames = new Set(installedData?.installed.map((p) => p.name) ?? [])
+  const installedVersions = Object.fromEntries(
+    installedData?.installed.map((p) => [p.name, p.version]) ?? []
+  )
+  const allPlugins = browseData?.plugins ?? []
+
+  const filtered = allPlugins.filter((p) => {
+    const matchSearch =
+      p.name.toLowerCase().includes(search.toLowerCase()) ||
+      p.display_name.toLowerCase().includes(search.toLowerCase()) ||
+      p.description.toLowerCase().includes(search.toLowerCase())
+    const matchInstalled = !onlyInstalled || installedNames.has(p.name)
+    return matchSearch && matchInstalled
+  })
+
+  const doInstall = useCallback(async (plugin: MarketplaceBrowsePlugin) => {
+    setPendingInstall(null)
+    try {
+      await installMutation.mutateAsync(plugin)
+      toast(`"${plugin.display_name}" installed`, 'success')
+    } catch {
+      toast(`Failed to install "${plugin.display_name}"`, 'error')
+    }
+  }, [installMutation])
+
+  const handleInstallRequest = useCallback((plugin: MarketplaceBrowsePlugin) => {
+    if (!plugin.is_official && hasRiskyCapabilities(plugin.capabilities)) {
+      setPendingInstall(plugin)
+    } else {
+      void doInstall(plugin)
+    }
+  }, [doInstall])
+
+  const handleUninstall = useCallback(async (name: string, displayName: string) => {
+    try {
+      await uninstallMutation.mutateAsync(name)
+      toast(`"${displayName}" removed`, 'success')
+    } catch {
+      toast(`Failed to remove "${displayName}"`, 'error')
+    }
+  }, [uninstallMutation])
+
+  return (
+    <div className="space-y-4">
+      <div className="flex gap-3 items-center">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+          <input
+            type="text"
+            placeholder="Search plugins..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="w-full pl-10 pr-4 py-2 bg-gray-800 border border-gray-700 rounded text-white placeholder-gray-500"
+          />
+        </div>
+        <label className="flex items-center gap-2 text-sm text-gray-400 cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={onlyInstalled}
+            onChange={(e) => setOnlyInstalled(e.target.checked)}
+            className="rounded"
+          />
+          Installed only
+        </label>
+        <button
+          onClick={() => refreshMutation.mutate()}
+          disabled={refreshMutation.isPending}
+          className="px-3 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded flex items-center gap-2 text-sm disabled:opacity-50"
+          title="Refresh from GitHub"
+        >
+          <RefreshCw className={`w-4 h-4 ${refreshMutation.isPending ? 'animate-spin' : ''}`} />
+          Refresh
+        </button>
+      </div>
+
+      {isLoading ? (
+        <div className="flex justify-center py-12">
+          <Loader2 className="w-8 h-8 animate-spin text-teal-500" />
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {filtered.map((plugin) => {
+            const installed = installedNames.has(plugin.name)
+            const currentVersion = installedVersions[plugin.name]
+            const hasUpdate = installed && currentVersion !== undefined && currentVersion !== plugin.version
+            const isInstalling =
+              installMutation.isPending &&
+              (installMutation.variables as MarketplaceBrowsePlugin | undefined)?.name === plugin.name
+
+            return (
+              <div
+                key={plugin.name}
+                className="flex items-start gap-4 p-4 bg-gray-800 rounded-lg border border-gray-700"
+              >
+                <Package className="w-5 h-5 text-teal-500 shrink-0 mt-0.5" />
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <span className="font-semibold text-white">{plugin.display_name}</span>
+                    <span className="text-xs text-gray-400">v{plugin.version}</span>
+                    {plugin.is_official ? (
+                      <span className="flex items-center gap-1 text-xs bg-green-600/20 text-green-400 px-2 py-0.5 rounded-full">
+                        <ShieldCheck className="w-3 h-3" /> Official
+                      </span>
+                    ) : (
+                      <span className="text-xs bg-gray-700 text-gray-400 px-2 py-0.5 rounded-full">
+                        Community
+                      </span>
+                    )}
+                    {hasUpdate && (
+                      <span className="text-xs bg-yellow-600/20 text-yellow-400 px-2 py-0.5 rounded-full">
+                        Update → v{plugin.version}
+                      </span>
+                    )}
+                  </div>
+                  <p className="text-sm text-gray-400 mt-1 truncate">{plugin.description}</p>
+                  <p className="text-xs text-gray-500 mt-0.5">by {plugin.author}</p>
+                </div>
+                <div className="flex items-center gap-2 shrink-0">
+                  <a
+                    href={plugin.github_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="p-1.5 text-gray-400 hover:text-white rounded"
+                    title="View on GitHub"
+                  >
+                    <ExternalLink className="w-4 h-4" />
+                  </a>
+                  {installed ? (
+                    <button
+                      onClick={() => void handleUninstall(plugin.name, plugin.display_name)}
+                      className="px-3 py-1.5 text-sm bg-red-500/20 hover:bg-red-500/30 text-red-400 rounded flex items-center gap-1.5"
+                    >
+                      <Trash2 className="w-4 h-4" />
+                      Remove
+                    </button>
+                  ) : (
+                    <button
+                      onClick={() => handleInstallRequest(plugin)}
+                      disabled={isInstalling}
+                      className="px-3 py-1.5 text-sm bg-teal-600 hover:bg-teal-500 text-white rounded flex items-center gap-1.5 disabled:opacity-50"
+                    >
+                      {isInstalling ? (
+                        <Loader2 className="w-4 h-4 animate-spin" />
+                      ) : (
+                        <Download className="w-4 h-4" />
+                      )}
+                      Install
+                    </button>
+                  )}
+                </div>
+              </div>
+            )
+          })}
+          {filtered.length === 0 && (
+            <div className="text-center py-12 text-gray-400">
+              <Package className="w-10 h-10 mx-auto mb-3 opacity-40" />
+              <p>No plugins found.</p>
+            </div>
+          )}
+        </div>
+      )}
+
+      {pendingInstall !== null && (
+        <CapabilityWarningModal
+          plugin={pendingInstall}
+          onConfirm={() => void doInstall(pendingInstall)}
+          onCancel={() => setPendingInstall(null)}
+        />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/Settings/providers/MarketplaceTab.tsx
+++ b/frontend/src/pages/Settings/providers/MarketplaceTab.tsx
@@ -149,15 +149,17 @@ export function MarketplaceTab() {
                   <p className="text-xs text-gray-500 mt-0.5">by {plugin.author}</p>
                 </div>
                 <div className="flex items-center gap-2 shrink-0">
-                  <a
-                    href={plugin.github_url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="p-1.5 text-gray-400 hover:text-white rounded"
-                    title="View on GitHub"
-                  >
-                    <ExternalLink className="w-4 h-4" />
-                  </a>
+                  {plugin.github_url.startsWith('https://') && (
+                    <a
+                      href={plugin.github_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="p-1.5 text-gray-400 hover:text-white rounded"
+                      title="View on GitHub"
+                    >
+                      <ExternalLink className="w-4 h-4" />
+                    </a>
+                  )}
                   {installed ? (
                     <button
                       onClick={() => void handleUninstall(plugin.name, plugin.display_name)}

--- a/frontend/src/test/MarketplaceTab.test.tsx
+++ b/frontend/src/test/MarketplaceTab.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * MarketplaceTab.test.tsx — Tests for plugin marketplace rendering,
+ * capability warning modal, and search filtering.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MarketplaceTab } from '@/pages/Settings/providers/MarketplaceTab'
+
+const mockPlugin = {
+  name: 'test-provider',
+  display_name: 'Test Provider',
+  author: 'testuser',
+  version: '1.0.0',
+  description: 'A test provider',
+  github_url: 'https://github.com/testuser/test-provider',
+  zip_url: 'https://github.com/testuser/test-provider/releases/download/v1.0.0/plugin.zip',
+  sha256: 'abc123',
+  capabilities: ['network'],
+  min_sublarr_version: '0.22.0',
+  is_official: false,
+}
+
+const mockRiskyPlugin = {
+  ...mockPlugin,
+  name: 'risky-provider',
+  display_name: 'Risky Provider',
+  capabilities: ['network', 'filesystem'],
+}
+
+vi.mock('@/hooks/useApi', () => ({
+  useMarketplaceBrowse: () => ({
+    data: { plugins: [mockPlugin, mockRiskyPlugin] },
+    isLoading: false,
+  }),
+  useInstalledPlugins: () => ({ data: { installed: [] } }),
+  useInstallBrowsePlugin: () => ({
+    mutateAsync: vi.fn().mockResolvedValue({}),
+    isPending: false,
+    variables: null,
+  }),
+  useUninstallBrowsePlugin: () => ({
+    mutateAsync: vi.fn().mockResolvedValue({}),
+    isPending: false,
+  }),
+  useRefreshMarketplaceBrowse: () => ({ mutate: vi.fn(), isPending: false }),
+}))
+
+vi.mock('@/components/shared/Toast', () => ({
+  toast: vi.fn(),
+}))
+
+function renderWithQuery(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>)
+}
+
+describe('MarketplaceTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders plugin cards', () => {
+    renderWithQuery(<MarketplaceTab />)
+    expect(screen.getByText('Test Provider')).toBeInTheDocument()
+    expect(screen.getByText('Risky Provider')).toBeInTheDocument()
+  })
+
+  it('shows Community badge for non-official plugins', () => {
+    renderWithQuery(<MarketplaceTab />)
+    const badges = screen.getAllByText('Community')
+    expect(badges.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('shows capability warning modal for risky community plugin', async () => {
+    renderWithQuery(<MarketplaceTab />)
+    const installButtons = screen.getAllByText('Install')
+    // Risky plugin is second card
+    fireEvent.click(installButtons[1])
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+      expect(screen.getByText(/Elevated Permissions/i)).toBeInTheDocument()
+    })
+  })
+
+  it('does NOT show capability warning for safe (network-only) plugin', () => {
+    renderWithQuery(<MarketplaceTab />)
+    const installButtons = screen.getAllByText('Install')
+    // Safe plugin is first — network-only, no dialog expected
+    fireEvent.click(installButtons[0])
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('filters plugins by search text', () => {
+    renderWithQuery(<MarketplaceTab />)
+    const searchInput = screen.getByPlaceholderText('Search plugins...')
+    fireEvent.change(searchInput, { target: { value: 'risky' } })
+    expect(screen.queryByText('Test Provider')).not.toBeInTheDocument()
+    expect(screen.getByText('Risky Provider')).toBeInTheDocument()
+  })
+})

--- a/official-registry.json
+++ b/official-registry.json
@@ -1,0 +1,4 @@
+{
+  "_comment": "Curated list of official Sublarr provider plugins. Names must match the manifest.json 'name' field of the plugin repo.",
+  "official_plugins": []
+}


### PR DESCRIPTION
## Summary

- **GitHub Plugin Registry** — discovers community providers via `topic:sublarr-provider` GitHub search; caches results in new `marketplace_cache` DB table (1h TTL); supports `SUBLARR_GITHUB_TOKEN` for higher rate limits
- **SHA256 Integrity + SSRF Protection** — all plugin zip installs verify SHA256 hash; `zip_url` must be HTTPS; path traversal guards (`is_safe_path`) on all install/uninstall file operations
- **Official / Community Badges** — curated `official-registry.json` at repo root marks trusted providers; community plugins with `filesystem`/`subprocess` capabilities trigger a confirmation modal before install
- **Settings → Providers → Marketplace Tab** — new tab with search, refresh, install/remove buttons, version update badges; replaces standalone Plugins page
- **DB persistence** — `installed_plugins` table tracks what's installed; hot-reload after install/uninstall without restart

## What's already in the codebase (not new)

`backend/providers/plugins/` (PluginManager, loader, watcher) and `backend/routes/plugins.py` were pre-existing. This PR completes the marketplace layer on top.

## Test Plan

- [ ] Backend: `python -m pytest tests/test_marketplace_db.py tests/test_github_registry.py tests/test_marketplace_service.py tests/test_marketplace_routes.py -v`
- [ ] Frontend: `npx tsc --noEmit && npm run lint`
- [ ] Full suite: 400 tests passing (6 pre-existing Windows permission errors in test_server.py)
- [ ] Manual: Settings → Providers → Marketplace tab visible and renders empty state
- [ ] Manual: `POST /api/v1/marketplace/refresh` returns plugins list
- [ ] Manual: Install attempt with empty sha256 returns 400
- [ ] Manual: Install attempt with non-HTTPS zip_url returns 500 with SSRF guard message