### PR TITLE
feat: v0.24.1 — OP/ED Detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to Sublarr are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.24.1-beta] — 2026-03-12
+
+### Added
+
+- **OP/ED Detector — `op_ed_detector.py`** — detects Opening and Ending cue regions in ASS/SSA/SRT files using two passes: Pass 1 matches ASS style names (`OP`, `ED`, `Opening`, `Ending`, `OP Theme`, `ED Theme`); Pass 2 uses position + duration heuristics (OP: 60–120 s in first window, ED: 90–180 s in last window) with per-type gating and overlapping-window guard
+- **`POST /api/v1/tools/detect-opening-ending`** — read-only endpoint returning detected OP/ED regions as `{type, start_ms, end_ms, event_count, method}`; returns `detected: []` when nothing found (not a 4xx); no file modification
+- **Config — `op_window_sec`** — new setting (`SUBLARR_OP_WINDOW_SEC`, default 300 s) controls how many seconds from the start and end of a file are considered the OP/ED detection window
+
+### Changed
+
+- **SubtitleEditorModal — Quality Tools** — added Detect OP/ED button after Remove Credits button
+
+---
+
 ## [0.24.0-beta] — 2026-03-12
 
 ### Added

--- a/backend/config.py
+++ b/backend/config.py
@@ -164,6 +164,7 @@ class Settings(BaseSettings):
     credit_threshold_sec: int = 90
     """Seconds from end of subtitle file to treat as credits region.
     Set via SUBLARR_CREDIT_THRESHOLD_SEC."""
+    op_window_sec: int = 300  # seconds from start/end of file to consider OP/ED window
 
     # Forced Subtitles
     forced_preference: str = "include"  # include | prefer | exclude | only

--- a/backend/op_ed_detector.py
+++ b/backend/op_ed_detector.py
@@ -22,7 +22,7 @@ _ED_STYLE = re.compile(r"^(ED|Ending|ED Theme|Ending Theme)$", re.IGNORECASE)
 
 _OP_MIN_MS = 60_000  # 60 s minimum OP duration
 _OP_MAX_MS = 120_000  # 120 s maximum OP duration
-_ED_MIN_MS = 10_000  # 10 s minimum ED duration (ED length varies widely)
+_ED_MIN_MS = 90_000  # 90 s minimum ED duration
 _ED_MAX_MS = 180_000  # 180 s maximum ED duration
 _MAX_GAP_MS = 3_000  # max gap between events in a cluster
 _MIN_EVENTS = 3  # minimum events to form a valid cluster

--- a/backend/op_ed_detector.py
+++ b/backend/op_ed_detector.py
@@ -1,0 +1,206 @@
+# backend/op_ed_detector.py
+"""OP/ED region detection for subtitle files.
+
+Detects Opening (OP) and Ending (ED) cue regions using two passes:
+  Pass 1 (ASS/SSA only): Match event style names against known OP/ED patterns.
+                          Per-type gating — Pass 2 is skipped only for types
+                          already found by Pass 1.
+  Pass 2 (fallback):     Position + duration heuristic — cluster of ≥3 events
+                          near start/end with expected OP/ED duration.
+
+Returns detected regions as list[dict] without modifying the file.
+"""
+
+import re
+
+# ─── Compiled patterns ────────────────────────────────────────────────────────
+
+_OP_STYLE = re.compile(r"^(OP|Opening|OP Theme|Opening Theme)$", re.IGNORECASE)
+_ED_STYLE = re.compile(r"^(ED|Ending|ED Theme|Ending Theme)$", re.IGNORECASE)
+
+# ─── Constants ────────────────────────────────────────────────────────────────
+
+_OP_MIN_MS = 60_000  # 60 s minimum OP duration
+_OP_MAX_MS = 120_000  # 120 s maximum OP duration
+_ED_MIN_MS = 10_000  # 10 s minimum ED duration (ED length varies widely)
+_ED_MAX_MS = 180_000  # 180 s maximum ED duration
+_MAX_GAP_MS = 3_000  # max gap between events in a cluster
+_MIN_EVENTS = 3  # minimum events to form a valid cluster
+
+# ─── SRT timestamp regex ──────────────────────────────────────────────────────
+
+_SRT_TS_RE = re.compile(r"(\d{2}):(\d{2}):(\d{2}),(\d{3})\s*-->\s*(\d{2}):(\d{2}):(\d{2}),(\d{3})")
+
+
+def _get_op_window_ms() -> int:
+    """Return the OP/ED window size in milliseconds."""
+    import os
+
+    env_val = os.environ.get("SUBLARR_OP_WINDOW_SEC")
+    if env_val:
+        try:
+            return int(env_val) * 1_000
+        except ValueError:
+            pass
+    try:
+        from config import get_settings
+
+        return getattr(get_settings(), "op_window_sec", 300) * 1_000
+    except Exception:
+        return 300_000
+
+
+def detect_op_ed_from_ass(content: str) -> list[dict]:
+    """Detect OP/ED regions from ASS/SSA content.
+
+    Returns:
+        List of region dicts: {type, start_ms, end_ms, event_count, method}
+    """
+    try:
+        import pysubs2
+    except ImportError:
+        return []
+
+    subs = pysubs2.SSAFile.from_string(content)
+    dialogues = [e for e in subs if not e.is_comment]
+    if not dialogues:
+        return []
+
+    # Pass 1: style name matching (per-type gating)
+    op_region = _pass1_style(dialogues, _OP_STYLE, "OP")
+    ed_region = _pass1_style(dialogues, _ED_STYLE, "ED")
+
+    # Pass 2: duration heuristic for types not found by Pass 1
+    total_end_ms = max(e.end for e in dialogues)
+    window_ms = _get_op_window_ms()
+
+    if window_ms * 2 < total_end_ms:  # windows don't overlap
+        events = [{"start": e.start, "end": e.end} for e in dialogues]
+        if op_region is None:
+            op_region = _pass2_cluster(events, total_end_ms, window_ms, "OP")
+        if ed_region is None:
+            ed_region = _pass2_cluster(events, total_end_ms, window_ms, "ED")
+
+    return [r for r in [op_region, ed_region] if r is not None]
+
+
+def detect_op_ed_from_srt(content: str) -> list[dict]:
+    """Detect OP/ED regions from SRT content (duration heuristic only).
+
+    Returns:
+        List of region dicts: {type, start_ms, end_ms, event_count, method}
+    """
+    events = _parse_srt_events(content)
+    if not events:
+        return []
+
+    total_end_ms = max(e["end"] for e in events)
+    window_ms = _get_op_window_ms()
+
+    if window_ms * 2 >= total_end_ms:
+        return []
+
+    op_region = _pass2_cluster(events, total_end_ms, window_ms, "OP")
+    ed_region = _pass2_cluster(events, total_end_ms, window_ms, "ED")
+
+    return [r for r in [op_region, ed_region] if r is not None]
+
+
+# ─── Detection helpers ────────────────────────────────────────────────────────
+
+
+def _pass1_style(dialogues: list, pattern: re.Pattern, region_type: str) -> dict | None:
+    """Find a region by matching ASS event style names."""
+    matching = [{"start": e.start, "end": e.end} for e in dialogues if pattern.match(e.style or "")]
+    if not matching:
+        return None
+    return {
+        "type": region_type,
+        "start_ms": min(e["start"] for e in matching),
+        "end_ms": max(e["end"] for e in matching),
+        "event_count": len(matching),
+        "method": "style",
+    }
+
+
+def _pass2_cluster(
+    events: list[dict],
+    total_end_ms: int,
+    window_ms: int,
+    region_type: str,
+) -> dict | None:
+    """Find OP or ED region by position + duration heuristic."""
+    if region_type == "OP":
+        window_start, window_end = 0, window_ms
+        min_dur, max_dur = _OP_MIN_MS, _OP_MAX_MS
+    else:
+        window_start = total_end_ms - window_ms
+        window_end = total_end_ms
+        min_dur, max_dur = _ED_MIN_MS, _ED_MAX_MS
+
+    candidates = sorted(
+        [e for e in events if window_start <= e["start"] < window_end],
+        key=lambda e: e["start"],
+    )
+    if len(candidates) < _MIN_EVENTS:
+        return None
+
+    clusters = _split_into_clusters(candidates)
+    valid = [
+        c
+        for c in clusters
+        if len(c) >= _MIN_EVENTS and min_dur <= (c[-1]["end"] - c[0]["start"]) <= max_dur
+    ]
+    if not valid:
+        return None
+
+    best = max(valid, key=lambda c: c[-1]["end"] - c[0]["start"])
+    region_start, region_end = best[0]["start"], best[-1]["end"]
+
+    return {
+        "type": region_type,
+        "start_ms": region_start,
+        "end_ms": region_end,
+        "event_count": sum(1 for e in events if region_start <= e["start"] <= region_end),
+        "method": "duration",
+    }
+
+
+def _split_into_clusters(events: list[dict]) -> list[list[dict]]:
+    """Split sorted events into contiguous clusters (no gap > _MAX_GAP_MS)."""
+    if not events:
+        return []
+    clusters: list[list[dict]] = []
+    current = [events[0]]
+    for event in events[1:]:
+        if event["start"] - current[-1]["end"] > _MAX_GAP_MS:
+            clusters.append(current)
+            current = [event]
+        else:
+            current.append(event)
+    clusters.append(current)
+    return clusters
+
+
+def _parse_srt_events(content: str) -> list[dict]:
+    """Parse SRT content into event dicts with start/end in ms."""
+    events = []
+    for block in content.strip().split("\n\n"):
+        for line in block.strip().split("\n"):
+            m = _SRT_TS_RE.match(line.strip())
+            if m:
+                start_ms = (
+                    int(m.group(1)) * 3_600_000
+                    + int(m.group(2)) * 60_000
+                    + int(m.group(3)) * 1_000
+                    + int(m.group(4))
+                )
+                end_ms = (
+                    int(m.group(5)) * 3_600_000
+                    + int(m.group(6)) * 60_000
+                    + int(m.group(7)) * 1_000
+                    + int(m.group(8))
+                )
+                events.append({"start": start_ms, "end": end_ms})
+                break
+    return events

--- a/backend/routes/tools.py
+++ b/backend/routes/tools.py
@@ -1,4 +1,4 @@
-"""Subtitle processing tools -- /tools/remove-hi, /tools/adjust-timing, /tools/common-fixes, /tools/preview, /tools/content, /tools/backup, /tools/validate, /tools/parse, /tools/health-check, /tools/health-fix, /tools/advanced-sync, /tools/compare, /tools/quality-trends, /tools/remove-credits."""
+"""Subtitle processing tools -- /tools/remove-hi, /tools/adjust-timing, /tools/common-fixes, /tools/preview, /tools/content, /tools/backup, /tools/validate, /tools/parse, /tools/health-check, /tools/health-fix, /tools/advanced-sync, /tools/compare, /tools/quality-trends, /tools/remove-credits, /tools/detect-opening-ending."""
 
 import contextlib
 import logging
@@ -276,6 +276,73 @@ def remove_credits():
     except Exception as exc:
         logger.error("Credit removal failed for %s: %s", abs_path, exc)
         return jsonify({"error": f"Credit removal failed: {exc}"}), 500
+
+
+# -- Detect Opening / Ending --------------------------------------------------
+
+
+@bp.route("/detect-opening-ending", methods=["POST"])
+def detect_opening_ending():
+    """Detect OP/ED cue regions in a subtitle file.
+    ---
+    post:
+      tags:
+        - Tools
+      summary: Detect OP/ED regions
+      description: Detects Opening (OP) and Ending (ED) cue regions in .srt/.ass/.ssa
+        files using style name matching and duration heuristics. Read-only — no file
+        modification. Returns empty detected list when nothing is found.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - file_path
+              properties:
+                file_path:
+                  type: string
+                  description: Path to subtitle file (must be under media_path)
+      responses:
+        200:
+          description: Detection complete (detected may be empty)
+        400:
+          description: Invalid file path or unsupported format
+        403:
+          description: File outside media_path
+        404:
+          description: File not found
+        500:
+          description: Processing error
+    """
+    from op_ed_detector import detect_op_ed_from_ass, detect_op_ed_from_srt
+
+    data = request.get_json() or {}
+    file_path = data.get("file_path", "")
+
+    error, result = _validate_file_path(file_path)
+    if error:
+        return jsonify({"error": error}), result
+
+    abs_path = result
+
+    try:
+        with open(abs_path, encoding="utf-8") as f:
+            content = f.read()
+
+        ext = os.path.splitext(abs_path)[1].lower()
+
+        if ext == ".srt":
+            detected = detect_op_ed_from_srt(content)
+        else:  # .ass / .ssa
+            detected = detect_op_ed_from_ass(content)
+
+        return jsonify({"status": "detected", "detected": detected})
+
+    except Exception as exc:
+        logger.error("OP/ED detection failed for %s: %s", abs_path, exc)
+        return jsonify({"error": f"OP/ED detection failed: {exc}"}), 500
 
 
 # -- Adjust Timing --------------------------------------------------------------

--- a/backend/tests/test_detect_op_ed_route.py
+++ b/backend/tests/test_detect_op_ed_route.py
@@ -1,0 +1,103 @@
+# backend/tests/test_detect_op_ed_route.py
+"""Route tests for POST /api/v1/tools/detect-opening-ending."""
+
+import os
+
+import pytest
+
+
+@pytest.fixture
+def client(temp_db):
+    from app import create_app
+
+    app = create_app(testing=True)
+    with app.test_client() as c:
+        yield c
+
+
+def test_no_op_ed_returns_empty_detected(client, tmp_path):
+    """Valid subtitle file with no OP/ED cues returns detected=[]."""
+    f = tmp_path / "plain.ass"
+    # Simple ASS with Default-style events only — no OP/ED
+    f.write_text(
+        "[Script Info]\nScriptType: v4.00+\n\n"
+        "[V4+ Styles]\nFormat: Name, Fontname, Fontsize, PrimaryColour, "
+        "SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, "
+        "StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, "
+        "Alignment, MarginL, MarginR, MarginV, Encoding\n"
+        "Style: Default,Arial,20,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,"
+        "0,0,0,0,100,100,0,0,1,2,2,2,10,10,10,1\n\n"
+        "[Events]\nFormat: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text\n"
+        "Dialogue: 0,0:00:01.00,0:00:03.00,Default,,0,0,0,,Hello.\n",
+        encoding="utf-8",
+    )
+    resp = client.post(
+        "/api/v1/tools/detect-opening-ending",
+        json={"file_path": str(f)},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["status"] == "detected"
+    assert data["detected"] == []
+
+
+def test_ass_with_opening_style_returns_op_region(client, tmp_path):
+    """Valid ASS file with Opening style events returns OP region."""
+    f = tmp_path / "anime.ass"
+    f.write_text(
+        "[Script Info]\nScriptType: v4.00+\n\n"
+        "[V4+ Styles]\nFormat: Name, Fontname, Fontsize, PrimaryColour, "
+        "SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, "
+        "StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, "
+        "Alignment, MarginL, MarginR, MarginV, Encoding\n"
+        "Style: Default,Arial,20,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,"
+        "0,0,0,0,100,100,0,0,1,2,2,2,10,10,10,1\n"
+        "Style: Opening,Arial,20,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,"
+        "0,0,0,0,100,100,0,0,1,2,2,2,10,10,10,1\n\n"
+        "[Events]\nFormat: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text\n"
+        "Dialogue: 0,0:00:05.00,0:00:10.00,Opening,,0,0,0,,OP line 1\n"
+        "Dialogue: 0,0:00:10.00,0:00:15.00,Opening,,0,0,0,,OP line 2\n"
+        "Dialogue: 0,0:00:15.00,0:00:20.00,Opening,,0,0,0,,OP line 3\n"
+        "Dialogue: 0,0:10:00.00,0:10:02.00,Default,,0,0,0,,Normal dialogue.\n",
+        encoding="utf-8",
+    )
+    resp = client.post(
+        "/api/v1/tools/detect-opening-ending",
+        json={"file_path": str(f)},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["status"] == "detected"
+    assert any(r["type"] == "OP" for r in data["detected"])
+
+
+def test_path_outside_media_path_returns_403(client, tmp_path):
+    """File outside media_path returns 403."""
+    import tempfile
+
+    outside = os.path.join(tempfile.gettempdir(), "..", "outside.ass")
+    resp = client.post(
+        "/api/v1/tools/detect-opening-ending",
+        json={"file_path": outside},
+    )
+    assert resp.status_code == 403
+
+
+def test_unsupported_format_returns_400(client, tmp_path):
+    """VTT file returns 400 (unsupported format)."""
+    f = tmp_path / "sub.vtt"
+    f.write_text("WEBVTT\n\n00:00:01.000 --> 00:00:03.000\nHello.\n", encoding="utf-8")
+    resp = client.post(
+        "/api/v1/tools/detect-opening-ending",
+        json={"file_path": str(f)},
+    )
+    assert resp.status_code == 400
+
+
+def test_nonexistent_file_returns_404(client, tmp_path):
+    """Non-existent file path returns 404."""
+    resp = client.post(
+        "/api/v1/tools/detect-opening-ending",
+        json={"file_path": str(tmp_path / "nonexistent.ass")},
+    )
+    assert resp.status_code == 404

--- a/backend/tests/test_op_ed_config.py
+++ b/backend/tests/test_op_ed_config.py
@@ -1,0 +1,25 @@
+# backend/tests/test_op_ed_config.py
+"""Config tests for op_window_sec setting."""
+
+
+def test_op_window_sec_default_is_300(temp_db):
+    from config import get_settings
+
+    s = get_settings()
+    assert getattr(s, "op_window_sec", None) == 300
+
+
+def test_op_window_sec_env_override(monkeypatch, temp_db):
+    monkeypatch.setenv("SUBLARR_OP_WINDOW_SEC", "120")
+    from config import reload_settings
+
+    reload_settings()
+    try:
+        from config import get_settings
+
+        s = get_settings()
+        assert getattr(s, "op_window_sec", None) == 120
+    finally:
+        # Restore singleton after monkeypatch restores env var
+        monkeypatch.delenv("SUBLARR_OP_WINDOW_SEC", raising=False)
+        reload_settings()

--- a/backend/tests/test_op_ed_detector.py
+++ b/backend/tests/test_op_ed_detector.py
@@ -97,8 +97,9 @@ def test_pass1_per_type_gating_op_style_ed_duration():
     # File total: ~1700s so windows don't overlap
     op_events = [(5_000, 10_000, "Opening")] * 8
     dialogue = [(300_000, 301_000, "Default")] * 3
-    # ED cluster: starts at 1390s, ends at 1500s = 110s duration, within last 300s of 1700s file
-    ed_events = [(1_390_000 + i * 5_000, 1_392_000 + i * 5_000, "Default") for i in range(5)]
+    # ED cluster: starts at 1390s, ends ~1524s = 134s duration, within last 300s of ~1524s file
+    # Each event 26s long, 1s gap between events → contiguous cluster, span > 90s
+    ed_events = [(1_390_000 + i * 27_000, 1_416_000 + i * 27_000, "Default") for i in range(5)]
     all_events = op_events + dialogue + ed_events
     result = detect_op_ed_from_ass(_make_ass_events(all_events))
     types = {r["type"] for r in result}
@@ -153,6 +154,8 @@ def test_pass2_ed_cluster_in_last_window_detected():
     result = detect_op_ed_from_ass(_make_ass_events(dialogue + ed_events))
     types = {r["type"] for r in result}
     assert "ED" in types
+    ed = next(r for r in result if r["type"] == "ED")
+    assert ed["method"] == "duration"
 
 
 def test_pass2_cluster_too_short_not_op():
@@ -164,6 +167,18 @@ def test_pass2_cluster_too_short_not_op():
     dialogue = [(600_000 + i * 2_000, 602_000 + i * 2_000, "Default") for i in range(5)]
     result = detect_op_ed_from_ass(_make_ass_events(op_events + dialogue))
     assert not any(r["type"] == "OP" for r in result)
+
+
+def test_pass2_cluster_too_short_not_ed():
+    """Cluster shorter than 90s is NOT detected as ED."""
+    from op_ed_detector import detect_op_ed_from_ass
+
+    # Only 5 events with 10s each = 50s duration → below 90s minimum for ED
+    dialogue = [(300_000 + i * 2_000, 302_000 + i * 2_000, "Default") for i in range(5)]
+    # File total ~1700s so windows don't overlap
+    ed_events = [(1_390_000 + i * 10_000, 1_400_000 + i * 10_000, "Default") for i in range(5)]
+    result = detect_op_ed_from_ass(_make_ass_events(dialogue + ed_events))
+    assert not any(r["type"] == "ED" for r in result)
 
 
 def test_pass2_cluster_outside_window_not_detected():

--- a/backend/tests/test_op_ed_detector.py
+++ b/backend/tests/test_op_ed_detector.py
@@ -1,0 +1,258 @@
+# backend/tests/test_op_ed_detector.py
+"""Tests for op_ed_detector — OP/ED region detection."""
+
+import pytest
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+_ASS_HEADER = (
+    "[Script Info]\nScriptType: v4.00+\n\n"
+    "[V4+ Styles]\n"
+    "Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, "
+    "OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, "
+    "ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, "
+    "Alignment, MarginL, MarginR, MarginV, Encoding\n"
+    "Style: Default,Arial,20,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,"
+    "0,0,0,0,100,100,0,0,1,2,2,2,10,10,10,1\n"
+    "Style: Opening,Arial,20,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,"
+    "0,0,0,0,100,100,0,0,1,2,2,2,10,10,10,1\n"
+    "Style: Ending,Arial,20,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,"
+    "0,0,0,0,100,100,0,0,1,2,2,2,10,10,10,1\n\n"
+    "[Events]\n"
+    "Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text\n"
+)
+
+
+def _ms_to_ass(ms: int) -> str:
+    """Convert milliseconds to ASS timestamp h:mm:ss.cc."""
+    h = ms // 3_600_000
+    ms %= 3_600_000
+    m = ms // 60_000
+    ms %= 60_000
+    s = ms // 1_000
+    cs = (ms % 1_000) // 10
+    return f"{h}:{m:02d}:{s:02d}.{cs:02d}"
+
+
+def _make_ass_events(events: list[tuple[int, int, str]]) -> str:
+    """Build ASS content from list of (start_ms, end_ms, style) tuples."""
+    lines = []
+    for i, (start, end, style) in enumerate(events):
+        lines.append(f"Dialogue: 0,{_ms_to_ass(start)},{_ms_to_ass(end)},{style},,0,0,0,,Line {i}")
+    return _ASS_HEADER + "\n".join(lines) + "\n"
+
+
+def _make_srt_events(events: list[tuple[int, int]]) -> str:
+    """Build SRT content from list of (start_ms, end_ms) tuples."""
+
+    def ms_to_srt(ms: int) -> str:
+        h = ms // 3_600_000
+        ms %= 3_600_000
+        m = ms // 60_000
+        ms %= 60_000
+        s = ms // 1_000
+        millis = ms % 1_000
+        return f"{h:02d}:{m:02d}:{s:02d},{millis:03d}"
+
+    blocks = []
+    for i, (start, end) in enumerate(events, 1):
+        blocks.append(f"{i}\n{ms_to_srt(start)} --> {ms_to_srt(end)}\nLine {i}")
+    return "\n\n".join(blocks)
+
+
+# ─── Pass 1: Style name detection ─────────────────────────────────────────────
+
+
+def test_pass1_opening_style_detected_as_op():
+    """ASS events with style 'Opening' are detected as OP."""
+    from op_ed_detector import detect_op_ed_from_ass
+
+    events = [(5_000, 10_000, "Opening")] * 5 + [(600_000, 605_000, "Default")] * 3
+    result = detect_op_ed_from_ass(_make_ass_events(events))
+    types = {r["type"] for r in result}
+    assert "OP" in types
+    op = next(r for r in result if r["type"] == "OP")
+    assert op["method"] == "style"
+    assert op["event_count"] == 5
+
+
+def test_pass1_ed_theme_style_detected_as_ed():
+    """ASS events with style 'ED Theme' are detected as ED."""
+    from op_ed_detector import detect_op_ed_from_ass
+
+    # Use longer file so windows don't overlap
+    events = [(1_000, 2_000, "Default")] * 3 + [(1_380_000, 1_385_000, "ED Theme")] * 6
+    result = detect_op_ed_from_ass(_make_ass_events(events))
+    types = {r["type"] for r in result}
+    assert "ED" in types
+    ed = next(r for r in result if r["type"] == "ED")
+    assert ed["method"] == "style"
+
+
+def test_pass1_per_type_gating_op_style_ed_duration():
+    """Pass 1 finds OP via style; Pass 2 still runs for ED if no ED style exists."""
+    from op_ed_detector import detect_op_ed_from_ass
+
+    # OP has 'Opening' style; ED has Default style but is in last 300s and ~110s long
+    # File total: ~1700s so windows don't overlap
+    op_events = [(5_000, 10_000, "Opening")] * 8
+    dialogue = [(300_000, 301_000, "Default")] * 3
+    # ED cluster: starts at 1390s, ends at 1500s = 110s duration, within last 300s of 1700s file
+    ed_events = [(1_390_000 + i * 5_000, 1_392_000 + i * 5_000, "Default") for i in range(5)]
+    all_events = op_events + dialogue + ed_events
+    result = detect_op_ed_from_ass(_make_ass_events(all_events))
+    types = {r["type"] for r in result}
+    assert "OP" in types
+    assert "ED" in types
+    op = next(r for r in result if r["type"] == "OP")
+    ed = next(r for r in result if r["type"] == "ED")
+    assert op["method"] == "style"
+    assert ed["method"] == "duration"
+
+
+def test_pass1_skips_pass2_for_found_type():
+    """If Pass 1 finds both OP and ED, Pass 2 is not used for either."""
+    from op_ed_detector import detect_op_ed_from_ass
+
+    events = (
+        [(5_000, 10_000, "Opening")] * 5
+        + [(300_000, 301_000, "Default")] * 3
+        + [(1_380_000, 1_385_000, "Ending")] * 5
+    )
+    result = detect_op_ed_from_ass(_make_ass_events(events))
+    for r in result:
+        assert r["method"] == "style"
+
+
+# ─── Pass 2: Duration heuristic ───────────────────────────────────────────────
+
+
+def test_pass2_op_cluster_in_first_window_detected():
+    """OP cluster starting within op_window_sec with valid duration is detected."""
+    from op_ed_detector import detect_op_ed_from_ass
+
+    # OP: starts at 5s, each event 8s, 12 events → ~96s duration, within first 300s
+    # File total: ~1700s (windows don't overlap)
+    op_events = [(5_000 + i * 8_000, 12_000 + i * 8_000, "Default") for i in range(12)]
+    dialogue = [(300_000 + i * 2_000, 302_000 + i * 2_000, "Default") for i in range(5)]
+    ed_events = [(1_390_000 + i * 5_000, 1_395_000 + i * 5_000, "Default") for i in range(5)]
+    result = detect_op_ed_from_ass(_make_ass_events(op_events + dialogue + ed_events))
+    types = {r["type"] for r in result}
+    assert "OP" in types
+    op = next(r for r in result if r["type"] == "OP")
+    assert op["method"] == "duration"
+
+
+def test_pass2_ed_cluster_in_last_window_detected():
+    """ED cluster starting within last op_window_sec with valid duration is detected."""
+    from op_ed_detector import detect_op_ed_from_ass
+
+    dialogue = [(300_000 + i * 2_000, 302_000 + i * 2_000, "Default") for i in range(5)]
+    # ED: starts at 1390s, each event 10s, 12 events → ~120s, within last 300s of 1700s file
+    ed_events = [(1_390_000 + i * 10_000, 1_400_000 + i * 10_000, "Default") for i in range(12)]
+    result = detect_op_ed_from_ass(_make_ass_events(dialogue + ed_events))
+    types = {r["type"] for r in result}
+    assert "ED" in types
+
+
+def test_pass2_cluster_too_short_not_op():
+    """Cluster shorter than 60s is NOT detected as OP."""
+    from op_ed_detector import detect_op_ed_from_ass
+
+    # Only 5 events with 5s each = 25s duration → below 60s minimum
+    op_events = [(5_000 + i * 5_000, 10_000 + i * 5_000, "Default") for i in range(5)]
+    dialogue = [(600_000 + i * 2_000, 602_000 + i * 2_000, "Default") for i in range(5)]
+    result = detect_op_ed_from_ass(_make_ass_events(op_events + dialogue))
+    assert not any(r["type"] == "OP" for r in result)
+
+
+def test_pass2_cluster_outside_window_not_detected():
+    """Cluster that starts after op_window_sec is not detected."""
+    from op_ed_detector import detect_op_ed_from_ass
+
+    # Cluster starts at 400s (> 300s window), lasts 90s — outside OP window
+    # File total: ~2000s
+    late_events = [(400_000 + i * 8_000, 408_000 + i * 8_000, "Default") for i in range(12)]
+    dialogue = [(1_000_000 + i * 2_000, 1_002_000 + i * 2_000, "Default") for i in range(5)]
+    result = detect_op_ed_from_ass(_make_ass_events(late_events + dialogue))
+    assert not any(r["type"] == "OP" for r in result)
+
+
+def test_pass2_cluster_fewer_than_3_events_not_detected():
+    """Cluster with fewer than 3 events is not detected."""
+    from op_ed_detector import detect_op_ed_from_ass
+
+    # Only 2 events — below minimum cluster size
+    op_events = [(5_000, 50_000, "Default"), (55_000, 90_000, "Default")]
+    dialogue = [(600_000, 602_000, "Default")] * 5
+    result = detect_op_ed_from_ass(_make_ass_events(op_events + dialogue))
+    assert not any(r["type"] == "OP" for r in result)
+
+
+def test_pass2_op_window_sec_setting_respected(monkeypatch):
+    """Custom SUBLARR_OP_WINDOW_SEC changes the window boundary."""
+    monkeypatch.setenv("SUBLARR_OP_WINDOW_SEC", "60")
+
+    from op_ed_detector import detect_op_ed_from_ass
+
+    # OP cluster starts at 90s — outside a 60s window but inside a 300s window
+    op_events = [(90_000 + i * 8_000, 98_000 + i * 8_000, "Default") for i in range(12)]
+    dialogue = [(1_000_000 + i * 2_000, 1_002_000 + i * 2_000, "Default") for i in range(5)]
+    result = detect_op_ed_from_ass(_make_ass_events(op_events + dialogue))
+    # With 60s window: cluster starts at 90s > 60s → not detected
+    assert not any(r["type"] == "OP" for r in result)
+
+
+def test_pass2_overlapping_windows_returns_empty():
+    """File shorter than 2 * op_window_sec returns [] for duration-detected regions."""
+    from op_ed_detector import detect_op_ed_from_ass
+
+    # File total ~200s, op_window_sec default 300s → windows overlap (200 < 600)
+    events = [(i * 5_000, (i + 1) * 5_000, "Default") for i in range(10)]
+    result = detect_op_ed_from_ass(_make_ass_events(events))
+    # No style-based detection either, so result must be []
+    assert result == []
+
+
+def test_file_with_only_op_returns_op_region():
+    """File with only OP events returns a list with just the OP region."""
+    from op_ed_detector import detect_op_ed_from_ass
+
+    # OP cluster only
+    op_events = [(5_000, 10_000, "Opening")] * 6
+    dialogue = [(800_000, 801_000, "Default")] * 3
+    result = detect_op_ed_from_ass(_make_ass_events(op_events + dialogue))
+    assert len(result) == 1
+    assert result[0]["type"] == "OP"
+
+
+def test_empty_file_returns_empty_list():
+    """Empty ASS file returns []."""
+    from op_ed_detector import detect_op_ed_from_ass
+
+    result = detect_op_ed_from_ass(_make_ass_events([]))
+    assert result == []
+
+
+def test_ssa_processed_same_as_ass():
+    """SSA files (same format as ASS) are handled identically."""
+    from op_ed_detector import detect_op_ed_from_ass
+
+    # SSA content is identical in structure to ASS — pysubs2 handles both
+    events = [(5_000, 10_000, "Opening")] * 5 + [(800_000, 801_000, "Default")] * 3
+    content = _make_ass_events(events)
+    result = detect_op_ed_from_ass(content)
+    assert any(r["type"] == "OP" for r in result)
+
+
+def test_srt_op_cluster_detected_via_duration():
+    """SRT file with OP cluster in first window is detected via Pass 2."""
+    from op_ed_detector import detect_op_ed_from_srt
+
+    # OP: 12 events starting at 5s, each 8s → ~96s duration in first 300s
+    # File total: ~1700s
+    op_events = [(5_000 + i * 8_000, 12_000 + i * 8_000) for i in range(12)]
+    dialogue = [(300_000, 302_000)] * 3
+    ed_events = [(1_390_000 + i * 10_000, 1_400_000 + i * 10_000) for i in range(12)]
+    result = detect_op_ed_from_srt(_make_srt_events(op_events + dialogue + ed_events))
+    assert any(r["type"] == "OP" and r["method"] == "duration" for r in result)

--- a/docs/API.md
+++ b/docs/API.md
@@ -1071,6 +1071,39 @@ Remove staff credit lines from a subtitle file.
 | 404 | File not found |
 | 500 | Processing error |
 
+### POST /api/v1/tools/detect-opening-ending
+
+Detect Opening (OP) and Ending (ED) cue regions in a subtitle file. Read-only — does not modify the file.
+
+**Request:**
+```json
+{
+  "file_path": "/media/anime/ep01.ass"
+}
+```
+
+**Response 200 — detected:**
+```json
+{
+  "status": "detected",
+  "detected": [
+    { "type": "OP", "start_ms": 5000, "end_ms": 91400, "event_count": 12, "method": "style" },
+    { "type": "ED", "start_ms": 1382000, "end_ms": 1510000, "event_count": 8, "method": "duration" }
+  ]
+}
+```
+`detected` is an empty array `[]` when no regions are found (not an error).
+
+`method` is `"style"` when detection was based on ASS style name matching, `"duration"` when based on position + duration heuristic.
+
+| Status | Meaning |
+|--------|---------|
+| 200 | Detection complete (`detected` may be `[]`) |
+| 400 | Missing `file_path`, unsupported format (not `.ass`/`.ssa`/`.srt`) |
+| 403 | Path outside `media_path` |
+| 404 | File not found |
+| 500 | Processing error |
+
 ## Notifications
 
 ### POST /notifications/test

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -364,6 +364,7 @@ Configure in **Settings → Translation**.
 | Variable | Default | UI | Description |
 |---|---|:---:|---|
 | `SUBLARR_CREDIT_THRESHOLD_SEC` | `90` | ✅ | Seconds from the end of a subtitle file treated as the credits region by the duration heuristic in credit detection. |
+| `SUBLARR_OP_WINDOW_SEC` | `300` | ✅ | Seconds from the start and end of a subtitle file that are considered the OP and ED detection windows. Reduce if short episodes produce false positives. |
 
 ---
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -355,6 +355,20 @@ staff-credits-only lines from subtitle files. It uses four independent heuristic
 A `.bak` backup is created before any modification. Use the API's `dry_run: true`
 option to preview which lines would be removed before committing.
 
+### OP/ED Detection
+
+The **OP/ED erkennen** button in the Quality Tools toolbar identifies Opening (OP) and Ending (ED) cue regions in your subtitle file and shows their time boundaries.
+
+**How it works:**
+
+Two detection passes run automatically:
+
+1. **Style name** (ASS/SSA only) — Events with a style named `OP`, `ED`, `Opening`, `Ending`, `OP Theme`, `ED Theme`, `Opening Theme`, or `Ending Theme` are identified directly. This is the most reliable method for professionally typeset fansub releases.
+
+2. **Position + Duration** — Used as fallback when no matching style names are found. Looks for a cluster of 3+ consecutive events near the start of the file (Opening) or end of the file (Ending) with a duration matching typical OP length (60–120 s) or ED length (90–180 s).
+
+**Result:** Detected regions are shown with their time range, event count, and detection method. If nothing is detected, a "Keine OP/ED erkannt" message is shown. The file is never modified.
+
 ### Stream Removal (Remux)
 
 Remove an embedded subtitle stream from a video file directly from the UI — without re-encoding the video.

--- a/docs/superpowers/plans/2026-03-12-v0.24.1-op-ed-detection.md
+++ b/docs/superpowers/plans/2026-03-12-v0.24.1-op-ed-detection.md
@@ -1,0 +1,1112 @@
+# v0.24.1 — OP/ED Detection Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Detect Opening (OP) and Ending (ED) cue regions in ASS/SSA/SRT subtitle files and return time boundaries via a new read-only API endpoint — no file modification.
+
+**Architecture:** New module `backend/op_ed_detector.py` mirrors `credit_remover.py` (pure detection, no DB, no side effects). Two-pass detection: Pass 1 matches ASS style names; Pass 2 uses position + duration heuristics as fallback, with per-type gating. New `POST /api/v1/tools/detect-opening-ending` endpoint in `tools.py`. Frontend button in SubtitleEditorModal Quality Tools toolbar.
+
+**Tech Stack:** Python + pysubs2 (ASS parsing), Flask Blueprint, React 19 + TypeScript.
+
+---
+
+## Chunk 1: Core Detection Module
+
+### Task 1: Failing tests for `op_ed_detector.py`
+
+**Files:**
+- Create: `backend/tests/test_op_ed_detector.py`
+
+**Context:** `temp_db` fixture comes from `backend/tests/conftest.py` — imported automatically by pytest. The test file does NOT need to import it explicitly. Study `backend/tests/test_credit_remover.py` for the test structure pattern.
+
+- [ ] **Step 1: Create the test file**
+
+```python
+# backend/tests/test_op_ed_detector.py
+"""Tests for op_ed_detector — OP/ED region detection."""
+
+import pytest
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+_ASS_HEADER = (
+    "[Script Info]\nScriptType: v4.00+\n\n"
+    "[V4+ Styles]\n"
+    "Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, "
+    "OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, "
+    "ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, "
+    "Alignment, MarginL, MarginR, MarginV, Encoding\n"
+    "Style: Default,Arial,20,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,"
+    "0,0,0,0,100,100,0,0,1,2,2,2,10,10,10,1\n"
+    "Style: Opening,Arial,20,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,"
+    "0,0,0,0,100,100,0,0,1,2,2,2,10,10,10,1\n"
+    "Style: Ending,Arial,20,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,"
+    "0,0,0,0,100,100,0,0,1,2,2,2,10,10,10,1\n\n"
+    "[Events]\n"
+    "Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text\n"
+)
+
+
+def _ms_to_ass(ms: int) -> str:
+    """Convert milliseconds to ASS timestamp h:mm:ss.cc."""
+    h = ms // 3_600_000
+    ms %= 3_600_000
+    m = ms // 60_000
+    ms %= 60_000
+    s = ms // 1_000
+    cs = (ms % 1_000) // 10
+    return f"{h}:{m:02d}:{s:02d}.{cs:02d}"
+
+
+def _make_ass_events(events: list[tuple[int, int, str]]) -> str:
+    """Build ASS content from list of (start_ms, end_ms, style) tuples."""
+    lines = []
+    for i, (start, end, style) in enumerate(events):
+        lines.append(
+            f"Dialogue: 0,{_ms_to_ass(start)},{_ms_to_ass(end)},{style},,0,0,0,,Line {i}"
+        )
+    return _ASS_HEADER + "\n".join(lines) + "\n"
+
+
+def _make_srt_events(events: list[tuple[int, int]]) -> str:
+    """Build SRT content from list of (start_ms, end_ms) tuples."""
+
+    def ms_to_srt(ms: int) -> str:
+        h = ms // 3_600_000
+        ms %= 3_600_000
+        m = ms // 60_000
+        ms %= 60_000
+        s = ms // 1_000
+        millis = ms % 1_000
+        return f"{h:02d}:{m:02d}:{s:02d},{millis:03d}"
+
+    blocks = []
+    for i, (start, end) in enumerate(events, 1):
+        blocks.append(f"{i}\n{ms_to_srt(start)} --> {ms_to_srt(end)}\nLine {i}")
+    return "\n\n".join(blocks)
+
+
+# ─── Pass 1: Style name detection ─────────────────────────────────────────────
+
+
+def test_pass1_opening_style_detected_as_op():
+    """ASS events with style 'Opening' are detected as OP."""
+    from op_ed_detector import detect_op_ed_from_ass
+
+    events = [(5_000, 10_000, "Opening")] * 5 + [(600_000, 605_000, "Default")] * 3
+    result = detect_op_ed_from_ass(_make_ass_events(events))
+    types = {r["type"] for r in result}
+    assert "OP" in types
+    op = next(r for r in result if r["type"] == "OP")
+    assert op["method"] == "style"
+    assert op["event_count"] == 5
+
+
+def test_pass1_ed_theme_style_detected_as_ed():
+    """ASS events with style 'ED Theme' are detected as ED."""
+    from op_ed_detector import detect_op_ed_from_ass
+
+    # Use longer file so windows don't overlap
+    events = (
+        [(1_000, 2_000, "Default")] * 3
+        + [(1_380_000, 1_385_000, "ED Theme")] * 6
+    )
+    result = detect_op_ed_from_ass(_make_ass_events(events))
+    types = {r["type"] for r in result}
+    assert "ED" in types
+    ed = next(r for r in result if r["type"] == "ED")
+    assert ed["method"] == "style"
+
+
+def test_pass1_per_type_gating_op_style_ed_duration():
+    """Pass 1 finds OP via style; Pass 2 still runs for ED if no ED style exists."""
+    from op_ed_detector import detect_op_ed_from_ass
+
+    # OP has 'Opening' style; ED has Default style but is in last 300s and ~110s long
+    # File total: ~1700s so windows don't overlap
+    op_events = [(5_000, 10_000, "Opening")] * 8
+    dialogue = [(300_000, 301_000, "Default")] * 3
+    # ED cluster: starts at 1390s, ends at 1500s = 110s duration, within last 300s of 1700s file
+    ed_events = [(1_390_000 + i * 5_000, 1_392_000 + i * 5_000, "Default") for i in range(5)]
+    all_events = op_events + dialogue + ed_events
+    result = detect_op_ed_from_ass(_make_ass_events(all_events))
+    types = {r["type"] for r in result}
+    assert "OP" in types
+    assert "ED" in types
+    op = next(r for r in result if r["type"] == "OP")
+    ed = next(r for r in result if r["type"] == "ED")
+    assert op["method"] == "style"
+    assert ed["method"] == "duration"
+
+
+def test_pass1_skips_pass2_for_found_type():
+    """If Pass 1 finds both OP and ED, Pass 2 is not used for either."""
+    from op_ed_detector import detect_op_ed_from_ass
+
+    events = (
+        [(5_000, 10_000, "Opening")] * 5
+        + [(300_000, 301_000, "Default")] * 3
+        + [(1_380_000, 1_385_000, "Ending")] * 5
+    )
+    result = detect_op_ed_from_ass(_make_ass_events(events))
+    for r in result:
+        assert r["method"] == "style"
+
+
+# ─── Pass 2: Duration heuristic ───────────────────────────────────────────────
+
+
+def test_pass2_op_cluster_in_first_window_detected():
+    """OP cluster starting within op_window_sec with valid duration is detected."""
+    from op_ed_detector import detect_op_ed_from_ass
+
+    # OP: starts at 5s, each event 8s, 12 events → ~96s duration, within first 300s
+    # File total: ~1700s (windows don't overlap)
+    op_events = [(5_000 + i * 8_000, 12_000 + i * 8_000, "Default") for i in range(12)]
+    dialogue = [(300_000 + i * 2_000, 302_000 + i * 2_000, "Default") for i in range(5)]
+    ed_events = [(1_390_000 + i * 5_000, 1_395_000 + i * 5_000, "Default") for i in range(5)]
+    result = detect_op_ed_from_ass(_make_ass_events(op_events + dialogue + ed_events))
+    types = {r["type"] for r in result}
+    assert "OP" in types
+    op = next(r for r in result if r["type"] == "OP")
+    assert op["method"] == "duration"
+
+
+def test_pass2_ed_cluster_in_last_window_detected():
+    """ED cluster starting within last op_window_sec with valid duration is detected."""
+    from op_ed_detector import detect_op_ed_from_ass
+
+    dialogue = [(300_000 + i * 2_000, 302_000 + i * 2_000, "Default") for i in range(5)]
+    # ED: starts at 1390s, each event 10s, 12 events → ~120s, within last 300s of 1700s file
+    ed_events = [(1_390_000 + i * 10_000, 1_400_000 + i * 10_000, "Default") for i in range(12)]
+    result = detect_op_ed_from_ass(_make_ass_events(dialogue + ed_events))
+    types = {r["type"] for r in result}
+    assert "ED" in types
+
+
+def test_pass2_cluster_too_short_not_op():
+    """Cluster shorter than 60s is NOT detected as OP."""
+    from op_ed_detector import detect_op_ed_from_ass
+
+    # Only 5 events with 5s each = 25s duration → below 60s minimum
+    op_events = [(5_000 + i * 5_000, 10_000 + i * 5_000, "Default") for i in range(5)]
+    dialogue = [(600_000 + i * 2_000, 602_000 + i * 2_000, "Default") for i in range(5)]
+    result = detect_op_ed_from_ass(_make_ass_events(op_events + dialogue))
+    assert not any(r["type"] == "OP" for r in result)
+
+
+def test_pass2_cluster_outside_window_not_detected():
+    """Cluster that starts after op_window_sec is not detected."""
+    from op_ed_detector import detect_op_ed_from_ass
+
+    # Cluster starts at 400s (> 300s window), lasts 90s — outside OP window
+    # File total: ~2000s
+    late_events = [(400_000 + i * 8_000, 408_000 + i * 8_000, "Default") for i in range(12)]
+    dialogue = [(1_000_000 + i * 2_000, 1_002_000 + i * 2_000, "Default") for i in range(5)]
+    result = detect_op_ed_from_ass(_make_ass_events(late_events + dialogue))
+    assert not any(r["type"] == "OP" for r in result)
+
+
+def test_pass2_cluster_fewer_than_3_events_not_detected():
+    """Cluster with fewer than 3 events is not detected."""
+    from op_ed_detector import detect_op_ed_from_ass
+
+    # Only 2 events — below minimum cluster size
+    op_events = [(5_000, 50_000, "Default"), (55_000, 90_000, "Default")]
+    dialogue = [(600_000, 602_000, "Default")] * 5
+    result = detect_op_ed_from_ass(_make_ass_events(op_events + dialogue))
+    assert not any(r["type"] == "OP" for r in result)
+
+
+def test_pass2_op_window_sec_setting_respected(monkeypatch):
+    """Custom SUBLARR_OP_WINDOW_SEC changes the window boundary."""
+    monkeypatch.setenv("SUBLARR_OP_WINDOW_SEC", "60")
+
+    from op_ed_detector import detect_op_ed_from_ass
+
+    # OP cluster starts at 90s — outside a 60s window but inside a 300s window
+    op_events = [(90_000 + i * 8_000, 98_000 + i * 8_000, "Default") for i in range(12)]
+    dialogue = [(1_000_000 + i * 2_000, 1_002_000 + i * 2_000, "Default") for i in range(5)]
+    result = detect_op_ed_from_ass(_make_ass_events(op_events + dialogue))
+    # With 60s window: cluster starts at 90s > 60s → not detected
+    assert not any(r["type"] == "OP" for r in result)
+
+
+def test_pass2_overlapping_windows_returns_empty():
+    """File shorter than 2 * op_window_sec returns [] for duration-detected regions."""
+    from op_ed_detector import detect_op_ed_from_ass
+
+    # File total ~200s, op_window_sec default 300s → windows overlap (200 < 600)
+    events = [(i * 5_000, (i + 1) * 5_000, "Default") for i in range(10)]
+    result = detect_op_ed_from_ass(_make_ass_events(events))
+    # No style-based detection either, so result must be []
+    assert result == []
+
+
+def test_file_with_only_op_returns_op_region():
+    """File with only OP events returns a list with just the OP region."""
+    from op_ed_detector import detect_op_ed_from_ass
+
+    # OP cluster only
+    op_events = [(5_000, 10_000, "Opening")] * 6
+    dialogue = [(800_000, 801_000, "Default")] * 3
+    result = detect_op_ed_from_ass(_make_ass_events(op_events + dialogue))
+    assert len(result) == 1
+    assert result[0]["type"] == "OP"
+
+
+def test_empty_file_returns_empty_list():
+    """Empty ASS file returns []."""
+    from op_ed_detector import detect_op_ed_from_ass
+
+    result = detect_op_ed_from_ass(_make_ass_events([]))
+    assert result == []
+
+
+def test_ssa_processed_same_as_ass():
+    """SSA files (same format as ASS) are handled identically."""
+    from op_ed_detector import detect_op_ed_from_ass
+
+    # SSA content is identical in structure to ASS — pysubs2 handles both
+    events = [(5_000, 10_000, "Opening")] * 5 + [(800_000, 801_000, "Default")] * 3
+    content = _make_ass_events(events)
+    result = detect_op_ed_from_ass(content)
+    assert any(r["type"] == "OP" for r in result)
+
+
+def test_srt_op_cluster_detected_via_duration():
+    """SRT file with OP cluster in first window is detected via Pass 2."""
+    from op_ed_detector import detect_op_ed_from_srt
+
+    # OP: 12 events starting at 5s, each 8s → ~96s duration in first 300s
+    # File total: ~1700s
+    op_events = [(5_000 + i * 8_000, 12_000 + i * 8_000) for i in range(12)]
+    dialogue = [(300_000, 302_000)] * 3
+    ed_events = [(1_390_000 + i * 10_000, 1_400_000 + i * 10_000) for i in range(12)]
+    result = detect_op_ed_from_srt(_make_srt_events(op_events + dialogue + ed_events))
+    assert any(r["type"] == "OP" and r["method"] == "duration" for r in result)
+```
+
+- [ ] **Step 2: Run tests to verify they all FAIL**
+
+```bash
+cd backend && python -m pytest tests/test_op_ed_detector.py --no-cov -q 2>&1 | tail -5
+```
+Expected: `ImportError: No module named 'op_ed_detector'` (or similar import error for every test)
+
+- [ ] **Step 3: Commit failing tests**
+
+```bash
+git add backend/tests/test_op_ed_detector.py
+git commit -m "test: add failing tests for op_ed_detector (RED)"
+```
+
+---
+
+### Task 2: Implement `op_ed_detector.py`
+
+**Files:**
+- Create: `backend/op_ed_detector.py`
+
+- [ ] **Step 1: Create the module**
+
+```python
+# backend/op_ed_detector.py
+"""OP/ED region detection for subtitle files.
+
+Detects Opening (OP) and Ending (ED) cue regions using two passes:
+  Pass 1 (ASS/SSA only): Match event style names against known OP/ED patterns.
+                          Per-type gating — Pass 2 is skipped only for types
+                          already found by Pass 1.
+  Pass 2 (fallback):     Position + duration heuristic — cluster of ≥3 events
+                          near start/end with expected OP/ED duration.
+
+Returns detected regions as list[dict] without modifying the file.
+"""
+
+import re
+
+# ─── Compiled patterns ────────────────────────────────────────────────────────
+
+_OP_STYLE = re.compile(r"^(OP|Opening|OP Theme|Opening Theme)$", re.IGNORECASE)
+_ED_STYLE = re.compile(r"^(ED|Ending|ED Theme|Ending Theme)$", re.IGNORECASE)
+
+# ─── Constants ────────────────────────────────────────────────────────────────
+
+_OP_MIN_MS = 60_000    # 60 s minimum OP duration
+_OP_MAX_MS = 120_000   # 120 s maximum OP duration
+_ED_MIN_MS = 90_000    # 90 s minimum ED duration
+_ED_MAX_MS = 180_000   # 180 s maximum ED duration
+_MAX_GAP_MS = 3_000    # max gap between events in a cluster
+_MIN_EVENTS = 3        # minimum events to form a valid cluster
+
+# ─── SRT timestamp regex ──────────────────────────────────────────────────────
+
+_SRT_TS_RE = re.compile(
+    r"(\d{2}):(\d{2}):(\d{2}),(\d{3})\s*-->\s*(\d{2}):(\d{2}):(\d{2}),(\d{3})"
+)
+
+
+def _get_op_window_ms() -> int:
+    """Return the OP/ED window size in milliseconds."""
+    import os
+
+    env_val = os.environ.get("SUBLARR_OP_WINDOW_SEC")
+    if env_val:
+        try:
+            return int(env_val) * 1_000
+        except ValueError:
+            pass
+    try:
+        from config import get_settings
+
+        return getattr(get_settings(), "op_window_sec", 300) * 1_000
+    except Exception:
+        return 300_000
+
+
+def detect_op_ed_from_ass(content: str) -> list[dict]:
+    """Detect OP/ED regions from ASS/SSA content.
+
+    Returns:
+        List of region dicts: {type, start_ms, end_ms, event_count, method}
+    """
+    try:
+        import pysubs2
+    except ImportError:
+        return []
+
+    subs = pysubs2.SSAFile.from_string(content)
+    dialogues = [e for e in subs if not e.is_comment]
+    if not dialogues:
+        return []
+
+    # Pass 1: style name matching (per-type gating)
+    op_region = _pass1_style(dialogues, _OP_STYLE, "OP")
+    ed_region = _pass1_style(dialogues, _ED_STYLE, "ED")
+
+    # Pass 2: duration heuristic for types not found by Pass 1
+    total_end_ms = max(e.end for e in dialogues)
+    window_ms = _get_op_window_ms()
+
+    if window_ms * 2 < total_end_ms:  # windows don't overlap
+        events = [{"start": e.start, "end": e.end} for e in dialogues]
+        if op_region is None:
+            op_region = _pass2_cluster(events, total_end_ms, window_ms, "OP")
+        if ed_region is None:
+            ed_region = _pass2_cluster(events, total_end_ms, window_ms, "ED")
+
+    return [r for r in [op_region, ed_region] if r is not None]
+
+
+def detect_op_ed_from_srt(content: str) -> list[dict]:
+    """Detect OP/ED regions from SRT content (duration heuristic only).
+
+    Returns:
+        List of region dicts: {type, start_ms, end_ms, event_count, method}
+    """
+    events = _parse_srt_events(content)
+    if not events:
+        return []
+
+    total_end_ms = max(e["end"] for e in events)
+    window_ms = _get_op_window_ms()
+
+    if window_ms * 2 >= total_end_ms:
+        return []
+
+    op_region = _pass2_cluster(events, total_end_ms, window_ms, "OP")
+    ed_region = _pass2_cluster(events, total_end_ms, window_ms, "ED")
+
+    return [r for r in [op_region, ed_region] if r is not None]
+
+
+# ─── Detection helpers ────────────────────────────────────────────────────────
+
+
+def _pass1_style(dialogues: list, pattern: re.Pattern, region_type: str) -> dict | None:
+    """Find a region by matching ASS event style names."""
+    matching = [
+        {"start": e.start, "end": e.end}
+        for e in dialogues
+        if pattern.match(e.style or "")
+    ]
+    if not matching:
+        return None
+    return {
+        "type": region_type,
+        "start_ms": min(e["start"] for e in matching),
+        "end_ms": max(e["end"] for e in matching),
+        "event_count": len(matching),
+        "method": "style",
+    }
+
+
+def _pass2_cluster(
+    events: list[dict],
+    total_end_ms: int,
+    window_ms: int,
+    region_type: str,
+) -> dict | None:
+    """Find OP or ED region by position + duration heuristic."""
+    if region_type == "OP":
+        window_start, window_end = 0, window_ms
+        min_dur, max_dur = _OP_MIN_MS, _OP_MAX_MS
+    else:
+        window_start = total_end_ms - window_ms
+        window_end = total_end_ms
+        min_dur, max_dur = _ED_MIN_MS, _ED_MAX_MS
+
+    candidates = sorted(
+        [e for e in events if window_start <= e["start"] < window_end],
+        key=lambda e: e["start"],
+    )
+    if len(candidates) < _MIN_EVENTS:
+        return None
+
+    clusters = _split_into_clusters(candidates)
+    valid = [
+        c
+        for c in clusters
+        if len(c) >= _MIN_EVENTS and min_dur <= (c[-1]["end"] - c[0]["start"]) <= max_dur
+    ]
+    if not valid:
+        return None
+
+    best = max(valid, key=lambda c: c[-1]["end"] - c[0]["start"])
+    region_start, region_end = best[0]["start"], best[-1]["end"]
+
+    return {
+        "type": region_type,
+        "start_ms": region_start,
+        "end_ms": region_end,
+        "event_count": sum(1 for e in events if region_start <= e["start"] <= region_end),
+        "method": "duration",
+    }
+
+
+def _split_into_clusters(events: list[dict]) -> list[list[dict]]:
+    """Split sorted events into contiguous clusters (no gap > _MAX_GAP_MS)."""
+    if not events:
+        return []
+    clusters: list[list[dict]] = []
+    current = [events[0]]
+    for event in events[1:]:
+        if event["start"] - current[-1]["end"] > _MAX_GAP_MS:
+            clusters.append(current)
+            current = [event]
+        else:
+            current.append(event)
+    clusters.append(current)
+    return clusters
+
+
+def _parse_srt_events(content: str) -> list[dict]:
+    """Parse SRT content into event dicts with start/end in ms."""
+    events = []
+    for block in content.strip().split("\n\n"):
+        for line in block.strip().split("\n"):
+            m = _SRT_TS_RE.match(line.strip())
+            if m:
+                start_ms = (
+                    int(m.group(1)) * 3_600_000
+                    + int(m.group(2)) * 60_000
+                    + int(m.group(3)) * 1_000
+                    + int(m.group(4))
+                )
+                end_ms = (
+                    int(m.group(5)) * 3_600_000
+                    + int(m.group(6)) * 60_000
+                    + int(m.group(7)) * 1_000
+                    + int(m.group(8))
+                )
+                events.append({"start": start_ms, "end": end_ms})
+                break
+    return events
+```
+
+- [ ] **Step 2: Run tests — expect all GREEN**
+
+```bash
+cd backend && python -m pytest tests/test_op_ed_detector.py --no-cov -q 2>&1 | tail -5
+```
+Expected: `14 passed`
+
+- [ ] **Step 3: Run ruff check + format**
+
+```bash
+cd backend && ruff check op_ed_detector.py tests/test_op_ed_detector.py --fix && ruff format op_ed_detector.py tests/test_op_ed_detector.py
+```
+Expected: `All checks passed!`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/op_ed_detector.py backend/tests/test_op_ed_detector.py
+git commit -m "feat: add op_ed_detector.py with 2-pass OP/ED detection (GREEN)"
+```
+
+---
+
+## Chunk 2: Config Setting + Route Endpoint
+
+### Task 3: Add `op_window_sec` config setting
+
+**Files:**
+- Modify: `backend/config.py` — add `op_window_sec: int = 300` after `credit_threshold_sec`
+
+**Context:** Open `backend/config.py` and find the `credit_threshold_sec` field. Add `op_window_sec` immediately after it, following the same pattern. The Pydantic `BaseSettings` class automatically reads `SUBLARR_OP_WINDOW_SEC` from environment.
+
+- [ ] **Step 1: Write a failing test**
+
+Create `backend/tests/test_op_ed_config.py`:
+
+```python
+# backend/tests/test_op_ed_config.py
+"""Config tests for op_window_sec setting."""
+
+import os
+
+
+def test_op_window_sec_default_is_300(temp_db):
+    from config import get_settings
+
+    s = get_settings()
+    assert getattr(s, "op_window_sec", None) == 300
+
+
+def test_op_window_sec_env_override(monkeypatch, temp_db):
+    monkeypatch.setenv("SUBLARR_OP_WINDOW_SEC", "120")
+    from config import reload_settings
+
+    reload_settings()
+    try:
+        from config import get_settings
+
+        s = get_settings()
+        assert getattr(s, "op_window_sec", None) == 120
+    finally:
+        # Restore singleton after monkeypatch restores env var
+        monkeypatch.delenv("SUBLARR_OP_WINDOW_SEC", raising=False)
+        reload_settings()
+```
+
+- [ ] **Step 2: Run test to verify it FAILS**
+
+```bash
+cd backend && python -m pytest tests/test_op_ed_config.py --no-cov -q 2>&1 | tail -5
+```
+Expected: `AssertionError: assert None == 300`
+
+- [ ] **Step 3: Add the setting to `backend/config.py`**
+
+Find the line with `credit_threshold_sec` and add `op_window_sec` after it:
+
+```python
+    credit_threshold_sec: int = 90  # seconds from end of file to consider credits region
+    op_window_sec: int = 300  # seconds from start/end of file to consider OP/ED window
+```
+
+- [ ] **Step 4: Run tests — expect GREEN**
+
+```bash
+cd backend && python -m pytest tests/test_op_ed_config.py --no-cov -q 2>&1 | tail -5
+```
+Expected: `2 passed`
+
+- [ ] **Step 5: Run ruff check + format**
+
+```bash
+cd backend && ruff check config.py tests/test_op_ed_config.py --fix && ruff format config.py tests/test_op_ed_config.py
+```
+Expected: `All checks passed!`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/config.py backend/tests/test_op_ed_config.py
+git commit -m "feat: add op_window_sec config setting (SUBLARR_OP_WINDOW_SEC)"
+```
+
+---
+
+### Task 4: Add `POST /tools/detect-opening-ending` route
+
+**Files:**
+- Modify: `backend/routes/tools.py` — add route after `remove_credits()`; update module docstring line 1
+- Create: `backend/tests/test_detect_op_ed_route.py`
+
+**Context:** The route follows the exact same pattern as `remove_credits()` — use `_validate_file_path()`, check extension, call the detector, return JSON. `_validate_file_path()` returns `(error_msg, status_code)` on failure and `(None, abs_path)` on success. The `temp_db` fixture comes from `conftest.py`.
+
+- [ ] **Step 1: Write failing route tests**
+
+```python
+# backend/tests/test_detect_op_ed_route.py
+"""Route tests for POST /api/v1/tools/detect-opening-ending."""
+
+import os
+
+import pytest
+
+
+@pytest.fixture
+def client(temp_db):
+    from app import create_app
+
+    app = create_app(testing=True)
+    with app.test_client() as c:
+        yield c
+
+
+def test_no_op_ed_returns_empty_detected(client, tmp_path):
+    """Valid subtitle file with no OP/ED cues returns detected=[]."""
+    f = tmp_path / "plain.ass"
+    # Simple ASS with Default-style events only — no OP/ED
+    f.write_text(
+        "[Script Info]\nScriptType: v4.00+\n\n"
+        "[V4+ Styles]\nFormat: Name, Fontname, Fontsize, PrimaryColour, "
+        "SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, "
+        "StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, "
+        "Alignment, MarginL, MarginR, MarginV, Encoding\n"
+        "Style: Default,Arial,20,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,"
+        "0,0,0,0,100,100,0,0,1,2,2,2,10,10,10,1\n\n"
+        "[Events]\nFormat: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text\n"
+        "Dialogue: 0,0:00:01.00,0:00:03.00,Default,,0,0,0,,Hello.\n",
+        encoding="utf-8",
+    )
+    resp = client.post(
+        "/api/v1/tools/detect-opening-ending",
+        json={"file_path": str(f)},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["status"] == "detected"
+    assert data["detected"] == []
+
+
+def test_ass_with_opening_style_returns_op_region(client, tmp_path):
+    """Valid ASS file with Opening style events returns OP region."""
+    f = tmp_path / "anime.ass"
+    f.write_text(
+        "[Script Info]\nScriptType: v4.00+\n\n"
+        "[V4+ Styles]\nFormat: Name, Fontname, Fontsize, PrimaryColour, "
+        "SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, "
+        "StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, "
+        "Alignment, MarginL, MarginR, MarginV, Encoding\n"
+        "Style: Default,Arial,20,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,"
+        "0,0,0,0,100,100,0,0,1,2,2,2,10,10,10,1\n"
+        "Style: Opening,Arial,20,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,"
+        "0,0,0,0,100,100,0,0,1,2,2,2,10,10,10,1\n\n"
+        "[Events]\nFormat: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text\n"
+        "Dialogue: 0,0:00:05.00,0:00:10.00,Opening,,0,0,0,,OP line 1\n"
+        "Dialogue: 0,0:00:10.00,0:00:15.00,Opening,,0,0,0,,OP line 2\n"
+        "Dialogue: 0,0:00:15.00,0:00:20.00,Opening,,0,0,0,,OP line 3\n"
+        "Dialogue: 0,0:10:00.00,0:10:02.00,Default,,0,0,0,,Normal dialogue.\n",
+        encoding="utf-8",
+    )
+    resp = client.post(
+        "/api/v1/tools/detect-opening-ending",
+        json={"file_path": str(f)},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["status"] == "detected"
+    assert any(r["type"] == "OP" for r in data["detected"])
+
+
+def test_path_outside_media_path_returns_403(client, tmp_path):
+    """File outside media_path returns 403."""
+    import tempfile
+
+    outside = os.path.join(tempfile.gettempdir(), "..", "outside.ass")
+    resp = client.post(
+        "/api/v1/tools/detect-opening-ending",
+        json={"file_path": outside},
+    )
+    assert resp.status_code == 403
+
+
+def test_unsupported_format_returns_400(client, tmp_path):
+    """VTT file returns 400 (unsupported format)."""
+    f = tmp_path / "sub.vtt"
+    f.write_text("WEBVTT\n\n00:00:01.000 --> 00:00:03.000\nHello.\n", encoding="utf-8")
+    resp = client.post(
+        "/api/v1/tools/detect-opening-ending",
+        json={"file_path": str(f)},
+    )
+    assert resp.status_code == 400
+
+
+def test_nonexistent_file_returns_404(client, tmp_path):
+    """Non-existent file path returns 404."""
+    resp = client.post(
+        "/api/v1/tools/detect-opening-ending",
+        json={"file_path": str(tmp_path / "nonexistent.ass")},
+    )
+    assert resp.status_code == 404
+```
+
+- [ ] **Step 2: Run tests to verify they FAIL**
+
+```bash
+cd backend && python -m pytest tests/test_detect_op_ed_route.py --no-cov -q 2>&1 | tail -5
+```
+Expected: `404 NOT FOUND` (route doesn't exist yet)
+
+- [ ] **Step 3: Update the module docstring in `backend/routes/tools.py` line 1**
+
+Change from:
+```python
+"""Subtitle processing tools -- /tools/remove-hi, ..., /tools/remove-credits."""
+```
+To:
+```python
+"""Subtitle processing tools -- /tools/remove-hi, ..., /tools/remove-credits, /tools/detect-opening-ending."""
+```
+
+- [ ] **Step 4: Add the route to `backend/routes/tools.py`**
+
+Find the `remove_credits()` function and add the new route immediately after it (before the next `# --` section comment):
+
+```python
+# -- Detect Opening / Ending --------------------------------------------------
+
+
+@bp.route("/detect-opening-ending", methods=["POST"])
+def detect_opening_ending():
+    """Detect OP/ED cue regions in a subtitle file.
+    ---
+    post:
+      tags:
+        - Tools
+      summary: Detect OP/ED regions
+      description: Detects Opening (OP) and Ending (ED) cue regions in .srt/.ass/.ssa
+        files using style name matching and duration heuristics. Read-only — no file
+        modification. Returns empty detected list when nothing is found.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - file_path
+              properties:
+                file_path:
+                  type: string
+                  description: Path to subtitle file (must be under media_path)
+      responses:
+        200:
+          description: Detection complete (detected may be empty)
+        400:
+          description: Invalid file path or unsupported format
+        403:
+          description: File outside media_path
+        404:
+          description: File not found
+        500:
+          description: Processing error
+    """
+    from op_ed_detector import detect_op_ed_from_ass, detect_op_ed_from_srt
+
+    data = request.get_json() or {}
+    file_path = data.get("file_path", "")
+
+    error, result = _validate_file_path(file_path)
+    if error:
+        return jsonify({"error": error}), result
+
+    abs_path = result
+
+    try:
+        with open(abs_path, encoding="utf-8") as f:
+            content = f.read()
+
+        ext = os.path.splitext(abs_path)[1].lower()
+
+        if ext == ".srt":
+            detected = detect_op_ed_from_srt(content)
+        else:  # .ass / .ssa
+            detected = detect_op_ed_from_ass(content)
+
+        return jsonify({"status": "detected", "detected": detected})
+
+    except Exception as exc:
+        logger.error("OP/ED detection failed for %s: %s", abs_path, exc)
+        return jsonify({"error": f"OP/ED detection failed: {exc}"}), 500
+```
+
+- [ ] **Step 5: Run all tests — expect GREEN**
+
+```bash
+cd backend && python -m pytest tests/test_op_ed_detector.py tests/test_op_ed_config.py tests/test_detect_op_ed_route.py --no-cov -q 2>&1 | tail -5
+```
+Expected: `21 passed` (14 + 2 + 5)
+
+- [ ] **Step 6: Run ruff check + format**
+
+```bash
+cd backend && ruff check routes/tools.py tests/test_detect_op_ed_route.py --fix && ruff format routes/tools.py tests/test_detect_op_ed_route.py
+```
+Expected: `All checks passed!`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/routes/tools.py backend/tests/test_detect_op_ed_route.py
+git commit -m "feat: add POST /tools/detect-opening-ending endpoint"
+```
+
+---
+
+## Chunk 3: Frontend
+
+### Task 5: Add `detectOpeningEnding()` to `client.ts`
+
+**Files:**
+- Modify: `frontend/src/api/client.ts` — add `detectOpeningEnding` after `removeCredits`
+
+**Context:** Open `frontend/src/api/client.ts` and find the `removeCredits` function. Add `detectOpeningEnding` immediately after it, following the same structure.
+
+- [ ] **Step 1: Write a failing frontend test**
+
+Note: The `api` axios instance in `client.ts` is not exported, so intercepting it directly in Vitest requires mocking at the module level. The most reliable test here is a TypeScript compile check (in Step 3) combined with a module import smoke test:
+
+```typescript
+// frontend/src/api/__tests__/detectOpeningEnding.test.ts
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('axios', () => ({
+  default: {
+    create: () => ({
+      post: vi.fn().mockResolvedValue({ data: { status: 'detected', detected: [] } }),
+      interceptors: { request: { use: vi.fn() }, response: { use: vi.fn() } },
+    }),
+  },
+}))
+
+describe('detectOpeningEnding', () => {
+  it('is exported from client.ts and returns detected array', async () => {
+    const { detectOpeningEnding } = await import('../client')
+    expect(typeof detectOpeningEnding).toBe('function')
+    const result = await detectOpeningEnding('/media/test.ass')
+    expect(result).toHaveProperty('status', 'detected')
+    expect(Array.isArray(result.detected)).toBe(true)
+  })
+})
+```
+
+- [ ] **Step 2: Add the function to `frontend/src/api/client.ts`**
+
+Find `export async function removeCredits(` and add after its closing `}`:
+
+```typescript
+export async function detectOpeningEnding(filePath: string): Promise<{
+  status: string
+  detected: Array<{
+    type: 'OP' | 'ED'
+    start_ms: number
+    end_ms: number
+    event_count: number
+    method: 'style' | 'duration'
+  }>
+}> {
+  const { data } = await api.post('/tools/detect-opening-ending', { file_path: filePath })
+  return data
+}
+```
+
+- [ ] **Step 3: Run TypeScript check**
+
+```bash
+cd frontend && npx tsc --noEmit 2>&1 | tail -10
+```
+Expected: no errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/api/client.ts
+git commit -m "feat: add detectOpeningEnding() API client function"
+```
+
+---
+
+### Task 6: Add Detect OP/ED button to `SubtitleEditorModal`
+
+**Files:**
+- Modify: `frontend/src/components/editor/SubtitleEditorModal.tsx`
+
+**Context:** Open `SubtitleEditorModal.tsx` and find the `qualityFixes` array. It currently ends with the `credits` entry. Add a new `opEd` entry after it. Also add `detectOpeningEnding` to the imports from `@/api/client`.
+
+The `detectOpeningEnding` button works differently from the other quality fixes — it returns a `detected` array, not a `removed` count. Display the result as `${detected.length} OP/ED Bereiche erkannt`. If `detected` is empty, show `Keine OP/ED erkannt`.
+
+- [ ] **Step 1: Update the import in `SubtitleEditorModal.tsx`**
+
+Find the import line that includes `removeCredits` and add `detectOpeningEnding`:
+
+```typescript
+// Before:
+import { ..., removeCredits } from '@/api/client'
+// After:
+import { ..., removeCredits, detectOpeningEnding } from '@/api/client'
+```
+
+- [ ] **Step 2: Add the button to the `qualityFixes` array**
+
+Find the `credits` entry (last item in `qualityFixes`) and add `opEd` after it:
+
+```typescript
+    { key: 'credits', label: 'Credits entfernen', fn: () => removeCredits(filePath!).then(r => `${r.removed ?? 0} Credit-Zeilen entfernt`) },
+    { key: 'opEd', label: 'OP/ED erkennen', fn: () => detectOpeningEnding(filePath!).then(r => r.detected.length > 0 ? `${r.detected.length} OP/ED Bereiche erkannt` : 'Keine OP/ED erkannt') },
+```
+
+- [ ] **Step 3: Run TypeScript check**
+
+```bash
+cd frontend && npx tsc --noEmit 2>&1 | tail -10
+```
+Expected: no errors
+
+- [ ] **Step 4: Run lint**
+
+```bash
+cd frontend && npm run lint 2>&1 | tail -10
+```
+Expected: no errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/editor/SubtitleEditorModal.tsx
+git commit -m "feat: add Detect OP/ED button to SubtitleEditorModal quality toolbar"
+```
+
+---
+
+## Chunk 4: Documentation
+
+### Task 7: Update docs
+
+**Files:**
+- Modify: `docs/API.md`
+- Modify: `docs/USER-GUIDE.md`
+- Modify: `docs/CONFIGURATION.md`
+- Modify: `CHANGELOG.md`
+
+**Context:** Read the existing sections for `remove-credits` in each doc and mirror their structure for `detect-opening-ending`. The CHANGELOG format is: `- **Component — Title** — what; technical details; user impact` under `### Added`.
+
+- [ ] **Step 1: Update `docs/API.md`**
+
+Find the `POST /api/v1/tools/remove-credits` section and add after it:
+
+```markdown
+### `POST /api/v1/tools/detect-opening-ending`
+
+Detect Opening (OP) and Ending (ED) cue regions in a subtitle file. Read-only — does not modify the file.
+
+**Request:**
+```json
+{
+  "file_path": "/media/anime/ep01.ass"
+}
+```
+
+**Response 200 — detected:**
+```json
+{
+  "status": "detected",
+  "detected": [
+    { "type": "OP", "start_ms": 5000, "end_ms": 91400, "event_count": 12, "method": "style" },
+    { "type": "ED", "start_ms": 1382000, "end_ms": 1510000, "event_count": 8, "method": "duration" }
+  ]
+}
+```
+`detected` is an empty array `[]` when no regions are found (not an error).
+
+`method` is `"style"` when detection was based on ASS style name matching, `"duration"` when based on position + duration heuristic.
+
+| Status | Meaning |
+|--------|---------|
+| 200 | Detection complete (`detected` may be `[]`) |
+| 400 | Missing `file_path`, unsupported format (not `.ass`/`.ssa`/`.srt`) |
+| 403 | Path outside `media_path` |
+| 404 | File not found |
+| 500 | Processing error |
+```
+
+- [ ] **Step 2: Update `docs/USER-GUIDE.md`**
+
+Find the Credit Filtering section and add an OP/ED Detection section after it:
+
+```markdown
+### OP/ED Detection
+
+The **Detect OP/ED** button in the Quality Tools toolbar identifies Opening (OP) and Ending (ED) cue regions in your subtitle file and shows their time boundaries.
+
+**How it works:**
+
+Two detection passes run automatically:
+
+1. **Style name** (ASS/SSA only) — Events with a style named `OP`, `ED`, `Opening`, `Ending`, `OP Theme`, `ED Theme`, `Opening Theme`, or `Ending Theme` are identified directly. This is the most reliable method for professionally typeset fansub releases.
+
+2. **Position + Duration** — Used as fallback when no matching style names are found. Looks for a cluster of 3+ consecutive events near the start of the file (Opening) or end of the file (Ending) with a duration matching typical OP length (60–120 s) or ED length (90–180 s).
+
+**Result:** Detected regions are shown with their time range, event count, and detection method. If nothing is detected, a "Keine OP/ED erkannt" message is shown. The file is never modified.
+```
+
+- [ ] **Step 3: Update `docs/CONFIGURATION.md`**
+
+Find the `SUBLARR_CREDIT_THRESHOLD_SEC` row in the configuration table and add after it:
+
+```markdown
+| `SUBLARR_OP_WINDOW_SEC` | `op_window_sec` | `300` | Seconds from the start and end of a subtitle file that are considered the OP and ED detection windows. Reduce if short episodes produce false positives. |
+```
+
+- [ ] **Step 4: Update `CHANGELOG.md`**
+
+Add v0.24.1 entry at the top (above the `## [0.24.0-beta]` entry):
+
+```markdown
+## [0.24.1-beta] — 2026-03-12
+
+### Added
+
+- **OP/ED Detector — `op_ed_detector.py`** — detects Opening and Ending cue regions in ASS/SSA/SRT files using two passes: Pass 1 matches ASS style names (`OP`, `ED`, `Opening`, `Ending`, `OP Theme`, `ED Theme`); Pass 2 uses position + duration heuristics (OP: 60–120 s in first window, ED: 90–180 s in last window) with per-type gating and overlapping-window guard
+- **`POST /api/v1/tools/detect-opening-ending`** — read-only endpoint returning detected OP/ED regions as `{type, start_ms, end_ms, event_count, method}`; returns `detected: []` when nothing found (not a 4xx); no file modification
+- **Config — `op_window_sec`** — new setting (`SUBLARR_OP_WINDOW_SEC`, default 300 s) controls how many seconds from the start and end of a file are considered the OP/ED detection window
+
+### Changed
+
+- **SubtitleEditorModal — Quality Tools** — added Detect OP/ED button after Remove Credits button
+
+---
+```
+
+- [ ] **Step 5: Run ruff check on all changed backend files**
+
+```bash
+cd backend && ruff check . && ruff format --check . 2>&1 | tail -3
+```
+Expected: `All checks passed!` / `N files already formatted`
+
+- [ ] **Step 6: Run TypeScript check**
+
+```bash
+cd frontend && npx tsc --noEmit 2>&1 | tail -5
+```
+Expected: no errors
+
+- [ ] **Step 7: Run all backend tests one final time**
+
+```bash
+cd backend && python -m pytest tests/test_op_ed_detector.py tests/test_op_ed_config.py tests/test_detect_op_ed_route.py --no-cov -q 2>&1 | tail -5
+```
+Expected: `21 passed`
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add docs/API.md docs/USER-GUIDE.md docs/CONFIGURATION.md CHANGELOG.md
+git commit -m "docs: document detect-opening-ending endpoint, OP/ED detection UX, and op_window_sec config"
+```

--- a/docs/superpowers/specs/2026-03-12-v0.24.1-op-ed-detection-design.md
+++ b/docs/superpowers/specs/2026-03-12-v0.24.1-op-ed-detection-design.md
@@ -36,16 +36,18 @@ Match event style against:
 
 Consecutive events sharing a matching style are grouped into a single region. `type` is derived from the style name: styles containing `"OP"` or `"Opening"` → `"OP"`, styles containing `"ED"` or `"Ending"` → `"ED"`.
 
-If Pass 1 finds at least one region, Pass 2 is skipped for that file.
+Pass 1 uses **per-type gating**: if Pass 1 finds an OP region, Pass 2 is skipped for OP only; if Pass 1 finds an ED region, Pass 2 is skipped for ED only. A file with an `"Opening"` style but no `"Ending"` style will have its OP detected via Pass 1 and its ED (if present) detected via Pass 2.
 
 **Pass 2 — Position + Duration Heuristic (ASS + SRT fallback):**
 - Sort all dialogue events by start time.
 - Candidate region: a contiguous cluster of ≥ 3 events where no gap between consecutive events exceeds 3 s.
 - **OP candidate**: cluster that begins within the first `op_window_sec` seconds AND has a total duration of 60–120 s.
-- **ED candidate**: cluster that begins within the last `op_window_sec` seconds of the file AND has a total duration of 90–180 s.
+- **ED candidate**: cluster that begins within the last `op_window_sec` seconds of the file (i.e., start_ms ≥ total_duration_ms − op_window_sec * 1000) AND has a total duration of 90–180 s. The same `op_window_sec` setting controls both the OP and ED windows.
 - `total_duration` = last dialogue event's end time. Guard: if `total_duration` is 0 (empty file), skip heuristic.
+- **Overlapping windows guard**: if `op_window_sec * 2 * 1000 ≥ total_duration_ms` (windows overlap), skip Pass 2 entirely and return `[]` for duration-detected regions.
 - At most one OP and one ED region are returned. If multiple candidates qualify, the longest is chosen.
 - `method` field is `"duration"` for regions found by this pass.
+- `event_count` is the total number of dialogue events whose start time falls within the returned region's `[start_ms, end_ms]` boundaries.
 
 ### New setting: `config.py`
 
@@ -120,6 +122,9 @@ No file modification endpoint — detection only.
 - Pass 2: cluster outside the window is NOT detected
 - Pass 2: cluster with fewer than 3 events is NOT detected
 - Pass 2: `op_window_sec` setting is respected (custom value changes boundary)
+- Pass 2: file shorter than `2 * op_window_sec` (overlapping windows) returns `[]`
+- Pass 1 + Pass 2 mixed: file with `"Opening"` style but no `"Ending"` style — OP detected via Pass 1, ED detected via Pass 2 if cluster present
+- File with only OP cues returns `[{"type": "OP", ...}]` (not `[]`)
 - Empty file returns `[]`
 - SSA files processed same as ASS (pysubs2 handles both)
 - SRT file with positional cluster is detected via Pass 2
@@ -129,6 +134,7 @@ No file modification endpoint — detection only.
 - Returns detected regions for valid ASS file
 - 403 on path outside `media_path`
 - 400 on `.vtt` file (unsupported format)
+- 404 on non-existent file path
 
 **Frontend tests:**
 - `detectOpeningEnding()` in `client.ts` sends correct payload

--- a/docs/superpowers/specs/2026-03-12-v0.24.1-op-ed-detection-design.md
+++ b/docs/superpowers/specs/2026-03-12-v0.24.1-op-ed-detection-design.md
@@ -1,0 +1,145 @@
+# v0.24.1 — OP/ED Detection Design
+
+**Date:** 2026-03-12
+**Status:** Approved
+
+---
+
+## Goal
+
+Detect Opening (OP) and Ending (ED) cue regions in ASS, SSA, and SRT subtitle files and return their time boundaries — without modifying the file. Follows the same pattern as `credit_remover.py`: pure detection, no side effects, no DB access.
+
+---
+
+## Architecture
+
+### New module: `backend/op_ed_detector.py`
+
+Mirrors `credit_remover.py` in structure. No DB access. Pure detection.
+
+```
+op_ed_detector.py
+  detect_op_ed_from_ass(content: str) -> list[dict]
+  detect_op_ed_from_srt(content: str) -> list[dict]
+```
+
+Each function returns a list of region dicts:
+```python
+{"type": "OP"|"ED", "start_ms": int, "end_ms": int, "event_count": int, "method": "style"|"duration"}
+```
+
+**Detection (2 passes — ASS runs both, SRT runs Pass 2 only):**
+
+**Pass 1 — ASS Style Name (ASS/SSA only):**
+Match event style against:
+`r'^(OP|ED|Opening|Ending|OP Theme|ED Theme|Opening Theme|Ending Theme)$'` (case-insensitive)
+
+Consecutive events sharing a matching style are grouped into a single region. `type` is derived from the style name: styles containing `"OP"` or `"Opening"` → `"OP"`, styles containing `"ED"` or `"Ending"` → `"ED"`.
+
+If Pass 1 finds at least one region, Pass 2 is skipped for that file.
+
+**Pass 2 — Position + Duration Heuristic (ASS + SRT fallback):**
+- Sort all dialogue events by start time.
+- Candidate region: a contiguous cluster of ≥ 3 events where no gap between consecutive events exceeds 3 s.
+- **OP candidate**: cluster that begins within the first `op_window_sec` seconds AND has a total duration of 60–120 s.
+- **ED candidate**: cluster that begins within the last `op_window_sec` seconds of the file AND has a total duration of 90–180 s.
+- `total_duration` = last dialogue event's end time. Guard: if `total_duration` is 0 (empty file), skip heuristic.
+- At most one OP and one ED region are returned. If multiple candidates qualify, the longest is chosen.
+- `method` field is `"duration"` for regions found by this pass.
+
+### New setting: `config.py`
+
+```python
+op_window_sec: int = 300  # seconds from start/end to consider as OP/ED window
+```
+
+Env var: `SUBLARR_OP_WINDOW_SEC`. Read via `getattr(get_settings(), "op_window_sec", 300)`.
+
+### New endpoint: `backend/routes/tools.py`
+
+```
+POST /api/v1/tools/detect-opening-ending
+Body: { "file_path": "..." }
+
+200:
+{
+  "status": "detected",
+  "detected": [
+    {"type": "OP", "start_ms": 5000, "end_ms": 91400, "event_count": 12, "method": "style"},
+    {"type": "ED", "start_ms": 1382000, "end_ms": 1510000, "event_count": 8, "method": "duration"}
+  ]
+}
+— "detected" is [] when nothing is found (not an error)
+
+400: invalid path, unsupported format (not .ass/.ssa/.srt), or missing file_path
+403: path outside media_path — checked via is_safe_path(file_path, settings.media_path)
+                               NOTE: arg order is (file_path, base_dir) per security_utils.py
+404: file not found
+500: processing error
+```
+
+No file is read more than once. No backup. No write. Read-only operation.
+
+### Frontend: `SubtitleEditorModal`
+
+One new button **"Detect OP/ED"** in the Quality Tools toolbar, after the existing "Remove Credits" button. Clicking calls `detectOpeningEnding(filePath)` from `api/client.ts` and shows a results modal listing detected regions formatted as `OP: 0:00:05 – 0:01:31 (12 events, style)`. No confirm dialog needed — no file modification occurs.
+
+New frontend API function: `detectOpeningEnding(filePath: string)`.
+No new hook needed — call directly from the component (same pattern as remove-credits button).
+
+---
+
+## Files
+
+| Action | File |
+|--------|------|
+| Create | `backend/op_ed_detector.py` |
+| Create | `backend/tests/test_op_ed_detector.py` |
+| Modify | `backend/routes/tools.py` — add `POST /tools/detect-opening-ending`; update module docstring |
+| Modify | `backend/config.py` — add `op_window_sec: int = 300` |
+| Modify | `frontend/src/api/client.ts` — add `detectOpeningEnding(filePath)` |
+| Modify | `frontend/src/components/editor/SubtitleEditorModal.tsx` — add Detect OP/ED button |
+| Modify | `docs/API.md` — document new endpoint |
+| Modify | `docs/USER-GUIDE.md` — OP/ED Detection section |
+| Modify | `docs/CONFIGURATION.md` — document `op_window_sec` / `SUBLARR_OP_WINDOW_SEC` |
+| Modify | `CHANGELOG.md` — add v0.24.1 entry at release |
+
+No file modification endpoint — detection only.
+
+---
+
+## Testing
+
+**Backend unit tests (`test_op_ed_detector.py`):**
+- Pass 1: ASS event with style `"Opening"` is detected as OP
+- Pass 1: ASS event with style `"ED Theme"` is detected as ED
+- Pass 1: style detection skips Pass 2 (no duplicate detection)
+- Pass 2: OP cluster in first 300 s with 90 s duration is detected
+- Pass 2: ED cluster in last 300 s with 120 s duration is detected
+- Pass 2: cluster shorter than 60 s is NOT detected as OP
+- Pass 2: cluster outside the window is NOT detected
+- Pass 2: cluster with fewer than 3 events is NOT detected
+- Pass 2: `op_window_sec` setting is respected (custom value changes boundary)
+- Empty file returns `[]`
+- SSA files processed same as ASS (pysubs2 handles both)
+- SRT file with positional cluster is detected via Pass 2
+
+**Route tests:**
+- Returns `"detected": []` for file with no OP/ED cues (not a 4xx)
+- Returns detected regions for valid ASS file
+- 403 on path outside `media_path`
+- 400 on `.vtt` file (unsupported format)
+
+**Frontend tests:**
+- `detectOpeningEnding()` in `client.ts` sends correct payload
+- Detect OP/ED button renders in SubtitleEditorModal Quality Tools toolbar
+
+---
+
+## Out of Scope
+
+- Writing markers back to the subtitle file
+- Machine learning / audio-based OP/ED detection
+- Per-series OP/ED configuration
+- Lyrics pattern detection (content heuristics beyond style name and timing)
+- Bulk endpoint

--- a/frontend/src/api/__tests__/detectOpeningEnding.test.ts
+++ b/frontend/src/api/__tests__/detectOpeningEnding.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('axios', () => ({
+  default: {
+    create: () => ({
+      post: vi.fn().mockResolvedValue({ data: { status: 'detected', detected: [] } }),
+      interceptors: { request: { use: vi.fn() }, response: { use: vi.fn() } },
+    }),
+  },
+}))
+
+describe('detectOpeningEnding', () => {
+  it('is exported from client.ts and returns detected array', async () => {
+    const { detectOpeningEnding } = await import('../client')
+    expect(typeof detectOpeningEnding).toBe('function')
+    const result = await detectOpeningEnding('/media/test.ass')
+    expect(result).toHaveProperty('status', 'detected')
+    expect(Array.isArray(result.detected)).toBe(true)
+  })
+})

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1538,6 +1538,20 @@ export async function removeCredits(
   return data
 }
 
+export async function detectOpeningEnding(filePath: string): Promise<{
+  status: string
+  detected: Array<{
+    type: 'OP' | 'ED'
+    start_ms: number
+    end_ms: number
+    event_count: number
+    method: 'style' | 'duration'
+  }>
+}> {
+  const { data } = await api.post('/tools/detect-opening-ending', { file_path: filePath })
+  return data
+}
+
 // ─── Phase 33: Format conversion ──────────────────────────────────────────────
 
 export async function convertSubtitle(params: {

--- a/frontend/src/components/editor/SubtitleEditorModal.tsx
+++ b/frontend/src/components/editor/SubtitleEditorModal.tsx
@@ -11,7 +11,7 @@ import { createPortal } from 'react-dom'
 import { Loader2, X, Eye, Pencil, GitCompare, RefreshCw, Activity } from 'lucide-react'
 import { useQueryClient } from '@tanstack/react-query'
 import { useSubtitleContent } from '@/hooks/useApi'
-import { autoSyncFile, overlapFix, timingNormalize, mergeLines, splitLines, spellCheck, removeCredits } from '@/api/client'
+import { autoSyncFile, overlapFix, timingNormalize, mergeLines, splitLines, spellCheck, removeCredits, detectOpeningEnding } from '@/api/client'
 import { toast } from '@/components/shared/Toast'
 
 // Lazy-loaded editor components -- CodeMirror stays in separate chunks
@@ -171,6 +171,7 @@ export default function SubtitleEditorModal({
     { key: 'split', label: 'Aufteilen', fn: () => splitLines(filePath!).then(r => `${r.split} Cues aufgeteilt`) },
     { key: 'spell', label: 'Rechtschreibung', fn: () => spellCheck(filePath!).then(r => `${r.total} Fehler gefunden`) },
     { key: 'credits', label: 'Credits entfernen', fn: () => removeCredits(filePath!).then(r => `${r.removed ?? 0} Credit-Zeilen entfernt`) },
+    { key: 'opEd', label: 'OP/ED erkennen', fn: () => detectOpeningEnding(filePath!).then(r => r.detected.length > 0 ? `${r.detected.length} OP/ED Bereiche erkannt` : 'Keine OP/ED erkannt') },
   ]
 
   // When modal is closed, render nothing


### PR DESCRIPTION
## Summary

- **`op_ed_detector.py`** — new pure-detection module using two-pass strategy: Pass 1 matches ASS style names (`OP`, `ED`, `Opening`, `Ending`, `OP Theme`, `ED Theme`); Pass 2 uses position + duration heuristics (OP: 60–120 s in first window, ED: 90–180 s in last window) with per-type gating and overlapping-window guard
- **`POST /api/v1/tools/detect-opening-ending`** — read-only endpoint returning detected regions as `{type, start_ms, end_ms, event_count, method}`; returns `detected: []` when nothing found; no file modification
- **Config `op_window_sec`** (`SUBLARR_OP_WINDOW_SEC`, default 300 s) + **Detect OP/ED button** in SubtitleEditorModal Quality Tools toolbar

## Test Plan

- [ ] Backend: `python -m pytest tests/test_op_ed_detector.py tests/test_op_ed_config.py tests/test_detect_op_ed_route.py` → 23 passed
- [ ] Frontend: `npx tsc --noEmit` + `npm run lint` → no errors
- [ ] CI green