### PR TITLE
feat: v0.24.2 — Multi-Audio Track Support for Whisper

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -171,11 +171,11 @@ Goals: Mark OP/ED cue regions in subtitle files for optional skip during transla
 
 ---
 
-## v0.24.2 — Multi-Audio Track Support for Whisper
+## v0.24.2 — Multi-Audio Track Support for Whisper ✅
 
 Goals: Select the correct audio track per series for Whisper transcription.
 
-- Per-series audio track preference stored in DB (extend `series_language_profiles`)
+- Per-series audio track preference stored in DB (`series_settings.preferred_audio_track_index`)
 - `POST /whisper/transcribe` extended with optional `audio_track_index` parameter
 - SeriesDetail — audio track picker showing available tracks with language/codec info
 

--- a/backend/db/migrations/versions/a9b8c7d6e5f4_add_audio_track_pref.py
+++ b/backend/db/migrations/versions/a9b8c7d6e5f4_add_audio_track_pref.py
@@ -1,0 +1,36 @@
+"""add_audio_track_pref
+
+Revision ID: a9b8c7d6e5f4
+Revises:
+Create Date: 2026-03-13
+
+Adds preferred_audio_track_index to series_settings for per-series
+Whisper audio track pinning, and audio_track_index to whisper_jobs
+for observability.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "a9b8c7d6e5f4"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("series_settings") as batch_op:
+        batch_op.add_column(
+            sa.Column("preferred_audio_track_index", sa.Integer(), nullable=True)
+        )
+    with op.batch_alter_table("whisper_jobs") as batch_op:
+        batch_op.add_column(
+            sa.Column("audio_track_index", sa.Integer(), nullable=True)
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("whisper_jobs") as batch_op:
+        batch_op.drop_column("audio_track_index")
+    with op.batch_alter_table("series_settings") as batch_op:
+        batch_op.drop_column("preferred_audio_track_index")

--- a/backend/db/migrations/versions/a9b8c7d6e5f4_add_audio_track_pref.py
+++ b/backend/db/migrations/versions/a9b8c7d6e5f4_add_audio_track_pref.py
@@ -20,13 +20,9 @@ depends_on = None
 
 def upgrade():
     with op.batch_alter_table("series_settings") as batch_op:
-        batch_op.add_column(
-            sa.Column("preferred_audio_track_index", sa.Integer(), nullable=True)
-        )
+        batch_op.add_column(sa.Column("preferred_audio_track_index", sa.Integer(), nullable=True))
     with op.batch_alter_table("whisper_jobs") as batch_op:
-        batch_op.add_column(
-            sa.Column("audio_track_index", sa.Integer(), nullable=True)
-        )
+        batch_op.add_column(sa.Column("audio_track_index", sa.Integer(), nullable=True))
 
 
 def downgrade():

--- a/backend/db/models/core.py
+++ b/backend/db/models/core.py
@@ -258,6 +258,7 @@ class SeriesSettings(db.Model):
 
     sonarr_series_id: Mapped[int] = mapped_column(Integer, primary_key=True)
     absolute_order: Mapped[int] = mapped_column(Integer, nullable=False, default=0)  # 0=off, 1=on
+    preferred_audio_track_index: Mapped[int | None] = mapped_column(Integer, nullable=True, default=None)
     updated_at: Mapped[str] = mapped_column(Text, nullable=False)
 
 

--- a/backend/db/models/core.py
+++ b/backend/db/models/core.py
@@ -258,7 +258,9 @@ class SeriesSettings(db.Model):
 
     sonarr_series_id: Mapped[int] = mapped_column(Integer, primary_key=True)
     absolute_order: Mapped[int] = mapped_column(Integer, nullable=False, default=0)  # 0=off, 1=on
-    preferred_audio_track_index: Mapped[int | None] = mapped_column(Integer, nullable=True, default=None)
+    preferred_audio_track_index: Mapped[int | None] = mapped_column(
+        Integer, nullable=True, default=None
+    )
     updated_at: Mapped[str] = mapped_column(Text, nullable=False)
 
 

--- a/backend/db/models/translation.py
+++ b/backend/db/models/translation.py
@@ -99,6 +99,7 @@ class WhisperJob(db.Model):
     segment_count: Mapped[int | None] = mapped_column(Integer, default=0)
     duration_seconds: Mapped[float | None] = mapped_column(Float, default=0.0)
     processing_time_ms: Mapped[float | None] = mapped_column(Float, default=0.0)
+    audio_track_index: Mapped[int | None] = mapped_column(Integer, nullable=True, default=None)
     error: Mapped[str | None] = mapped_column(Text, default="")
     created_at: Mapped[str] = mapped_column(Text, nullable=False)
     started_at: Mapped[str | None] = mapped_column(Text, default="")

--- a/backend/db/repositories/series_audio.py
+++ b/backend/db/repositories/series_audio.py
@@ -1,0 +1,45 @@
+"""Repository for per-series audio track preferences.
+
+Reads and writes preferred_audio_track_index on the series_settings table.
+Uses UPSERT semantics: creates the row if it does not exist yet.
+"""
+
+import logging
+from datetime import datetime
+
+from db.models.core import SeriesSettings
+from db.repositories.base import BaseRepository
+
+logger = logging.getLogger(__name__)
+
+
+class SeriesAudioRepository(BaseRepository):
+    """Read/write preferred_audio_track_index in series_settings."""
+
+    def get_audio_track_pref(self, series_id: int) -> int | None:
+        """Return the pinned audio track index for a series, or None if not set."""
+        row = self.session.get(SeriesSettings, series_id)
+        return row.preferred_audio_track_index if row else None
+
+    def set_audio_track_pref(self, series_id: int, track_index: int | None) -> None:
+        """Persist preferred_audio_track_index for a series.
+
+        Creates a series_settings row if one does not exist yet.
+        Pass track_index=None to clear the preference (auto-select resumes).
+        """
+        now = datetime.utcnow().isoformat()
+        existing = self.session.get(SeriesSettings, series_id)
+        if existing:
+            existing.preferred_audio_track_index = track_index
+            existing.updated_at = now
+        else:
+            self.session.add(
+                SeriesSettings(
+                    sonarr_series_id=series_id,
+                    absolute_order=0,
+                    preferred_audio_track_index=track_index,
+                    updated_at=now,
+                )
+            )
+        self._commit()
+        logger.debug("Series %d preferred_audio_track_index -> %s", series_id, track_index)

--- a/backend/db/repositories/whisper.py
+++ b/backend/db/repositories/whisper.py
@@ -17,7 +17,13 @@ logger = logging.getLogger(__name__)
 class WhisperRepository(BaseRepository):
     """Repository for whisper_jobs table operations."""
 
-    def create_whisper_job(self, job_id: str, file_path: str, language: str = "") -> dict:
+    def create_whisper_job(
+        self,
+        job_id: str,
+        file_path: str,
+        language: str = "",
+        audio_track_index: int | None = None,
+    ) -> dict:
         """Create a new whisper job in the database.
 
         Returns:
@@ -28,6 +34,7 @@ class WhisperRepository(BaseRepository):
             id=job_id,
             file_path=file_path,
             language=language,
+            audio_track_index=audio_track_index,
             status="queued",
             progress=0.0,
             created_at=now,
@@ -39,6 +46,7 @@ class WhisperRepository(BaseRepository):
             "id": job_id,
             "file_path": file_path,
             "language": language,
+            "audio_track_index": audio_track_index,
             "status": "queued",
             "progress": 0.0,
             "created_at": now,

--- a/backend/db/whisper.py
+++ b/backend/db/whisper.py
@@ -12,9 +12,14 @@ def _get_repo():
     return _repo
 
 
-def create_whisper_job(job_id: str, file_path: str, language: str = "") -> dict:
+def create_whisper_job(
+    job_id: str,
+    file_path: str,
+    language: str = "",
+    audio_track_index: int | None = None,
+) -> dict:
     """Create a new whisper job in the database."""
-    return _get_repo().create_whisper_job(job_id, file_path, language)
+    return _get_repo().create_whisper_job(job_id, file_path, language, audio_track_index)
 
 
 def update_whisper_job(job_id: str, **kwargs) -> None:

--- a/backend/routes/__init__.py
+++ b/backend/routes/__init__.py
@@ -27,6 +27,7 @@ def register_blueprints(app):
     from routes.providers import bp as providers_bp
     from routes.remux import bp as remux_bp
     from routes.search import bp as search_bp
+    from routes.series_audio import bp as series_audio_bp
     from routes.spell import bp as spell_bp
     from routes.standalone import bp as standalone_bp
     from routes.subtitles import bp as subtitles_bp
@@ -38,7 +39,6 @@ def register_blueprints(app):
     from routes.video_sync import bp as video_sync_bp
     from routes.wanted import bp as wanted_bp
     from routes.webhooks import bp as webhooks_bp
-    from routes.series_audio import bp as series_audio_bp
     from routes.whisper import bp as whisper_bp
 
     for blueprint in [

--- a/backend/routes/__init__.py
+++ b/backend/routes/__init__.py
@@ -38,6 +38,7 @@ def register_blueprints(app):
     from routes.video_sync import bp as video_sync_bp
     from routes.wanted import bp as wanted_bp
     from routes.webhooks import bp as webhooks_bp
+    from routes.series_audio import bp as series_audio_bp
     from routes.whisper import bp as whisper_bp
 
     for blueprint in [
@@ -73,5 +74,6 @@ def register_blueprints(app):
         video_sync_bp,
         subtitles_bp,
         remux_bp,
+        series_audio_bp,
     ]:
         app.register_blueprint(blueprint)

--- a/backend/routes/series_audio.py
+++ b/backend/routes/series_audio.py
@@ -1,0 +1,51 @@
+"""Series audio track preference endpoints.
+
+GET  /api/v1/series/<series_id>/audio-track-pref
+PUT  /api/v1/series/<series_id>/audio-track-pref
+"""
+
+import logging
+
+from flask import Blueprint, jsonify, request
+
+from db.repositories.series_audio import SeriesAudioRepository
+
+bp = Blueprint("series_audio", __name__, url_prefix="/api/v1/series")
+logger = logging.getLogger(__name__)
+
+
+@bp.route("/<int:series_id>/audio-track-pref", methods=["GET"])
+def get_audio_track_pref(series_id: int):
+    """Return the pinned audio track index for a series.
+
+    Returns {"series_id": int, "preferred_audio_track_index": int | null}.
+    Returns null when no preference is set (auto-select will be used).
+    """
+    pref = SeriesAudioRepository().get_audio_track_pref(series_id)
+    return jsonify({"series_id": series_id, "preferred_audio_track_index": pref})
+
+
+@bp.route("/<int:series_id>/audio-track-pref", methods=["PUT"])
+def set_audio_track_pref(series_id: int):
+    """Set or clear the pinned audio track index for a series.
+
+    Body: {"preferred_audio_track_index": int | null}
+    Pass null to clear the preference (auto-select resumes).
+    """
+    data = request.get_json(force=True, silent=True) or {}
+    raw = data.get("preferred_audio_track_index", "MISSING")
+
+    if raw == "MISSING":
+        return jsonify({"error": "preferred_audio_track_index is required"}), 400
+
+    if raw is not None and (not isinstance(raw, int) or raw < 0):
+        return (
+            jsonify(
+                {"error": "preferred_audio_track_index must be a non-negative integer or null"}
+            ),
+            400,
+        )
+
+    SeriesAudioRepository().set_audio_track_pref(series_id=series_id, track_index=raw)
+    logger.info("Series %d: preferred_audio_track_index -> %s", series_id, raw)
+    return jsonify({"series_id": series_id, "preferred_audio_track_index": raw})

--- a/backend/routes/whisper.py
+++ b/backend/routes/whisper.py
@@ -110,7 +110,9 @@ def transcribe():
     audio_track_index = data.get("audio_track_index")
     if audio_track_index is not None:
         if not isinstance(audio_track_index, int) or audio_track_index < 0:
-            return jsonify({"error": "audio_track_index must be a non-negative integer or null"}), 400
+            return jsonify(
+                {"error": "audio_track_index must be a non-negative integer or null"}
+            ), 400
 
     job_id = uuid.uuid4().hex
     manager = get_whisper_manager()

--- a/backend/routes/whisper.py
+++ b/backend/routes/whisper.py
@@ -1,11 +1,13 @@
 """Whisper routes -- /whisper/transcribe, /whisper/queue, /whisper/backends, /whisper/config, /whisper/stats."""
 
 import logging
+import os
 import uuid
 
 from flask import Blueprint, jsonify, request
 
 from extensions import socketio
+from security_utils import is_safe_path
 
 bp = Blueprint("whisper", __name__, url_prefix="/api/v1/whisper")
 logger = logging.getLogger(__name__)
@@ -86,10 +88,7 @@ def transcribe():
         404:
           description: File not found
     """
-    import os
-
     from config import get_settings, map_path
-    from security_utils import is_safe_path
     from whisper import get_whisper_manager
 
     data = request.get_json() or {}
@@ -108,6 +107,11 @@ def transcribe():
         return jsonify({"error": f"File not found: {file_path}"}), 404
     language = data.get("language", settings.source_language or "ja")
 
+    audio_track_index = data.get("audio_track_index")
+    if audio_track_index is not None:
+        if not isinstance(audio_track_index, int) or audio_track_index < 0:
+            return jsonify({"error": "audio_track_index must be a non-negative integer or null"}), 400
+
     job_id = uuid.uuid4().hex
     manager = get_whisper_manager()
     queue = _get_queue()
@@ -119,6 +123,7 @@ def transcribe():
         source_language=language,
         whisper_manager=manager,
         socketio=socketio,
+        audio_track_index=audio_track_index,
     )
 
     return jsonify(

--- a/backend/tests/test_series_audio_pref.py
+++ b/backend/tests/test_series_audio_pref.py
@@ -1,0 +1,124 @@
+"""Tests for per-series audio track preference."""
+
+import pytest
+
+
+class TestSeriesAudioPrefModel:
+    def test_series_settings_has_audio_track_field(self):
+        from db.models.core import SeriesSettings
+
+        ss = SeriesSettings(sonarr_series_id=1, absolute_order=0, updated_at="2026-01-01")
+        assert hasattr(ss, "preferred_audio_track_index")
+        assert ss.preferred_audio_track_index is None
+
+
+class TestGetAudioTrackByIndex:
+    def test_valid_index_returns_track_dict(self, monkeypatch):
+        from whisper.audio import get_audio_track_by_index
+
+        fake = [
+            {"stream_index": 0, "language": "jpn", "codec": "aac", "channels": 2, "title": ""},
+            {"stream_index": 1, "language": "eng", "codec": "aac", "channels": 2, "title": ""},
+        ]
+        monkeypatch.setattr("whisper.audio.get_audio_streams", lambda _: fake)
+        track = get_audio_track_by_index("/fake/file.mkv", 1)
+        assert track["stream_index"] == 1
+        assert track["language"] == "eng"
+
+    def test_out_of_range_raises(self, monkeypatch):
+        from whisper.audio import get_audio_track_by_index
+
+        monkeypatch.setattr(
+            "whisper.audio.get_audio_streams",
+            lambda _: [{"stream_index": 0, "language": "jpn", "codec": "aac", "channels": 2, "title": ""}],
+        )
+        with pytest.raises(ValueError, match="out of range"):
+            get_audio_track_by_index("/fake/file.mkv", 5)
+
+
+class TestSeriesAudioRepository:
+    def test_get_returns_none_for_unknown_series(self, app_ctx):
+        from db.repositories.series_audio import SeriesAudioRepository
+
+        result = SeriesAudioRepository().get_audio_track_pref(series_id=9999)
+        assert result is None
+
+    def test_set_and_get_roundtrip(self, app_ctx):
+        from db.repositories.series_audio import SeriesAudioRepository
+
+        repo = SeriesAudioRepository()
+        repo.set_audio_track_pref(series_id=42, track_index=2)
+        assert repo.get_audio_track_pref(series_id=42) == 2
+
+    def test_set_to_none_clears(self, app_ctx):
+        from db.repositories.series_audio import SeriesAudioRepository
+
+        repo = SeriesAudioRepository()
+        repo.set_audio_track_pref(series_id=42, track_index=1)
+        repo.set_audio_track_pref(series_id=42, track_index=None)
+        assert repo.get_audio_track_pref(series_id=42) is None
+
+
+class TestSeriesAudioPrefRoutes:
+    def test_get_unknown_returns_null(self, client):
+        r = client.get("/api/v1/series/9999/audio-track-pref")
+        assert r.status_code == 200
+        d = r.get_json()
+        assert d["series_id"] == 9999
+        assert d["preferred_audio_track_index"] is None
+
+    def test_put_sets_preference(self, client):
+        r = client.put(
+            "/api/v1/series/42/audio-track-pref",
+            json={"preferred_audio_track_index": 1},
+            content_type="application/json",
+        )
+        assert r.status_code == 200
+        assert r.get_json()["preferred_audio_track_index"] == 1
+
+    def test_get_reflects_put(self, client):
+        client.put(
+            "/api/v1/series/43/audio-track-pref",
+            json={"preferred_audio_track_index": 3},
+            content_type="application/json",
+        )
+        assert (
+            client.get("/api/v1/series/43/audio-track-pref").get_json()[
+                "preferred_audio_track_index"
+            ]
+            == 3
+        )
+
+    def test_put_null_clears(self, client):
+        client.put(
+            "/api/v1/series/44/audio-track-pref",
+            json={"preferred_audio_track_index": 2},
+            content_type="application/json",
+        )
+        client.put(
+            "/api/v1/series/44/audio-track-pref",
+            json={"preferred_audio_track_index": None},
+            content_type="application/json",
+        )
+        assert (
+            client.get("/api/v1/series/44/audio-track-pref").get_json()[
+                "preferred_audio_track_index"
+            ]
+            is None
+        )
+
+    def test_put_negative_rejected(self, client):
+        r = client.put(
+            "/api/v1/series/45/audio-track-pref",
+            json={"preferred_audio_track_index": -1},
+            content_type="application/json",
+        )
+        assert r.status_code == 400
+
+    def test_put_string_rejected(self, client):
+        r = client.put(
+            "/api/v1/series/45/audio-track-pref",
+            json={"preferred_audio_track_index": "auto"},
+            content_type="application/json",
+        )
+        assert r.status_code == 400

--- a/backend/tests/test_series_audio_pref.py
+++ b/backend/tests/test_series_audio_pref.py
@@ -30,7 +30,9 @@ class TestGetAudioTrackByIndex:
 
         monkeypatch.setattr(
             "whisper.audio.get_audio_streams",
-            lambda _: [{"stream_index": 0, "language": "jpn", "codec": "aac", "channels": 2, "title": ""}],
+            lambda _: [
+                {"stream_index": 0, "language": "jpn", "codec": "aac", "channels": 2, "title": ""}
+            ],
         )
         with pytest.raises(ValueError, match="out of range"):
             get_audio_track_by_index("/fake/file.mkv", 5)

--- a/backend/tests/test_whisper_audio_track.py
+++ b/backend/tests/test_whisper_audio_track.py
@@ -1,0 +1,210 @@
+"""Tests for audio_track_index propagation through WhisperQueue and transcribe route."""
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestWhisperJobDataclass:
+    def test_has_audio_track_index_field(self):
+        from whisper.queue import WhisperJob
+
+        job = WhisperJob(job_id="abc", file_path="/fake.mkv")
+        assert hasattr(job, "audio_track_index")
+        assert job.audio_track_index is None
+
+    def test_accepts_explicit_index(self):
+        from whisper.queue import WhisperJob
+
+        job = WhisperJob(job_id="abc", file_path="/fake.mkv", audio_track_index=2)
+        assert job.audio_track_index == 2
+
+
+class TestWhisperQueueAudioTrack:
+    def test_explicit_index_bypasses_language_selection(self):
+        """When audio_track_index is set, get_audio_track_by_index is called, not select_audio_track."""
+        from whisper.queue import WhisperQueue
+
+        fake_track = {
+            "stream_index": 2,
+            "language": "eng",
+            "codec": "aac",
+            "channels": 2,
+            "title": "",
+        }
+        fake_result = MagicMock(
+            success=True,
+            srt_content="1\n00:00:01,000 --> 00:00:02,000\nHello",
+            backend_name="faster_whisper",
+            detected_language="en",
+            language_probability=0.99,
+            segment_count=1,
+            duration_seconds=2.0,
+        )
+        manager = MagicMock()
+        manager.transcribe.return_value = fake_result
+
+        queue = WhisperQueue(max_concurrent=1)
+        by_index = []
+        by_lang = []
+
+        def mock_by_index(fp, idx):
+            by_index.append(idx)
+            return fake_track
+
+        def mock_by_lang(fp, preferred_language):
+            by_lang.append(preferred_language)
+            return fake_track
+
+        with (
+            patch("whisper.queue.get_audio_track_by_index", mock_by_index),
+            patch("whisper.queue.select_audio_track", mock_by_lang),
+            patch("whisper.queue.extract_audio_to_wav"),
+            patch("whisper.queue.create_whisper_job"),
+            patch("whisper.queue.update_whisper_job"),
+            patch("tempfile.mkstemp", return_value=(0, "/tmp/fake.wav")),
+            patch("os.close"),
+            patch("os.path.exists", return_value=True),
+            patch("os.remove"),
+        ):
+            queue.submit(
+                job_id="t1",
+                file_path="/fake.mkv",
+                language="ja",
+                source_language="ja",
+                audio_track_index=2,
+                whisper_manager=manager,
+            )
+            time.sleep(0.5)
+
+        assert by_index == [2], "get_audio_track_by_index must be called with explicit index"
+        assert by_lang == [], "select_audio_track must NOT be called when explicit index is set"
+
+    def test_none_index_uses_language_selection(self):
+        """When audio_track_index is None, select_audio_track is called normally."""
+        from whisper.queue import WhisperQueue
+
+        fake_track = {
+            "stream_index": 0,
+            "language": "jpn",
+            "codec": "aac",
+            "channels": 2,
+            "title": "",
+        }
+        fake_result = MagicMock(
+            success=True,
+            srt_content="1\n00:00:01,000 --> 00:00:02,000\nHello",
+            backend_name="faster_whisper",
+            detected_language="ja",
+            language_probability=0.99,
+            segment_count=1,
+            duration_seconds=2.0,
+        )
+        manager = MagicMock()
+        manager.transcribe.return_value = fake_result
+
+        queue = WhisperQueue(max_concurrent=1)
+        by_index = []
+        by_lang = []
+
+        def mock_by_index(fp, idx):
+            by_index.append(idx)
+            return fake_track
+
+        def mock_by_lang(fp, preferred_language):
+            by_lang.append(preferred_language)
+            return fake_track
+
+        with (
+            patch("whisper.queue.get_audio_track_by_index", mock_by_index),
+            patch("whisper.queue.select_audio_track", mock_by_lang),
+            patch("whisper.queue.extract_audio_to_wav"),
+            patch("whisper.queue.create_whisper_job"),
+            patch("whisper.queue.update_whisper_job"),
+            patch("tempfile.mkstemp", return_value=(0, "/tmp/fake.wav")),
+            patch("os.close"),
+            patch("os.path.exists", return_value=True),
+            patch("os.remove"),
+        ):
+            queue.submit(
+                job_id="t2",
+                file_path="/fake.mkv",
+                language="ja",
+                source_language="ja",
+                audio_track_index=None,
+                whisper_manager=manager,
+            )
+            time.sleep(0.5)
+
+        assert by_lang == ["ja"], "select_audio_track must be called when index is None"
+        assert by_index == [], "get_audio_track_by_index must NOT be called when index is None"
+
+
+class TestWhisperTranscribeRoute:
+    @pytest.fixture
+    def client(self, temp_db):
+        from app import create_app
+
+        app = create_app(testing=True)
+        app.config["TESTING"] = True
+        with app.test_client() as c:
+            yield c
+
+    def test_accepts_audio_track_index(self, client, monkeypatch):
+        captured = {}
+
+        class FakeQueue:
+            def submit(self, **kwargs):
+                captured.update(kwargs)
+                return "j1"
+
+        monkeypatch.setattr("routes.whisper._queue", FakeQueue())
+        monkeypatch.setattr("routes.whisper.is_safe_path", lambda *a: True)
+        monkeypatch.setattr("routes.whisper.os.path.exists", lambda p: True)
+        r = client.post(
+            "/api/v1/whisper/transcribe",
+            json={"file_path": "/media/ep1.mkv", "audio_track_index": 2},
+            content_type="application/json",
+        )
+        assert r.status_code == 202
+        assert captured.get("audio_track_index") == 2
+
+    def test_missing_index_defaults_to_none(self, client, monkeypatch):
+        captured = {}
+
+        class FakeQueue:
+            def submit(self, **kwargs):
+                captured.update(kwargs)
+                return "j2"
+
+        monkeypatch.setattr("routes.whisper._queue", FakeQueue())
+        monkeypatch.setattr("routes.whisper.is_safe_path", lambda *a: True)
+        monkeypatch.setattr("routes.whisper.os.path.exists", lambda p: True)
+        r = client.post(
+            "/api/v1/whisper/transcribe",
+            json={"file_path": "/media/ep1.mkv"},
+            content_type="application/json",
+        )
+        assert r.status_code == 202
+        assert captured.get("audio_track_index") is None
+
+    def test_rejects_negative_index(self, client, monkeypatch):
+        monkeypatch.setattr("routes.whisper.is_safe_path", lambda *a: True)
+        monkeypatch.setattr("routes.whisper.os.path.exists", lambda p: True)
+        r = client.post(
+            "/api/v1/whisper/transcribe",
+            json={"file_path": "/media/ep1.mkv", "audio_track_index": -1},
+            content_type="application/json",
+        )
+        assert r.status_code == 400
+
+    def test_rejects_string_index(self, client, monkeypatch):
+        monkeypatch.setattr("routes.whisper.is_safe_path", lambda *a: True)
+        monkeypatch.setattr("routes.whisper.os.path.exists", lambda p: True)
+        r = client.post(
+            "/api/v1/whisper/transcribe",
+            json={"file_path": "/media/ep1.mkv", "audio_track_index": "first"},
+            content_type="application/json",
+        )
+        assert r.status_code == 400

--- a/backend/whisper/audio.py
+++ b/backend/whisper/audio.py
@@ -170,6 +170,36 @@ def select_audio_track(
     return fallback
 
 
+def get_audio_track_by_index(file_path: str, index: int) -> dict:
+    """Return the audio stream dict for an explicit 0-based track index.
+
+    Args:
+        file_path: Path to the media file
+        index: 0-based audio stream index
+
+    Returns:
+        Stream dict with stream_index, language, codec, channels, title
+
+    Raises:
+        ValueError: If index is out of range for the file's audio streams
+        RuntimeError: If ffprobe fails (propagated from get_audio_streams)
+    """
+    streams = get_audio_streams(file_path)
+    if not streams or index >= len(streams):
+        raise ValueError(
+            f"Audio track index {index} out of range: file has {len(streams)} audio track(s)"
+        )
+    track = streams[index]
+    logger.info(
+        "Using pinned audio track %d (%s, %s, %dch)",
+        index,
+        track["language"],
+        track["codec"],
+        track["channels"],
+    )
+    return track
+
+
 def extract_audio_to_wav(
     file_path: str,
     stream_index: int,

--- a/backend/whisper/queue.py
+++ b/backend/whisper/queue.py
@@ -14,6 +14,8 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING
 
+from db.whisper import create_whisper_job, update_whisper_job
+from whisper.audio import extract_audio_to_wav, get_audio_track_by_index, select_audio_track
 from whisper.base import TranscriptionResult
 
 if TYPE_CHECKING:
@@ -29,6 +31,7 @@ class WhisperJob:
     job_id: str
     file_path: str
     language: str = ""
+    audio_track_index: int | None = None  # Explicit track index; None = auto-select by language
     status: str = "queued"  # queued/extracting/transcribing/saving/completed/failed/cancelled
     progress: float = 0.0
     phase: str = ""
@@ -60,6 +63,7 @@ class WhisperQueue:
         source_language: str,
         whisper_manager: "WhisperManager",
         socketio=None,
+        audio_track_index: int | None = None,
     ) -> str:
         """Submit a new transcription job.
 
@@ -73,6 +77,7 @@ class WhisperQueue:
             source_language: Source audio language for track selection
             whisper_manager: WhisperManager instance for transcription
             socketio: Optional Socket.IO instance for progress events
+            audio_track_index: Explicit 0-based audio track index; None = auto-select by language
 
         Returns:
             The job_id
@@ -82,6 +87,7 @@ class WhisperQueue:
             job_id=job_id,
             file_path=file_path,
             language=language,
+            audio_track_index=audio_track_index,
             status="queued",
             created_at=now,
         )
@@ -91,16 +97,14 @@ class WhisperQueue:
 
         # Persist to DB
         try:
-            from db.whisper import create_whisper_job
-
-            create_whisper_job(job_id, file_path, language)
+            create_whisper_job(job_id, file_path, language, audio_track_index)
         except Exception as e:
             logger.error("Failed to persist whisper job %s to DB: %s", job_id, e)
 
         # Start worker thread
         thread = threading.Thread(
             target=self._run_job,
-            args=(job_id, file_path, language, source_language, whisper_manager, socketio),
+            args=(job_id, file_path, language, source_language, audio_track_index, whisper_manager, socketio),
             daemon=True,
             name=f"whisper-job-{job_id}",
         )
@@ -138,8 +142,6 @@ class WhisperQueue:
 
         # Update DB
         try:
-            from db.whisper import update_whisper_job
-
             update_whisper_job(job_id, status="cancelled")
         except Exception as e:
             logger.error("Failed to update cancelled job %s in DB: %s", job_id, e)
@@ -153,6 +155,7 @@ class WhisperQueue:
         file_path: str,
         language: str,
         source_language: str,
+        audio_track_index: int | None,
         whisper_manager: "WhisperManager",
         socketio,
     ):
@@ -182,11 +185,12 @@ class WhisperQueue:
                 self._emit_progress(socketio, job_id, "extracting", 0.0, "Selecting audio track...")
 
                 # Phase 1: Audio extraction (0-10%)
-                from whisper.audio import extract_audio_to_wav, select_audio_track
-
-                track = select_audio_track(
-                    file_path, preferred_language=source_language or language or "ja"
-                )
+                if audio_track_index is not None:
+                    track = get_audio_track_by_index(file_path, audio_track_index)
+                else:
+                    track = select_audio_track(
+                        file_path, preferred_language=source_language or language or "ja"
+                    )
                 self._update_job(job_id, progress=0.05)
                 self._emit_progress(
                     socketio,
@@ -235,8 +239,6 @@ class WhisperQueue:
 
                 # Persist to DB
                 try:
-                    from db.whisper import update_whisper_job
-
                     update_whisper_job(
                         job_id,
                         status="completed",
@@ -324,8 +326,6 @@ class WhisperQueue:
 
             # Persist failure to DB
             try:
-                from db.whisper import update_whisper_job
-
                 update_whisper_job(
                     job_id,
                     status="failed",

--- a/backend/whisper/queue.py
+++ b/backend/whisper/queue.py
@@ -104,7 +104,15 @@ class WhisperQueue:
         # Start worker thread
         thread = threading.Thread(
             target=self._run_job,
-            args=(job_id, file_path, language, source_language, audio_track_index, whisper_manager, socketio),
+            args=(
+                job_id,
+                file_path,
+                language,
+                source_language,
+                audio_track_index,
+                whisper_manager,
+                socketio,
+            ),
             daemon=True,
             name=f"whisper-job-{job_id}",
         )

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -702,6 +702,20 @@ export const getWhisperJob = (jobId: string) => api.get(`/whisper/jobs/${jobId}`
 export const submitWhisperJob = (data: { file_path: string; language?: string }) => api.post('/whisper/transcribe', data).then(r => r.data)
 export const deleteWhisperJob = (jobId: string) => api.delete(`/whisper/jobs/${jobId}`).then(r => r.data)
 export const getWhisperStats = () => api.get('/whisper/stats').then(r => r.data)
+export const submitWhisperJobWithTrack = (data: { file_path: string; language?: string; audio_track_index?: number | null }) =>
+  api.post('/whisper/transcribe', data).then(r => r.data)
+
+// ─── Series Audio Track Preference ────────────────────────────────────────
+
+export async function getSeriesAudioPref(seriesId: number): Promise<import('@/lib/types').SeriesAudioPref> {
+  const { data } = await api.get(`/series/${seriesId}/audio-track-pref`)
+  return data
+}
+
+export async function setSeriesAudioPref(seriesId: number, trackIndex: number | null): Promise<import('@/lib/types').SeriesAudioPref> {
+  const { data } = await api.put(`/series/${seriesId}/audio-track-pref`, { preferred_audio_track_index: trackIndex })
+  return data
+}
 
 // ─── Standalone Mode ──────────────────────────────────────────────────────
 

--- a/frontend/src/components/series/SeriesAudioTrackPicker.tsx
+++ b/frontend/src/components/series/SeriesAudioTrackPicker.tsx
@@ -1,0 +1,174 @@
+/**
+ * SeriesAudioTrackPicker — lets users pin a preferred audio track index for a series.
+ *
+ * Loads audio tracks from the first available episode, then lets the user pick
+ * one (or clear the preference back to "auto"). The picked index is stored via
+ * PUT /series/<id>/audio-track-pref and used by the Whisper transcription queue.
+ */
+
+import { useState } from 'react'
+import { Loader2, Music } from 'lucide-react'
+import { useQuery } from '@tanstack/react-query'
+import { listEpisodeTracks } from '@/api/client'
+import { useSeriesAudioPref, useSetSeriesAudioPref } from '@/hooks/useApi'
+import type { EpisodeInfo } from '@/lib/types'
+
+interface Props {
+  seriesId: number
+  episodes: EpisodeInfo[]
+}
+
+export function SeriesAudioTrackPicker({ seriesId, episodes }: Props) {
+  const [open, setOpen] = useState(false)
+
+  const firstEpId = episodes.find(e => e.id != null)?.id ?? null
+
+  const { data: pref, isLoading: prefLoading } = useSeriesAudioPref(seriesId)
+  const setAudioPref = useSetSeriesAudioPref(seriesId)
+
+  const { data: tracksData, isLoading: tracksLoading } = useQuery({
+    queryKey: ['episode-tracks', firstEpId],
+    queryFn: () => listEpisodeTracks(firstEpId!),
+    enabled: firstEpId != null && open,
+  })
+
+  const audioTracks = tracksData?.tracks.filter(t => t.codec_type === 'audio') ?? []
+  const currentIndex = pref?.preferred_audio_track_index ?? null
+
+  function label() {
+    if (prefLoading) return '…'
+    if (currentIndex === null) return 'Auto'
+    const track = audioTracks.find(t => t.sub_index === currentIndex)
+    if (track) return trackLabel(track.sub_index, track.language, track.title)
+    return `Track ${currentIndex}`
+  }
+
+  function trackLabel(subIndex: number, language: string, title: string) {
+    const parts: string[] = [`#${subIndex}`]
+    if (language) parts.push(language.toUpperCase())
+    if (title) parts.push(title)
+    return parts.join(' · ')
+  }
+
+  function handleSelect(value: number | null) {
+    setAudioPref.mutate(value, { onSuccess: () => setOpen(false) })
+  }
+
+  if (firstEpId == null) return null
+
+  return (
+    <div style={{ position: 'relative', display: 'inline-block' }}>
+      <button
+        onClick={() => setOpen(v => !v)}
+        className="inline-flex items-center gap-1.5 px-2 py-1 rounded transition-colors"
+        style={{
+          backgroundColor: currentIndex !== null ? 'var(--accent-bg)' : 'rgba(255,255,255,0.06)',
+          color: currentIndex !== null ? 'var(--accent)' : 'var(--text-secondary)',
+          cursor: 'pointer',
+          fontSize: '0.7rem',
+          fontWeight: 500,
+        }}
+        title="Preferred audio track for Whisper transcription"
+        onMouseEnter={(e) => {
+          if (currentIndex === null) e.currentTarget.style.backgroundColor = 'var(--bg-surface-hover)'
+        }}
+        onMouseLeave={(e) => {
+          if (currentIndex === null) e.currentTarget.style.backgroundColor = 'rgba(255,255,255,0.06)'
+        }}
+      >
+        <Music size={11} />
+        Audio: {label()}
+      </button>
+
+      {open && (
+        <>
+          {/* backdrop */}
+          <div
+            style={{ position: 'fixed', inset: 0, zIndex: 49 }}
+            onClick={() => setOpen(false)}
+          />
+          <div
+            style={{
+              position: 'absolute',
+              top: '100%',
+              left: 0,
+              zIndex: 50,
+              marginTop: 4,
+              minWidth: 180,
+              backgroundColor: 'var(--bg-surface)',
+              border: '1px solid rgba(255,255,255,0.1)',
+              borderRadius: 6,
+              padding: '4px 0',
+              boxShadow: '0 4px 16px rgba(0,0,0,0.4)',
+            }}
+          >
+            {tracksLoading && (
+              <div className="flex items-center gap-2 px-3 py-2" style={{ color: 'var(--text-secondary)', fontSize: '0.75rem' }}>
+                <Loader2 size={12} className="animate-spin" /> Loading tracks…
+              </div>
+            )}
+
+            {!tracksLoading && (
+              <>
+                <DropdownItem
+                  active={currentIndex === null}
+                  label="Auto (by language)"
+                  onClick={() => handleSelect(null)}
+                  pending={setAudioPref.isPending}
+                />
+                {audioTracks.map(track => (
+                  <DropdownItem
+                    key={track.sub_index}
+                    active={currentIndex === track.sub_index}
+                    label={trackLabel(track.sub_index, track.language, track.title)}
+                    onClick={() => handleSelect(track.sub_index)}
+                    pending={setAudioPref.isPending}
+                  />
+                ))}
+                {audioTracks.length === 0 && (
+                  <div style={{ padding: '6px 12px', fontSize: '0.75rem', color: 'var(--text-secondary)' }}>
+                    No audio tracks found
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
+function DropdownItem({ active, label, onClick, pending }: {
+  active: boolean
+  label: string
+  onClick: () => void
+  pending: boolean
+}) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={pending}
+      style={{
+        display: 'block',
+        width: '100%',
+        textAlign: 'left',
+        padding: '5px 12px',
+        fontSize: '0.75rem',
+        color: active ? 'var(--accent)' : 'var(--text-primary)',
+        backgroundColor: active ? 'var(--accent-bg)' : 'transparent',
+        cursor: pending ? 'default' : 'pointer',
+        opacity: pending ? 0.6 : 1,
+        border: 'none',
+      }}
+      onMouseEnter={(e) => {
+        if (!active && !pending) e.currentTarget.style.backgroundColor = 'var(--bg-surface-hover)'
+      }}
+      onMouseLeave={(e) => {
+        if (!active) e.currentTarget.style.backgroundColor = 'transparent'
+      }}
+    >
+      {label}
+    </button>
+  )
+}

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -22,6 +22,7 @@ import {
   getMediaServerTypes, getMediaServerInstances, saveMediaServerInstances, testMediaServer, getMediaServerHealth,
   getWhisperBackends, testWhisperBackend, getWhisperBackendConfig, saveWhisperBackendConfig,
   getWhisperConfig, saveWhisperConfig, getWhisperQueue, getWhisperStats,
+  getSeriesAudioPref, setSeriesAudioPref,
   getWatchedFolders, saveWatchedFolder, deleteWatchedFolder,
   getStandaloneSeries, getStandaloneMovies, triggerStandaloneScan,
   getStandaloneStatus, refreshSeriesMetadata,
@@ -882,6 +883,23 @@ export function useWhisperQueue(params?: { status?: string; limit?: number }) {
 }
 export function useWhisperStats() {
   return useQuery({ queryKey: ['whisper-stats'], queryFn: getWhisperStats })
+}
+
+// ─── Series Audio Track Preference ────────────────────────────────────────
+
+export function useSeriesAudioPref(seriesId: number) {
+  return useQuery({
+    queryKey: ['series-audio-pref', seriesId],
+    queryFn: () => getSeriesAudioPref(seriesId),
+  })
+}
+
+export function useSetSeriesAudioPref(seriesId: number) {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (trackIndex: number | null) => setSeriesAudioPref(seriesId, trackIndex),
+    onSuccess: () => { void qc.invalidateQueries({ queryKey: ['series-audio-pref', seriesId] }) },
+  })
 }
 
 // ─── Standalone Mode ──────────────────────────────────────────────────────

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -429,6 +429,7 @@ export interface WhisperJob {
   id: string
   file_path: string
   language: string
+  audio_track_index: number | null
   status: 'queued' | 'extracting' | 'loading' | 'transcribing' | 'saving' | 'completed' | 'failed' | 'cancelled'
   progress: number
   phase: string
@@ -443,6 +444,19 @@ export interface WhisperJob {
   created_at: string
   started_at: string
   completed_at: string
+}
+
+export interface AudioTrackInfo {
+  stream_index: number
+  language: string
+  codec: string
+  channels: number
+  title: string
+}
+
+export interface SeriesAudioPref {
+  series_id: number
+  preferred_audio_track_index: number | null
 }
 
 export interface WhisperConfig {

--- a/frontend/src/pages/SeriesDetail.tsx
+++ b/frontend/src/pages/SeriesDetail.tsx
@@ -24,6 +24,7 @@ import { HealthBadge } from '@/components/health/HealthBadge'
 import { SubtitleCleanupModal } from '@/components/shared/SubtitleCleanupModal'
 import type { EpisodeInfo, WantedSearchResponse, EpisodeHistoryEntry, SidecarSubtitle } from '@/lib/types'
 import { EpisodeActionMenu } from '@/components/episodes/EpisodeActionMenu'
+import { SeriesAudioTrackPicker } from '@/components/series/SeriesAudioTrackPicker'
 
 const SubtitleComparison = lazy(() => import('@/components/comparison/SubtitleComparison').then(m => ({ default: m.SubtitleComparison })))
 const SyncControls = lazy(() => import('@/components/sync/SyncControls').then(m => ({ default: m.SyncControls })))
@@ -1542,6 +1543,13 @@ export function SeriesDetailPage() {
               </button>
 
               {/* AniDB refresh button — shown only when absolute order is active */}
+              {seriesId != null && (
+                <SeriesAudioTrackPicker
+                  seriesId={seriesId}
+                  episodes={series.episodes ?? []}
+                />
+              )}
+
               {series.absolute_order && (
                 <button
                   onClick={handleRefreshAnidbMapping}


### PR DESCRIPTION
## Summary

- **DB migration** — adds `preferred_audio_track_index` (nullable int) to `series_settings` and `audio_track_index` to `whisper_jobs` via Alembic
- **Backend** — `GET/PUT /api/v1/series/<id>/audio-track-pref` endpoints via new `SeriesAudioRepository` + `series_audio` blueprint; `POST /whisper/transcribe` now accepts optional `audio_track_index`; WhisperQueue routes explicit index to `get_audio_track_by_index()`, None falls back to language-based `select_audio_track()`
- **Frontend** — `SeriesAudioTrackPicker` dropdown in SeriesDetail settings row; loads tracks from first episode; persists choice via the new preference API

## Test plan

- [ ] Backend tests green: `pytest tests/test_whisper_audio_track.py tests/test_series_audio_pref.py` (20 tests)
- [ ] Full suite: 470 passed, 0 new failures
- [ ] TypeScript: `tsc --noEmit` clean
- [ ] SeriesDetail shows "Audio: Auto" button; clicking opens dropdown with tracks from first episode
- [ ] Selecting a track saves it (button turns accent color); Whisper jobs for that series use the pinned track
- [ ] Setting back to "Auto" clears the preference