### PR TITLE
feat: v0.24.3 — Fansub Preference Rules

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -181,7 +181,7 @@ Goals: Select the correct audio track per series for Whisper transcription.
 
 ---
 
-## v0.24.3 — Fansub Preference Rules
+## ~~v0.24.3 — Fansub Preference Rules~~ Complete
 
 Goals: Per-series preferred fansub group ordering with score bonuses.
 

--- a/backend/db/migrations/versions/c3d4e5f6a7b8_add_fansub_preferences.py
+++ b/backend/db/migrations/versions/c3d4e5f6a7b8_add_fansub_preferences.py
@@ -1,0 +1,30 @@
+"""Add fansub_preferences table.
+
+Revision ID: c3d4e5f6a7b8
+Revises: e4f5a6b7c8d9
+Create Date: 2026-03-13
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "c3d4e5f6a7b8"
+down_revision = "e4f5a6b7c8d9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "fansub_preferences",
+        sa.Column("sonarr_series_id", sa.Integer(), nullable=False),
+        sa.Column("preferred_groups_json", sa.Text(), nullable=False, server_default="[]"),
+        sa.Column("excluded_groups_json", sa.Text(), nullable=False, server_default="[]"),
+        sa.Column("bonus", sa.Integer(), nullable=False, server_default="20"),
+        sa.Column("updated_at", sa.Text(), nullable=False),
+        sa.PrimaryKeyConstraint("sonarr_series_id"),
+    )
+
+
+def downgrade():
+    op.drop_table("fansub_preferences")

--- a/backend/db/models/core.py
+++ b/backend/db/models/core.py
@@ -261,6 +261,23 @@ class SeriesSettings(db.Model):
     updated_at: Mapped[str] = mapped_column(Text, nullable=False)
 
 
+class FansubPreference(db.Model):
+    """Per-series fansub group preferences for subtitle result scoring.
+
+    preferred_groups_json / excluded_groups_json: JSON-encoded list of group
+    name strings (case-insensitive substring match against result.release_info).
+    bonus: Score points added for preferred group hits; excluded hits get -999.
+    """
+
+    __tablename__ = "fansub_preferences"
+
+    sonarr_series_id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    preferred_groups_json: Mapped[str] = mapped_column(Text, nullable=False, default="[]")
+    excluded_groups_json: Mapped[str] = mapped_column(Text, nullable=False, default="[]")
+    bonus: Mapped[int] = mapped_column(Integer, nullable=False, default=20)
+    updated_at: Mapped[str] = mapped_column(Text, nullable=False)
+
+
 __all__ = [
     "Job",
     "DailyStats",
@@ -275,4 +292,5 @@ __all__ = [
     "FilterPreset",
     "AnidbAbsoluteMapping",
     "SeriesSettings",
+    "FansubPreference",
 ]

--- a/backend/db/repositories/fansub_prefs.py
+++ b/backend/db/repositories/fansub_prefs.py
@@ -1,0 +1,61 @@
+"""Repository for per-series fansub group preferences."""
+
+import json
+import logging
+
+from db.models.core import FansubPreference
+from db.repositories.base import BaseRepository
+
+logger = logging.getLogger(__name__)
+
+
+class FansubPreferenceRepository(BaseRepository):
+    """Read/write fansub group preferences for a series."""
+
+    def get_fansub_prefs(self, series_id: int) -> dict | None:
+        """Return fansub prefs for series_id, or None if not set."""
+        row = self.session.get(FansubPreference, series_id)
+        if row is None:
+            return None
+        return {
+            "series_id": series_id,
+            "preferred_groups": json.loads(row.preferred_groups_json),
+            "excluded_groups": json.loads(row.excluded_groups_json),
+            "bonus": row.bonus,
+        }
+
+    def set_fansub_prefs(
+        self,
+        series_id: int,
+        preferred: list[str],
+        excluded: list[str],
+        bonus: int,
+    ) -> None:
+        """Upsert fansub preferences for series_id."""
+        now = self._now()
+        existing = self.session.get(FansubPreference, series_id)
+        if existing:
+            existing.preferred_groups_json = json.dumps(preferred)
+            existing.excluded_groups_json = json.dumps(excluded)
+            existing.bonus = bonus
+            existing.updated_at = now
+        else:
+            self.session.add(
+                FansubPreference(
+                    sonarr_series_id=series_id,
+                    preferred_groups_json=json.dumps(preferred),
+                    excluded_groups_json=json.dumps(excluded),
+                    bonus=bonus,
+                    updated_at=now,
+                )
+            )
+        self._commit()
+        logger.debug("Series %d fansub prefs updated", series_id)
+
+    def delete_fansub_prefs(self, series_id: int) -> None:
+        """Remove fansub preferences row for series_id (no-op if absent)."""
+        row = self.session.get(FansubPreference, series_id)
+        if row:
+            self.session.delete(row)
+            self._commit()
+            logger.debug("Series %d fansub prefs deleted", series_id)

--- a/backend/routes/__init__.py
+++ b/backend/routes/__init__.py
@@ -13,6 +13,7 @@ def register_blueprints(app):
     from routes.blacklist import bp as blacklist_bp
     from routes.cleanup import bp as cleanup_bp
     from routes.config import bp as config_bp
+    from routes.fansub_prefs import bp as fansub_prefs_bp
     from routes.filter_presets import bp as filter_presets_bp
     from routes.hooks import bp as hooks_bp
     from routes.integrations import bp as integrations_bp
@@ -57,6 +58,7 @@ def register_blueprints(app):
         hooks_bp,
         tools_bp,
         search_bp,
+        fansub_prefs_bp,
         filter_presets_bp,
         api_keys_bp,
         notifications_mgmt_bp,

--- a/backend/routes/fansub_prefs.py
+++ b/backend/routes/fansub_prefs.py
@@ -1,0 +1,62 @@
+"""Fansub preference rules per series.
+
+GET  /api/v1/series/<id>/fansub-prefs  — read prefs (defaults if unset)
+PUT  /api/v1/series/<id>/fansub-prefs  — upsert prefs
+DELETE /api/v1/series/<id>/fansub-prefs — clear prefs
+"""
+
+from flask import Blueprint, jsonify, request
+
+from db.repositories.fansub_prefs import FansubPreferenceRepository
+
+bp = Blueprint("fansub_prefs", __name__, url_prefix="/api/v1/series")
+
+_DEFAULTS = {"preferred_groups": [], "excluded_groups": [], "bonus": 20}
+
+
+@bp.route("/<int:series_id>/fansub-prefs", methods=["GET"])
+def get_fansub_prefs(series_id: int):
+    """Return fansub preferences for a series (defaults if not configured)."""
+    prefs = FansubPreferenceRepository().get_fansub_prefs(series_id)
+    if prefs is None:
+        return jsonify({"series_id": series_id, **_DEFAULTS})
+    return jsonify(prefs)
+
+
+@bp.route("/<int:series_id>/fansub-prefs", methods=["PUT"])
+def set_fansub_prefs(series_id: int):
+    """Upsert fansub preferences for a series."""
+    data = request.get_json(force=True, silent=True) or {}
+
+    preferred = data.get("preferred_groups", [])
+    excluded = data.get("excluded_groups", [])
+    bonus = data.get("bonus", 20)
+
+    if not isinstance(preferred, list) or not all(isinstance(g, str) for g in preferred):
+        return jsonify({"error": "preferred_groups must be a list of strings"}), 400
+    if not isinstance(excluded, list) or not all(isinstance(g, str) for g in excluded):
+        return jsonify({"error": "excluded_groups must be a list of strings"}), 400
+    if not isinstance(bonus, int):
+        return jsonify({"error": "bonus must be an integer"}), 400
+
+    FansubPreferenceRepository().set_fansub_prefs(
+        series_id=series_id,
+        preferred=preferred,
+        excluded=excluded,
+        bonus=bonus,
+    )
+    return jsonify(
+        {
+            "series_id": series_id,
+            "preferred_groups": preferred,
+            "excluded_groups": excluded,
+            "bonus": bonus,
+        }
+    )
+
+
+@bp.route("/<int:series_id>/fansub-prefs", methods=["DELETE"])
+def delete_fansub_prefs(series_id: int):
+    """Remove fansub preferences for a series (resets to defaults)."""
+    FansubPreferenceRepository().delete_fansub_prefs(series_id)
+    return jsonify({"series_id": series_id, "deleted": True})

--- a/backend/tests/test_fansub_prefs.py
+++ b/backend/tests/test_fansub_prefs.py
@@ -55,3 +55,63 @@ class TestFansubPreferenceRepository:
         repo.set_fansub_prefs(series_id=103, preferred=["X"], excluded=[], bonus=5)
         repo.delete_fansub_prefs(series_id=103)
         assert repo.get_fansub_prefs(series_id=103) is None
+
+
+class TestFansubPrefsRoutes:
+    def test_get_unknown_series_returns_defaults(self, client):
+        r = client.get("/api/v1/series/999/fansub-prefs")
+        assert r.status_code == 200
+        data = r.get_json()
+        assert data["series_id"] == 999
+        assert data["preferred_groups"] == []
+        assert data["excluded_groups"] == []
+        assert data["bonus"] == 20
+
+    def test_put_sets_prefs(self, client):
+        r = client.put(
+            "/api/v1/series/42/fansub-prefs",
+            json={"preferred_groups": ["SubsPlease"], "excluded_groups": [], "bonus": 25},
+        )
+        assert r.status_code == 200
+        data = r.get_json()
+        assert data["preferred_groups"] == ["SubsPlease"]
+        assert data["bonus"] == 25
+
+    def test_get_after_put_returns_saved_prefs(self, client):
+        client.put(
+            "/api/v1/series/43/fansub-prefs",
+            json={
+                "preferred_groups": ["Erai-raws"],
+                "excluded_groups": ["HorribleSubs"],
+                "bonus": 15,
+            },
+        )
+        r = client.get("/api/v1/series/43/fansub-prefs")
+        assert r.status_code == 200
+        data = r.get_json()
+        assert data["preferred_groups"] == ["Erai-raws"]
+        assert data["excluded_groups"] == ["HorribleSubs"]
+
+    def test_put_invalid_bonus_rejected(self, client):
+        r = client.put(
+            "/api/v1/series/44/fansub-prefs",
+            json={"preferred_groups": [], "excluded_groups": [], "bonus": "bad"},
+        )
+        assert r.status_code == 400
+
+    def test_put_groups_must_be_lists(self, client):
+        r = client.put(
+            "/api/v1/series/45/fansub-prefs",
+            json={"preferred_groups": "SubsPlease", "excluded_groups": [], "bonus": 10},
+        )
+        assert r.status_code == 400
+
+    def test_delete_clears_prefs(self, client):
+        client.put(
+            "/api/v1/series/46/fansub-prefs",
+            json={"preferred_groups": ["X"], "excluded_groups": [], "bonus": 5},
+        )
+        r = client.delete("/api/v1/series/46/fansub-prefs")
+        assert r.status_code == 200
+        r2 = client.get("/api/v1/series/46/fansub-prefs")
+        assert r2.get_json()["preferred_groups"] == []

--- a/backend/tests/test_fansub_prefs.py
+++ b/backend/tests/test_fansub_prefs.py
@@ -1,4 +1,7 @@
+import pytest
+
 from db.models.core import FansubPreference
+from db.repositories.fansub_prefs import FansubPreferenceRepository
 
 
 class TestFansubPreferenceModel:
@@ -12,3 +15,43 @@ class TestFansubPreferenceModel:
 
     def test_tablename(self):
         assert FansubPreference.__tablename__ == "fansub_preferences"
+
+
+class TestFansubPreferenceRepository:
+    def test_get_returns_none_for_unknown_series(self, app_ctx):
+        repo = FansubPreferenceRepository()
+        assert repo.get_fansub_prefs(series_id=9001) is None
+
+    def test_set_and_get_roundtrip(self, app_ctx):
+        repo = FansubPreferenceRepository()
+        repo.set_fansub_prefs(
+            series_id=100,
+            preferred=["SubsPlease", "Erai-raws"],
+            excluded=["HorribleSubs"],
+            bonus=30,
+        )
+        result = repo.get_fansub_prefs(series_id=100)
+        assert result["preferred_groups"] == ["SubsPlease", "Erai-raws"]
+        assert result["excluded_groups"] == ["HorribleSubs"]
+        assert result["bonus"] == 30
+
+    def test_update_replaces_existing(self, app_ctx):
+        repo = FansubPreferenceRepository()
+        repo.set_fansub_prefs(series_id=101, preferred=["GroupA"], excluded=[], bonus=20)
+        repo.set_fansub_prefs(series_id=101, preferred=["GroupB"], excluded=[], bonus=10)
+        result = repo.get_fansub_prefs(series_id=101)
+        assert result["preferred_groups"] == ["GroupB"]
+        assert result["bonus"] == 10
+
+    def test_set_with_empty_lists(self, app_ctx):
+        repo = FansubPreferenceRepository()
+        repo.set_fansub_prefs(series_id=102, preferred=[], excluded=[], bonus=0)
+        result = repo.get_fansub_prefs(series_id=102)
+        assert result["preferred_groups"] == []
+        assert result["excluded_groups"] == []
+
+    def test_delete_removes_row(self, app_ctx):
+        repo = FansubPreferenceRepository()
+        repo.set_fansub_prefs(series_id=103, preferred=["X"], excluded=[], bonus=5)
+        repo.delete_fansub_prefs(series_id=103)
+        assert repo.get_fansub_prefs(series_id=103) is None

--- a/backend/tests/test_fansub_prefs.py
+++ b/backend/tests/test_fansub_prefs.py
@@ -1,0 +1,14 @@
+from db.models.core import FansubPreference
+
+
+class TestFansubPreferenceModel:
+    def test_model_has_required_columns(self):
+        cols = {c.key for c in FansubPreference.__table__.columns}
+        assert "sonarr_series_id" in cols
+        assert "preferred_groups_json" in cols
+        assert "excluded_groups_json" in cols
+        assert "bonus" in cols
+        assert "updated_at" in cols
+
+    def test_tablename(self):
+        assert FansubPreference.__tablename__ == "fansub_preferences"

--- a/backend/wanted_search.py
+++ b/backend/wanted_search.py
@@ -454,6 +454,29 @@ def _get_priority_key(result, target_lang, source_lang):
         return (3, -result["score"])  # Lowest priority: source.srt
 
 
+def _apply_fansub_rules(
+    results: list[dict],
+    preferred: list[str],
+    excluded: list[str],
+    bonus: int,
+) -> None:
+    """Adjust scores in-place based on fansub group preferences.
+
+    Performs case-insensitive substring matching against result["release_info"].
+    Preferred group match: +bonus points.
+    Excluded group match: -999 points (effectively removes from selection).
+    """
+    preferred_lower = [g.lower() for g in preferred]
+    excluded_lower = [g.lower() for g in excluded]
+
+    for result in results:
+        info = result.get("release_info", "").lower()
+        if any(g in info for g in excluded_lower):
+            result["score"] -= 999
+        elif any(g in info for g in preferred_lower):
+            result["score"] += bonus
+
+
 def search_wanted_item(item_id: int) -> dict:
     """Search providers for a single wanted item.
 
@@ -515,6 +538,20 @@ def search_wanted_item(item_id: int) -> dict:
     except Exception as e:
         logger.warning("Source SRT search failed for wanted %d: %s", item_id, e, exc_info=True)
         # Continue with other searches - don't fail entire operation
+
+    # Apply per-series fansub group preferences
+    series_id = item.get("sonarr_series_id")
+    if series_id:
+        from db.repositories.fansub_prefs import FansubPreferenceRepository
+
+        fansub = FansubPreferenceRepository().get_fansub_prefs(series_id)
+        if fansub:
+            _apply_fansub_rules(
+                all_results,
+                preferred=fansub["preferred_groups"],
+                excluded=fansub["excluded_groups"],
+                bonus=fansub["bonus"],
+            )
 
     # Sort by priority: target.ass > source.ass > target.srt > source.srt
     all_results.sort(key=lambda r: _get_priority_key(r, item_lang, source_lang))

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -19,6 +19,7 @@ import type {
   NotificationTemplate, NotificationHistoryEntry, QuietHoursConfig, TemplateVariable, NotificationFilter,
   DiskSpaceStats, ScanStatus, DuplicateGroup, OrphanedFile, CleanupRule, CleanupHistoryEntry, CleanupPreviewData,
   BazarrMappingReport, CompatBatchResult, ExtendedHealthAllResponse, ExportResult,
+  SeriesFansubPrefs,
 } from '@/lib/types'
 
 const api = axios.create({
@@ -1709,6 +1710,25 @@ export async function installBrowsePlugin(plugin: MarketplaceBrowsePlugin): Prom
 export async function uninstallBrowsePlugin(name: string): Promise<{ status: string }> {
   const { data } = await api.post('/marketplace/uninstall', { plugin_name: name })
   return data
+}
+
+// ─── Fansub Preferences ──────────────────────────────────────────────────────
+
+export async function getSeriesFansubPrefs(seriesId: number): Promise<SeriesFansubPrefs> {
+  const { data } = await api.get(`/series/${seriesId}/fansub-prefs`)
+  return data
+}
+
+export async function setSeriesFansubPrefs(
+  seriesId: number,
+  prefs: { preferred_groups: string[]; excluded_groups: string[]; bonus: number },
+): Promise<SeriesFansubPrefs> {
+  const { data } = await api.put(`/series/${seriesId}/fansub-prefs`, prefs)
+  return data
+}
+
+export async function deleteSeriesFansubPrefs(seriesId: number): Promise<void> {
+  await api.delete(`/series/${seriesId}/fansub-prefs`)
 }
 
 export default api

--- a/frontend/src/components/series/SeriesFansubPrefsPanel.tsx
+++ b/frontend/src/components/series/SeriesFansubPrefsPanel.tsx
@@ -1,0 +1,133 @@
+import React, { useState, useEffect } from 'react'
+import { useSeriesFansubPrefs, useSetSeriesFansubPrefs, useDeleteSeriesFansubPrefs } from '../../hooks/useApi'
+
+interface Props {
+  seriesId: number
+}
+
+export function SeriesFansubPrefsPanel({ seriesId }: Props) {
+  const { data: prefs, isLoading } = useSeriesFansubPrefs(seriesId)
+  const save = useSetSeriesFansubPrefs(seriesId)
+  const reset = useDeleteSeriesFansubPrefs(seriesId)
+
+  const [preferred, setPreferred] = useState('')
+  const [excluded, setExcluded] = useState('')
+  const [bonus, setBonus] = useState(20)
+
+  useEffect(() => {
+    if (!prefs) return
+    setPreferred(prefs.preferred_groups.join(', '))
+    setExcluded(prefs.excluded_groups.join(', '))
+    setBonus(prefs.bonus)
+  }, [prefs])
+
+  if (isLoading) return null
+
+  const parseGroups = (raw: string) =>
+    raw
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean)
+
+  function handleSave() {
+    save.mutate({
+      preferred_groups: parseGroups(preferred),
+      excluded_groups: parseGroups(excluded),
+      bonus,
+    })
+  }
+
+  function handleReset() {
+    reset.mutate(undefined, {
+      onSuccess: () => {
+        setPreferred('')
+        setExcluded('')
+        setBonus(20)
+      },
+    })
+  }
+
+  const inputStyle: React.CSSProperties = {
+    width: '100%',
+    padding: '6px 8px',
+    borderRadius: 4,
+    border: '1px solid var(--border)',
+    background: 'var(--bg-input)',
+    color: 'var(--text)',
+    fontSize: 13,
+    boxSizing: 'border-box',
+  }
+
+  const labelStyle: React.CSSProperties = {
+    display: 'block',
+    fontSize: 12,
+    color: 'var(--text-muted)',
+    marginBottom: 4,
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <div>
+        <label style={labelStyle}>Preferred Groups (comma-separated)</label>
+        <input
+          style={inputStyle}
+          value={preferred}
+          onChange={(e) => setPreferred(e.target.value)}
+          placeholder="SubsPlease, Erai-raws"
+        />
+      </div>
+      <div>
+        <label style={labelStyle}>Excluded Groups (comma-separated)</label>
+        <input
+          style={inputStyle}
+          value={excluded}
+          onChange={(e) => setExcluded(e.target.value)}
+          placeholder="HorribleSubs"
+        />
+      </div>
+      <div>
+        <label style={labelStyle}>Bonus Points for Preferred Groups</label>
+        <input
+          type="number"
+          style={{ ...inputStyle, width: 80 }}
+          value={bonus}
+          min={0}
+          max={999}
+          onChange={(e) => setBonus(Number(e.target.value))}
+        />
+      </div>
+      <div style={{ display: 'flex', gap: 8 }}>
+        <button
+          onClick={handleSave}
+          disabled={save.isPending}
+          style={{
+            padding: '6px 16px',
+            borderRadius: 4,
+            border: 'none',
+            background: 'var(--accent)',
+            color: '#fff',
+            cursor: 'pointer',
+            fontSize: 13,
+          }}
+        >
+          {save.isPending ? 'Saving\u2026' : 'Save'}
+        </button>
+        <button
+          onClick={handleReset}
+          disabled={reset.isPending}
+          style={{
+            padding: '6px 16px',
+            borderRadius: 4,
+            border: '1px solid var(--border)',
+            background: 'transparent',
+            color: 'var(--text-muted)',
+            cursor: 'pointer',
+            fontSize: 13,
+          }}
+        >
+          Reset to Defaults
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -69,6 +69,7 @@ import {
   batchTranslate,
   getMarketplaceBrowse, refreshMarketplace, getInstalledPlugins,
   installBrowsePlugin, uninstallBrowsePlugin,
+  getSeriesFansubPrefs, setSeriesFansubPrefs, deleteSeriesFansubPrefs,
 } from '@/api/client'
 import type {
   LanguageProfile, BackendConfig, MediaServerInstance, HookConfig, WebhookConfig, LogRotationConfig, FilterScope, BatchAction,
@@ -1931,6 +1932,36 @@ export function useRefreshMarketplaceBrowse() {
     mutationFn: refreshMarketplace,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['marketplace', 'browse'] })
+    },
+  })
+}
+
+// ─── Fansub Preferences ──────────────────────────────────────────────────────
+
+export function useSeriesFansubPrefs(seriesId: number) {
+  return useQuery({
+    queryKey: ['series-fansub-prefs', seriesId],
+    queryFn: () => getSeriesFansubPrefs(seriesId),
+  })
+}
+
+export function useSetSeriesFansubPrefs(seriesId: number) {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (prefs: { preferred_groups: string[]; excluded_groups: string[]; bonus: number }) =>
+      setSeriesFansubPrefs(seriesId, prefs),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ['series-fansub-prefs', seriesId] })
+    },
+  })
+}
+
+export function useDeleteSeriesFansubPrefs(seriesId: number) {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: () => deleteSeriesFansubPrefs(seriesId),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ['series-fansub-prefs', seriesId] })
     },
   })
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1161,3 +1161,12 @@ export interface ExportResult {
   content_type: string
   warnings: string[]
 }
+
+// ─── Fansub Preferences ──────────────────────────────────────────────────────
+
+export interface SeriesFansubPrefs {
+  series_id: number
+  preferred_groups: string[]
+  excluded_groups: string[]
+  bonus: number
+}

--- a/frontend/src/pages/SeriesDetail.tsx
+++ b/frontend/src/pages/SeriesDetail.tsx
@@ -24,6 +24,7 @@ import { HealthBadge } from '@/components/health/HealthBadge'
 import { SubtitleCleanupModal } from '@/components/shared/SubtitleCleanupModal'
 import type { EpisodeInfo, WantedSearchResponse, EpisodeHistoryEntry, SidecarSubtitle } from '@/lib/types'
 import { EpisodeActionMenu } from '@/components/episodes/EpisodeActionMenu'
+import { SeriesFansubPrefsPanel } from '@/components/series/SeriesFansubPrefsPanel'
 
 const SubtitleComparison = lazy(() => import('@/components/comparison/SubtitleComparison').then(m => ({ default: m.SubtitleComparison })))
 const SyncControls = lazy(() => import('@/components/sync/SyncControls').then(m => ({ default: m.SyncControls })))
@@ -1680,6 +1681,19 @@ export function SeriesDetailPage() {
           style={{ border: '1px solid var(--border)' }}
         >
           {seriesId !== null && <GlossaryPanel seriesId={seriesId} />}
+        </div>
+      )}
+
+      {/* Fansub Preferences Panel */}
+      {seriesId !== null && (
+        <div
+          className="rounded-lg overflow-hidden"
+          style={{ border: '1px solid var(--border)', padding: '16px' }}
+        >
+          <h3 style={{ fontSize: 13, fontWeight: 600, color: 'var(--text-muted)', marginBottom: 8, marginTop: 0 }}>
+            Fansub Preferences
+          </h3>
+          <SeriesFansubPrefsPanel seriesId={seriesId} />
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- New `fansub_preferences` DB table (PK: sonarr_series_id) with preferred groups, excluded groups, and bonus points per series
- `FansubPreferenceRepository` — get/set/delete with UPSERT pattern
- `GET/PUT/DELETE /api/v1/series/<id>/fansub-prefs` endpoints (defaults returned for unset series)
- `_apply_fansub_rules()` in `wanted_search.py` — adjusts result scores before priority sort; case-insensitive substring match on `release_info`; preferred → +bonus, excluded → -999
- `SeriesFansubPrefsPanel` component in SeriesDetail — comma-separated group inputs + bonus field + Save/Reset

## Test plan
- [ ] Backend tests: `test_fansub_prefs.py` — model (2), repo (5), routes (6), scoring (6) = 19 tests
- [ ] `ruff check` + `ruff format --check` pass
- [ ] Frontend: `tsc --noEmit` clean
- [ ] CI green
- [ ] Manual: set preferred group "SubsPlease" for a series → verify wanted search boosts matching results