### PR TITLE
feat: v0.24.4 — Chapter-Aware Sync

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -192,7 +192,7 @@ Goals: Per-series preferred fansub group ordering with score bonuses.
 
 ---
 
-## v0.24.4 — Chapter-Aware Sync
+## ~~v0.24.4 — Chapter-Aware Sync~~ ✅ Complete
 
 Goals: Align subtitle timing to chapter markers in MKV files.
 

--- a/backend/chapters.py
+++ b/backend/chapters.py
@@ -1,0 +1,96 @@
+"""Chapter extraction and caching for MKV/MP4 video files.
+
+Provides get_chapters(video_path) -> list of chapter dicts with millisecond timestamps.
+Results are cached in chapter_cache DB table (invalidated by file mtime).
+"""
+
+import json
+import logging
+import subprocess
+from datetime import datetime
+
+logger = logging.getLogger(__name__)
+
+
+def get_chapters(video_path: str) -> list[dict]:
+    """Return chapter list for a video file.
+
+    Checks chapter_cache first (mtime-validated). On miss, runs ffprobe and caches.
+    Returns [] if the file has no chapters or ffprobe is unavailable.
+    """
+    import os
+
+    try:
+        mtime = os.path.getmtime(video_path)
+    except OSError:
+        return []
+
+    cached = _get_cached(video_path, mtime)
+    if cached is not None:
+        return cached
+
+    chapters = _probe_chapters(video_path)
+    _set_cached(video_path, mtime, chapters)
+    return chapters
+
+
+def _probe_chapters(video_path: str) -> list[dict]:
+    """Run ffprobe -show_chapters and return normalized chapter list."""
+    try:
+        result = subprocess.run(
+            ["ffprobe", "-v", "quiet", "-print_format", "json", "-show_chapters", video_path],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        data = json.loads(result.stdout or "{}")
+        return [_normalize_chapter(c) for c in data.get("chapters", [])]
+    except Exception as exc:
+        logger.debug("Chapter probe failed for %s: %s", video_path, exc)
+        return []
+
+
+def _normalize_chapter(raw: dict) -> dict:
+    """Convert raw ffprobe chapter dict to {id, title, start_ms, end_ms}."""
+    idx = raw["id"]
+    title = raw.get("tags", {}).get("title") or f"Chapter {idx + 1}"
+    return {
+        "id": idx,
+        "title": title,
+        "start_ms": int(float(raw["start_time"]) * 1000),
+        "end_ms": int(float(raw["end_time"]) * 1000),
+    }
+
+
+def _get_cached(file_path: str, mtime: float) -> list[dict] | None:
+    """Return cached chapters if mtime matches, else None."""
+    from db.models.core import ChapterCache
+    from extensions import db
+
+    row = db.session.get(ChapterCache, file_path)
+    if row is None or row.mtime != mtime:
+        return None
+    return json.loads(row.chapters_json)
+
+
+def _set_cached(file_path: str, mtime: float, chapters: list[dict]) -> None:
+    """Write chapters to chapter_cache (upsert)."""
+    from db.models.core import ChapterCache
+    from extensions import db
+
+    now = datetime.utcnow().isoformat()
+    existing = db.session.get(ChapterCache, file_path)
+    if existing:
+        existing.mtime = mtime
+        existing.chapters_json = json.dumps(chapters)
+        existing.cached_at = now
+    else:
+        db.session.add(
+            ChapterCache(
+                file_path=file_path,
+                mtime=mtime,
+                chapters_json=json.dumps(chapters),
+                cached_at=now,
+            )
+        )
+    db.session.commit()

--- a/backend/db/migrations/versions/d4e5f6a7b8c9_add_chapter_cache.py
+++ b/backend/db/migrations/versions/d4e5f6a7b8c9_add_chapter_cache.py
@@ -1,0 +1,29 @@
+"""Add chapter_cache table for per-video chapter list caching.
+
+Revision ID: d4e5f6a7b8c9
+Revises: e4f5a6b7c8d9
+Create Date: 2026-03-13
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "d4e5f6a7b8c9"
+down_revision = "e4f5a6b7c8d9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "chapter_cache",
+        sa.Column("file_path", sa.Text(), nullable=False),
+        sa.Column("mtime", sa.Float(), nullable=False),
+        sa.Column("chapters_json", sa.Text(), nullable=False, server_default="[]"),
+        sa.Column("cached_at", sa.Text(), nullable=False),
+        sa.PrimaryKeyConstraint("file_path"),
+    )
+
+
+def downgrade():
+    op.drop_table("chapter_cache")

--- a/backend/db/models/core.py
+++ b/backend/db/models/core.py
@@ -185,6 +185,21 @@ class FfprobeCache(db.Model):
     __table_args__ = (Index("idx_ffprobe_cache_mtime", "mtime"),)
 
 
+class ChapterCache(db.Model):
+    """Per-video chapter list cache, invalidated by file mtime.
+
+    chapters_json: JSON-encoded list of {"id", "title", "start_ms", "end_ms"} dicts.
+    Populated lazily when a video is opened in the sync UI.
+    """
+
+    __tablename__ = "chapter_cache"
+
+    file_path: Mapped[str] = mapped_column(Text, primary_key=True)
+    mtime: Mapped[float] = mapped_column(Float, nullable=False)
+    chapters_json: Mapped[str] = mapped_column(Text, nullable=False, default="[]")
+    cached_at: Mapped[str] = mapped_column(Text, nullable=False)
+
+
 class BlacklistEntry(db.Model):
     """Blacklisted subtitle provider results."""
 
@@ -271,6 +286,7 @@ __all__ = [
     "SeriesLanguageProfile",
     "MovieLanguageProfile",
     "FfprobeCache",
+    "ChapterCache",
     "BlacklistEntry",
     "FilterPreset",
     "AnidbAbsoluteMapping",

--- a/backend/routes/tools.py
+++ b/backend/routes/tools.py
@@ -10,6 +10,7 @@ import tempfile
 
 from flask import Blueprint, jsonify, request
 
+from chapters import get_chapters
 from security_utils import is_safe_path
 
 bp = Blueprint("tools", __name__, url_prefix="/api/v1/tools")
@@ -1695,6 +1696,7 @@ def advanced_sync():
     file_path = data.get("file_path", "")
     operation = data.get("operation", "")
     preview = data.get("preview", False)
+    chapter_range = data.get("chapter_range")
 
     if operation not in ("offset", "speed", "framerate"):
         return jsonify({"error": "operation must be one of: offset, speed, framerate"}), 400
@@ -1716,6 +1718,46 @@ def advanced_sync():
                     {"error": "offset_ms (integer) is required for offset operation"}
                 ), 400
             offset_ms = int(offset_ms)
+
+            if chapter_range:
+                cr_start = chapter_range.get("start_ms")
+                cr_end = chapter_range.get("end_ms")
+                if not isinstance(cr_start, (int, float)) or not isinstance(cr_end, (int, float)):
+                    return jsonify(
+                        {"error": "chapter_range must have start_ms and end_ms integers"}
+                    ), 400
+                cr_start = int(cr_start)
+                cr_end = int(cr_end)
+
+                in_range = [
+                    e for e in subs.events if not e.is_comment and cr_start <= e.start < cr_end
+                ]
+
+                if preview:
+                    return _chapter_range_preview(in_range, offset_ms, cr_start, cr_end)
+
+                _create_backup(abs_path)
+                for event in in_range:
+                    event.start += offset_ms
+                    event.end += offset_ms
+                subs.save(abs_path)
+                logger.info(
+                    "Chapter-range offset %dms [%d-%d ms] applied to %s (%d events)",
+                    offset_ms,
+                    cr_start,
+                    cr_end,
+                    abs_path,
+                    len(in_range),
+                )
+                return jsonify(
+                    {
+                        "status": "synced",
+                        "operation": "offset",
+                        "events": len(in_range),
+                        "offset_ms": offset_ms,
+                        "chapter_range": {"start_ms": cr_start, "end_ms": cr_end},
+                    }
+                )
 
             if preview:
                 return _sync_preview(
@@ -1867,6 +1909,70 @@ def _sync_preview(subs, apply_fn, operation, **params):
             **params,
         }
     )
+
+
+def _chapter_range_preview(in_range_events, offset_ms: int, cr_start: int, cr_end: int):
+    """Build a preview response showing before/after timing for chapter-range events."""
+    if not in_range_events:
+        return jsonify(
+            {
+                "status": "preview",
+                "operation": "offset",
+                "offset_ms": offset_ms,
+                "chapter_range": {"start_ms": cr_start, "end_ms": cr_end},
+                "events": [],
+            }
+        )
+
+    # Sample up to 5 representative events
+    n = len(in_range_events)
+    indices = sorted({0, n // 4, n // 2, 3 * n // 4, n - 1})
+    sampled = [in_range_events[i] for i in indices]
+
+    events = []
+    for ev in sampled:
+        events.append(
+            {
+                "index": in_range_events.index(ev),
+                "text": (ev.plaintext or "")[:60],
+                "before": {"start": ev.start, "end": ev.end},
+                "after": {"start": ev.start + offset_ms, "end": ev.end + offset_ms},
+            }
+        )
+
+    return jsonify(
+        {
+            "status": "preview",
+            "operation": "offset",
+            "offset_ms": offset_ms,
+            "chapter_range": {"start_ms": cr_start, "end_ms": cr_end},
+            "events": events,
+        }
+    )
+
+
+# -- Chapters ------------------------------------------------------------------
+
+
+@bp.route("/chapters", methods=["GET"])
+def get_video_chapters():
+    """Return chapter list for a video file.
+
+    Query params:
+        video_path (str, required): Absolute path to the video file.
+    """
+    from config import get_settings
+
+    video_path = request.args.get("video_path", "")
+    if not video_path:
+        return jsonify({"error": "video_path query parameter is required"}), 400
+
+    settings = get_settings()
+    if not is_safe_path(video_path, settings.media_path):
+        return jsonify({"error": "video_path is outside media directory"}), 403
+
+    chapters = get_chapters(video_path)
+    return jsonify({"video_path": video_path, "chapters": chapters})
 
 
 # -- Compare -------------------------------------------------------------------

--- a/backend/tests/test_chapters.py
+++ b/backend/tests/test_chapters.py
@@ -1,3 +1,7 @@
+import json
+from datetime import datetime
+from unittest.mock import patch
+
 from db.models.core import ChapterCache
 
 
@@ -11,3 +15,214 @@ class TestChapterCacheModel:
         assert "mtime" in cols
         assert "chapters_json" in cols
         assert "cached_at" in cols
+
+
+class TestNormalizeChapter:
+    def test_full_fields(self):
+        from chapters import _normalize_chapter
+
+        raw = {
+            "id": 0,
+            "start_time": "0.000000",
+            "end_time": "90.500000",
+            "tags": {"title": "Opening"},
+        }
+        result = _normalize_chapter(raw)
+        assert result == {
+            "id": 0,
+            "title": "Opening",
+            "start_ms": 0,
+            "end_ms": 90500,
+        }
+
+    def test_missing_title_uses_fallback(self):
+        from chapters import _normalize_chapter
+
+        raw = {"id": 2, "start_time": "300.000", "end_time": "600.000", "tags": {}}
+        result = _normalize_chapter(raw)
+        assert result["title"] == "Chapter 3"
+
+    def test_no_tags_key(self):
+        from chapters import _normalize_chapter
+
+        raw = {"id": 0, "start_time": "0.0", "end_time": "30.0"}
+        result = _normalize_chapter(raw)
+        assert result["title"] == "Chapter 1"
+        assert result["start_ms"] == 0
+        assert result["end_ms"] == 30000
+
+
+class TestProbeChapters:
+    def test_parses_ffprobe_output(self):
+        from chapters import _probe_chapters
+
+        fake_output = '{"chapters": [{"id": 0, "start_time": "0.000", "end_time": "90.000", "tags": {"title": "OP"}}]}'
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.stdout = fake_output
+            mock_run.return_value.returncode = 0
+            result = _probe_chapters("/fake/video.mkv")
+        assert len(result) == 1
+        assert result[0]["title"] == "OP"
+        assert result[0]["end_ms"] == 90000
+
+    def test_returns_empty_list_when_no_chapters(self):
+        from chapters import _probe_chapters
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.stdout = '{"chapters": []}'
+            mock_run.return_value.returncode = 0
+            result = _probe_chapters("/fake/video.mkv")
+        assert result == []
+
+    def test_returns_empty_on_ffprobe_failure(self):
+        from chapters import _probe_chapters
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.stdout = ""
+            mock_run.return_value.returncode = 1
+            result = _probe_chapters("/fake/video.mkv")
+        assert result == []
+
+
+class TestGetChapters:
+    def test_returns_cached_result(self, app_ctx, tmp_path):
+        """get_chapters returns DB-cached chapters without calling ffprobe."""
+        from chapters import get_chapters
+        from extensions import db
+
+        video = tmp_path / "ep.mkv"
+        video.write_bytes(b"fake")
+        chapters = [{"id": 0, "title": "OP", "start_ms": 0, "end_ms": 90000}]
+
+        row = ChapterCache(
+            file_path=str(video),
+            mtime=video.stat().st_mtime,
+            chapters_json=json.dumps(chapters),
+            cached_at=datetime.utcnow().isoformat(),
+        )
+        db.session.add(row)
+        db.session.commit()
+
+        with patch("chapters._probe_chapters") as mock_probe:
+            result = get_chapters(str(video))
+        mock_probe.assert_not_called()
+        assert result == chapters
+
+    def test_probes_when_cache_miss(self, app_ctx, tmp_path):
+        from chapters import get_chapters
+
+        video = tmp_path / "ep2.mkv"
+        video.write_bytes(b"fake")
+        fake_chapters = [{"id": 0, "title": "A", "start_ms": 0, "end_ms": 5000}]
+
+        with patch("chapters._probe_chapters", return_value=fake_chapters) as mock_probe:
+            result = get_chapters(str(video))
+        mock_probe.assert_called_once_with(str(video))
+        assert result == fake_chapters
+
+    def test_probes_when_mtime_changed(self, app_ctx, tmp_path):
+        from chapters import get_chapters
+        from extensions import db
+
+        video = tmp_path / "ep3.mkv"
+        video.write_bytes(b"fake")
+
+        # Cache with stale mtime
+        row = ChapterCache(
+            file_path=str(video),
+            mtime=0.0,  # wrong mtime
+            chapters_json=json.dumps([]),
+            cached_at=datetime.utcnow().isoformat(),
+        )
+        db.session.add(row)
+        db.session.commit()
+
+        fresh = [{"id": 0, "title": "Fresh", "start_ms": 0, "end_ms": 1000}]
+        with patch("chapters._probe_chapters", return_value=fresh):
+            result = get_chapters(str(video))
+        assert result == fresh
+
+
+class TestGetChaptersEndpoint:
+    def test_get_chapters_returns_list(self, client, tmp_path, monkeypatch):
+        video = tmp_path / "ep.mkv"
+        video.write_bytes(b"fake")
+        fake_chapters = [
+            {"id": 0, "title": "Opening", "start_ms": 0, "end_ms": 90000},
+            {"id": 1, "title": "Main", "start_ms": 90000, "end_ms": 1350000},
+        ]
+        monkeypatch.setattr("routes.tools.get_chapters", lambda p: fake_chapters)
+        monkeypatch.setattr("routes.tools.is_safe_path", lambda p, b: True)
+
+        r = client.get(f"/api/v1/tools/chapters?video_path={video}")
+        assert r.status_code == 200
+        data = r.get_json()
+        assert "chapters" in data
+        assert len(data["chapters"]) == 2
+        assert data["chapters"][0]["title"] == "Opening"
+
+    def test_get_chapters_missing_param(self, client):
+        r = client.get("/api/v1/tools/chapters")
+        assert r.status_code == 400
+
+    def test_get_chapters_unsafe_path_rejected(self, client, monkeypatch):
+        monkeypatch.setattr("routes.tools.is_safe_path", lambda p, b: False)
+        r = client.get("/api/v1/tools/chapters?video_path=/etc/passwd")
+        assert r.status_code == 403
+
+
+class TestAdvancedSyncChapterRange:
+    def test_offset_with_chapter_range_only_shifts_in_range(self, client, tmp_path, monkeypatch):
+        sub = tmp_path / "ep.de.srt"
+        sub.write_text(
+            "1\n00:00:01,000 --> 00:00:02,000\nIn chapter\n\n"
+            "2\n00:05:00,000 --> 00:05:01,000\nOutside chapter\n"
+        )
+        monkeypatch.setattr("routes.tools.is_safe_path", lambda p, b: True)
+
+        r = client.post(
+            "/api/v1/tools/advanced-sync",
+            json={
+                "file_path": str(sub),
+                "operation": "offset",
+                "offset_ms": 500,
+                "chapter_range": {"start_ms": 0, "end_ms": 60000},
+            },
+        )
+        assert r.status_code == 200
+        data = r.get_json()
+        assert data["status"] == "synced"
+        assert data["chapter_range"] == {"start_ms": 0, "end_ms": 60000}
+
+        import pysubs2
+
+        result = pysubs2.load(str(sub))
+        assert result[0].start == 1500  # shifted: 1000 + 500
+        assert result[1].start == 300000  # unchanged: 5*60*1000
+
+    def test_offset_chapter_range_preview_returns_in_range_events(
+        self, client, tmp_path, monkeypatch
+    ):
+        sub = tmp_path / "ep2.de.srt"
+        sub.write_text(
+            "1\n00:00:01,000 --> 00:00:02,000\nIn chapter\n\n"
+            "2\n00:05:00,000 --> 00:05:01,000\nOutside\n"
+        )
+        monkeypatch.setattr("routes.tools.is_safe_path", lambda p, b: True)
+
+        r = client.post(
+            "/api/v1/tools/advanced-sync",
+            json={
+                "file_path": str(sub),
+                "operation": "offset",
+                "offset_ms": 200,
+                "chapter_range": {"start_ms": 0, "end_ms": 60000},
+                "preview": True,
+            },
+        )
+        assert r.status_code == 200
+        data = r.get_json()
+        assert data["status"] == "preview"
+        texts = [e["text"] for e in data["events"]]
+        assert any("In chapter" in t for t in texts)
+        assert not any("Outside" in t for t in texts)

--- a/backend/tests/test_chapters.py
+++ b/backend/tests/test_chapters.py
@@ -1,0 +1,13 @@
+from db.models.core import ChapterCache
+
+
+class TestChapterCacheModel:
+    def test_tablename(self):
+        assert ChapterCache.__tablename__ == "chapter_cache"
+
+    def test_has_required_columns(self):
+        cols = {c.key for c in ChapterCache.__table__.columns}
+        assert "file_path" in cols
+        assert "mtime" in cols
+        assert "chapters_json" in cols
+        assert "cached_at" in cols

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -19,6 +19,7 @@ import type {
   NotificationTemplate, NotificationHistoryEntry, QuietHoursConfig, TemplateVariable, NotificationFilter,
   DiskSpaceStats, ScanStatus, DuplicateGroup, OrphanedFile, CleanupRule, CleanupHistoryEntry, CleanupPreviewData,
   BazarrMappingReport, CompatBatchResult, ExtendedHealthAllResponse, ExportResult,
+  ChapterList,
 } from '@/lib/types'
 
 const api = axios.create({
@@ -1489,6 +1490,13 @@ export async function getSyncJobStatus(jobId: string): Promise<{
   error?: string
 }> {
   const { data } = await api.get(`/tools/video-sync/${jobId}`)
+  return data
+}
+
+export async function getVideoChapters(videoPath: string): Promise<ChapterList> {
+  const { data } = await api.get('/tools/chapters', {
+    params: { video_path: videoPath },
+  })
   return data
 }
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -900,13 +900,15 @@ export async function advancedSync(
   filePath: string,
   operation: 'offset' | 'speed' | 'framerate',
   params: Record<string, number>,
-  preview?: boolean
+  preview?: boolean,
+  chapterRange?: { start_ms: number; end_ms: number }
 ): Promise<SyncResult | SyncPreviewResult> {
   const { data } = await api.post('/tools/advanced-sync', {
     file_path: filePath,
     operation,
     ...params,
     preview: preview ?? false,
+    ...(chapterRange ? { chapter_range: chapterRange } : {}),
   })
   return data
 }

--- a/frontend/src/components/sync/SyncControls.tsx
+++ b/frontend/src/components/sync/SyncControls.tsx
@@ -1,32 +1,44 @@
 /**
- * Timing sync UI with offset, speed, and framerate controls.
+ * Timing sync UI with offset, speed, framerate, and chapter controls.
  *
- * Three operation tabs allow adjusting subtitle timing via:
+ * Four operation tabs allow adjusting subtitle timing via:
  * - Offset: shift all timestamps by N milliseconds
  * - Speed: multiply timing by a speed factor
  * - Framerate: convert between frame rates (e.g., 23.976 -> 25)
+ * - Chapter: apply an offset restricted to a single chapter's time range
  *
  * Preview mode shows before/after timestamps before applying changes.
  */
 
 import { useState } from 'react'
 import { Timer, X, Loader2, Check, Eye } from 'lucide-react'
-import { useAdvancedSync } from '@/hooks/useApi'
+import { useAdvancedSync, useVideoChapters } from '@/hooks/useApi'
 import { SyncPreview } from './SyncPreview'
 import { toast } from '@/components/shared/Toast'
-import type { SyncPreviewResult, SyncPreviewEvent } from '@/lib/types'
+import type { SyncPreviewResult, SyncPreviewEvent, Chapter } from '@/lib/types'
 
-type SyncOperation = 'offset' | 'speed' | 'framerate'
+type SyncOperation = 'offset' | 'speed' | 'framerate' | 'chapter'
 
 const COMMON_FRAMERATES = [23.976, 24, 25, 29.97, 30]
 
 interface SyncControlsProps {
   filePath: string
+  videoPath?: string
   onSynced?: () => void
   onClose?: () => void
 }
 
-export function SyncControls({ filePath, onSynced, onClose }: SyncControlsProps) {
+function _formatMs(ms: number): string {
+  const totalSec = Math.floor(ms / 1000)
+  const h = Math.floor(totalSec / 3600)
+  const m = Math.floor((totalSec % 3600) / 60)
+  const s = totalSec % 60
+  return h > 0
+    ? `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`
+    : `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`
+}
+
+export function SyncControls({ filePath, videoPath, onSynced, onClose }: SyncControlsProps) {
   const [activeTab, setActiveTab] = useState<SyncOperation>('offset')
   const [offsetMs, setOffsetMs] = useState(0)
   const [speedFactor, setSpeedFactor] = useState(1.0)
@@ -35,6 +47,10 @@ export function SyncControls({ filePath, onSynced, onClose }: SyncControlsProps)
   const [previewEvents, setPreviewEvents] = useState<SyncPreviewEvent[] | null>(null)
   const [previewOperation, setPreviewOperation] = useState('')
   const [showConfirm, setShowConfirm] = useState(false)
+
+  const { data: chapterData } = useVideoChapters(videoPath)
+  const chapters = chapterData?.chapters ?? []
+  const [selectedChapterId, setSelectedChapterId] = useState<number | null>(null)
 
   const syncMutation = useAdvancedSync()
 
@@ -48,13 +64,15 @@ export function SyncControls({ filePath, onSynced, onClose }: SyncControlsProps)
         return { speed_factor: speedFactor }
       case 'framerate':
         return { in_fps: inFps, out_fps: outFps }
+      case 'chapter':
+        return { offset_ms: offsetMs }
     }
   }
 
   const handlePreview = () => {
     setPreviewEvents(null)
     syncMutation.mutate(
-      { filePath, operation: activeTab, params: getParams(), preview: true },
+      { filePath, operation: activeTab === 'chapter' ? 'offset' : activeTab, params: getParams(), preview: true },
       {
         onSuccess: (data) => {
           const result = data as SyncPreviewResult
@@ -70,7 +88,7 @@ export function SyncControls({ filePath, onSynced, onClose }: SyncControlsProps)
 
   const handleApply = () => {
     syncMutation.mutate(
-      { filePath, operation: activeTab, params: getParams(), preview: false },
+      { filePath, operation: activeTab === 'chapter' ? 'offset' : activeTab, params: getParams(), preview: false },
       {
         onSuccess: () => {
           toast('Sync applied successfully')
@@ -86,7 +104,58 @@ export function SyncControls({ filePath, onSynced, onClose }: SyncControlsProps)
     )
   }
 
-  const tabs: { key: SyncOperation; label: string }[] = [
+  function handleChapterPreview() {
+    const chapter = chapters.find((c: Chapter) => c.id === selectedChapterId)
+    if (!chapter) return
+    syncMutation.mutate(
+      {
+        filePath,
+        operation: 'offset',
+        params: { offset_ms: offsetMs },
+        chapterRange: { start_ms: chapter.start_ms, end_ms: chapter.end_ms },
+        preview: true,
+      },
+      {
+        onSuccess: (data) => {
+          const result = data as SyncPreviewResult
+          setPreviewEvents(result.preview)
+          setPreviewOperation(result.operation)
+          setShowConfirm(false)
+        },
+        onError: () => {
+          toast('Chapter preview failed', 'error')
+        },
+      },
+    )
+  }
+
+  function handleChapterApply() {
+    const chapter = chapters.find((c: Chapter) => c.id === selectedChapterId)
+    if (!chapter) return
+    syncMutation.mutate(
+      {
+        filePath,
+        operation: 'offset',
+        params: { offset_ms: offsetMs },
+        chapterRange: { start_ms: chapter.start_ms, end_ms: chapter.end_ms },
+        preview: false,
+      },
+      {
+        onSuccess: () => {
+          toast('Chapter sync applied successfully')
+          setShowConfirm(false)
+          setPreviewEvents(null)
+          onSynced?.()
+        },
+        onError: () => {
+          toast('Chapter sync failed', 'error')
+          setShowConfirm(false)
+        },
+      },
+    )
+  }
+
+  const standardTabs: { key: SyncOperation; label: string }[] = [
     { key: 'offset', label: 'Offset' },
     { key: 'speed', label: 'Speed' },
     { key: 'framerate', label: 'Framerate' },
@@ -134,7 +203,7 @@ export function SyncControls({ filePath, onSynced, onClose }: SyncControlsProps)
         className="flex gap-1 px-4 py-2"
         style={{ borderBottom: '1px solid var(--border)' }}
       >
-        {tabs.map((tab) => (
+        {standardTabs.map((tab) => (
           <button
             key={tab.key}
             onClick={() => {
@@ -152,6 +221,23 @@ export function SyncControls({ filePath, onSynced, onClose }: SyncControlsProps)
             {tab.label}
           </button>
         ))}
+        {chapters.length > 0 && (
+          <button
+            onClick={() => {
+              setActiveTab('chapter')
+              setPreviewEvents(null)
+              setShowConfirm(false)
+            }}
+            className="px-3 py-1.5 rounded text-xs font-medium transition-colors"
+            style={{
+              backgroundColor: activeTab === 'chapter' ? 'var(--accent-bg)' : 'transparent',
+              color: activeTab === 'chapter' ? 'var(--accent)' : 'var(--text-muted)',
+              border: activeTab === 'chapter' ? '1px solid var(--accent-dim)' : '1px solid transparent',
+            }}
+          >
+            Chapter
+          </button>
+        )}
       </div>
 
       {/* Tab content */}
@@ -294,67 +380,200 @@ export function SyncControls({ filePath, onSynced, onClose }: SyncControlsProps)
           </div>
         )}
 
-        {/* Action buttons */}
-        <div className="flex items-center gap-2 pt-1">
-          <button
-            onClick={handlePreview}
-            disabled={syncMutation.isPending}
-            className="flex items-center gap-1.5 px-3 py-1.5 rounded text-xs font-medium transition-colors"
-            style={{
-              backgroundColor: 'var(--bg-primary)',
-              border: '1px solid var(--border)',
-              color: 'var(--text-secondary)',
-            }}
-          >
-            {syncMutation.isPending ? (
-              <Loader2 size={12} className="animate-spin" />
-            ) : (
-              <Eye size={12} />
-            )}
-            Preview
-          </button>
+        {activeTab === 'chapter' && (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+            <div>
+              <label style={{ display: 'block', fontSize: 12, color: 'var(--text-muted)', marginBottom: 4 }}>
+                Chapter
+              </label>
+              <select
+                value={selectedChapterId ?? ''}
+                onChange={(e) => setSelectedChapterId(e.target.value === '' ? null : Number(e.target.value))}
+                style={{
+                  width: '100%',
+                  padding: '6px 8px',
+                  borderRadius: 4,
+                  border: '1px solid var(--border)',
+                  background: 'var(--bg-primary)',
+                  color: 'var(--text-primary)',
+                  fontSize: 13,
+                }}
+              >
+                <option value="">Select chapter…</option>
+                {chapters.map((ch: Chapter) => (
+                  <option key={ch.id} value={ch.id}>
+                    {ch.title} ({_formatMs(ch.start_ms)} – {_formatMs(ch.end_ms)})
+                  </option>
+                ))}
+              </select>
+            </div>
 
-          {showConfirm ? (
-            <div className="flex items-center gap-2">
-              <span className="text-xs" style={{ color: 'var(--warning)' }}>
-                This will modify the file. A backup will be created.
-              </span>
+            <div>
+              <label style={{ display: 'block', fontSize: 12, color: 'var(--text-muted)', marginBottom: 4 }}>
+                Offset (ms)
+              </label>
+              <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+                <input
+                  type="number"
+                  value={offsetMs}
+                  onChange={(e) => setOffsetMs(Number(e.target.value))}
+                  style={{
+                    width: 90,
+                    padding: '6px 8px',
+                    borderRadius: 4,
+                    border: '1px solid var(--border)',
+                    background: 'var(--bg-primary)',
+                    color: 'var(--text-primary)',
+                    fontSize: 13,
+                    fontFamily: 'var(--font-mono)',
+                  }}
+                />
+                {[-500, -100, 100, 500].map((delta) => (
+                  <button
+                    key={delta}
+                    onClick={() => setOffsetMs((prev) => prev + delta)}
+                    style={{
+                      padding: '4px 8px',
+                      borderRadius: 4,
+                      border: '1px solid var(--border)',
+                      background: 'var(--bg-primary)',
+                      color: 'var(--text-secondary)',
+                      cursor: 'pointer',
+                      fontSize: 12,
+                    }}
+                  >
+                    {delta > 0 ? `+${delta}` : delta}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
               <button
-                onClick={handleApply}
-                disabled={syncMutation.isPending}
-                className="flex items-center gap-1.5 px-3 py-1.5 rounded text-xs font-medium text-white"
-                style={{ backgroundColor: 'var(--accent)' }}
+                disabled={selectedChapterId === null || syncMutation.isPending}
+                onClick={handleChapterPreview}
+                className="flex items-center gap-1.5 px-3 py-1.5 rounded text-xs font-medium transition-colors"
+                style={{
+                  backgroundColor: 'var(--bg-primary)',
+                  border: '1px solid var(--border)',
+                  color: 'var(--text-secondary)',
+                }}
               >
                 {syncMutation.isPending ? (
                   <Loader2 size={12} className="animate-spin" />
                 ) : (
-                  <Check size={12} />
+                  <Eye size={12} />
                 )}
-                Confirm
+                Preview
               </button>
-              <button
-                onClick={() => setShowConfirm(false)}
-                className="px-2 py-1.5 rounded text-xs"
-                style={{ color: 'var(--text-muted)' }}
-              >
-                Cancel
-              </button>
+
+              {showConfirm ? (
+                <div className="flex items-center gap-2">
+                  <span className="text-xs" style={{ color: 'var(--warning)' }}>
+                    This will modify the file. A backup will be created.
+                  </span>
+                  <button
+                    onClick={handleChapterApply}
+                    disabled={syncMutation.isPending}
+                    className="flex items-center gap-1.5 px-3 py-1.5 rounded text-xs font-medium text-white"
+                    style={{ backgroundColor: 'var(--accent)' }}
+                  >
+                    {syncMutation.isPending ? (
+                      <Loader2 size={12} className="animate-spin" />
+                    ) : (
+                      <Check size={12} />
+                    )}
+                    Confirm
+                  </button>
+                  <button
+                    onClick={() => setShowConfirm(false)}
+                    className="px-2 py-1.5 rounded text-xs"
+                    style={{ color: 'var(--text-muted)' }}
+                  >
+                    Cancel
+                  </button>
+                </div>
+              ) : (
+                <button
+                  disabled={selectedChapterId === null || syncMutation.isPending}
+                  onClick={() => setShowConfirm(true)}
+                  className="flex items-center gap-1.5 px-3 py-1.5 rounded text-xs font-medium text-white transition-opacity"
+                  style={{
+                    backgroundColor: 'var(--accent)',
+                    opacity: selectedChapterId === null || syncMutation.isPending ? 0.5 : 1,
+                  }}
+                >
+                  <Check size={12} />
+                  Apply
+                </button>
+              )}
             </div>
-          ) : (
+          </div>
+        )}
+
+        {/* Action buttons (offset / speed / framerate tabs only) */}
+        {activeTab !== 'chapter' && (
+          <div className="flex items-center gap-2 pt-1">
             <button
-              onClick={() => setShowConfirm(true)}
+              onClick={handlePreview}
               disabled={syncMutation.isPending}
-              className="flex items-center gap-1.5 px-3 py-1.5 rounded text-xs font-medium text-white transition-opacity"
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded text-xs font-medium transition-colors"
               style={{
-                backgroundColor: 'var(--accent)',
-                opacity: syncMutation.isPending ? 0.5 : 1,
+                backgroundColor: 'var(--bg-primary)',
+                border: '1px solid var(--border)',
+                color: 'var(--text-secondary)',
               }}
             >
-              <Check size={12} />
-              Apply
+              {syncMutation.isPending ? (
+                <Loader2 size={12} className="animate-spin" />
+              ) : (
+                <Eye size={12} />
+              )}
+              Preview
             </button>
-          )}
-        </div>
+
+            {showConfirm ? (
+              <div className="flex items-center gap-2">
+                <span className="text-xs" style={{ color: 'var(--warning)' }}>
+                  This will modify the file. A backup will be created.
+                </span>
+                <button
+                  onClick={handleApply}
+                  disabled={syncMutation.isPending}
+                  className="flex items-center gap-1.5 px-3 py-1.5 rounded text-xs font-medium text-white"
+                  style={{ backgroundColor: 'var(--accent)' }}
+                >
+                  {syncMutation.isPending ? (
+                    <Loader2 size={12} className="animate-spin" />
+                  ) : (
+                    <Check size={12} />
+                  )}
+                  Confirm
+                </button>
+                <button
+                  onClick={() => setShowConfirm(false)}
+                  className="px-2 py-1.5 rounded text-xs"
+                  style={{ color: 'var(--text-muted)' }}
+                >
+                  Cancel
+                </button>
+              </div>
+            ) : (
+              <button
+                onClick={() => setShowConfirm(true)}
+                disabled={syncMutation.isPending}
+                className="flex items-center gap-1.5 px-3 py-1.5 rounded text-xs font-medium text-white transition-opacity"
+                style={{
+                  backgroundColor: 'var(--accent)',
+                  opacity: syncMutation.isPending ? 0.5 : 1,
+                }}
+              >
+                <Check size={12} />
+                Apply
+              </button>
+            )}
+          </div>
+        )}
 
         {/* Preview results */}
         {previewEvents && (

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -69,6 +69,7 @@ import {
   batchTranslate,
   getMarketplaceBrowse, refreshMarketplace, getInstalledPlugins,
   installBrowsePlugin, uninstallBrowsePlugin,
+  getVideoChapters,
 } from '@/api/client'
 import type {
   LanguageProfile, BackendConfig, MediaServerInstance, HookConfig, WebhookConfig, LogRotationConfig, FilterScope, BatchAction,
@@ -1932,5 +1933,16 @@ export function useRefreshMarketplaceBrowse() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['marketplace', 'browse'] })
     },
+  })
+}
+
+// ─── v0.24.4 Chapter Sync ────────────────────────────────────────────────────
+
+export function useVideoChapters(videoPath: string | undefined) {
+  return useQuery({
+    queryKey: ['video-chapters', videoPath],
+    queryFn: () => getVideoChapters(videoPath!),
+    enabled: !!videoPath,
+    staleTime: 5 * 60 * 1000, // chapters rarely change — 5 min cache
   })
 }

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -1289,12 +1289,14 @@ export function useAdvancedSync() {
       operation,
       params,
       preview,
+      chapterRange,
     }: {
       filePath: string
       operation: 'offset' | 'speed' | 'framerate'
       params: Record<string, number>
       preview?: boolean
-    }) => advancedSync(filePath, operation, params, preview),
+      chapterRange?: { start_ms: number; end_ms: number }
+    }) => advancedSync(filePath, operation, params, preview, chapterRange),
   })
 }
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -826,6 +826,20 @@ export interface ComparisonResponse {
   panels: ComparisonPanel[]
 }
 
+// ─── Chapter Sync ────────────────────────────────────────────────────────────
+
+export interface Chapter {
+  id: number
+  title: string
+  start_ms: number
+  end_ms: number
+}
+
+export interface ChapterList {
+  video_path: string
+  chapters: Chapter[]
+}
+
 // ─── Sync ───────────────────────────────────────────────────────────────────
 
 export interface SyncPreviewEvent {


### PR DESCRIPTION
## Summary
- New `chapter_cache` DB table (PK: file_path, mtime-invalidated) caches chapter lists per video file
- `backend/chapters.py` — `get_chapters(video_path)` via ffprobe -show_chapters; result cached in ChapterCache
- `GET /api/v1/tools/chapters?video_path=...` — returns `{video_path, chapters: [{id, title, start_ms, end_ms}]}`
- `POST /api/v1/tools/advanced-sync` extended: optional `chapter_range: {start_ms, end_ms}` restricts offset to events within the chapter window; preview samples only in-range events
- `SyncControls` gains optional `videoPath` prop; "Chapter" tab appears when chapters are detected; chapter dropdown + ±offset presets + preview/confirm-apply

## Test plan
- [ ] Backend: `test_chapters.py` — model (2), utility (8), endpoint (3), advanced-sync chapter_range (2) = 15 tests
- [ ] `ruff check` + `ruff format --check` clean
- [ ] `tsc --noEmit` clean
- [ ] CI green
- [ ] Manual: open SyncControls on MKV with chapters → Chapter tab visible → select chapter → preview → apply → verify only in-chapter events shifted