### PR TITLE
feat: v0.25.2 — Subtitle Diff Viewer (per-cue accept/reject)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to Sublarr are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.25.2-beta] — 2026-03-13
+
+### Added
+- **Subtitle Diff Viewer — Per-cue accept/reject** — `POST /tools/diff` computes a cue-level diff using pysubs2 + difflib.SequenceMatcher; returns structured diff entries (unchanged/modified/added/removed) with timing in seconds. `POST /tools/diff/apply` recomputes the diff server-side, merges accepted/rejected changes into the modified SSAFile (preserving header and styles), creates a `.bak` backup, and writes atomically via `os.replace`. Frontend `SubtitleDiff.tsx` rewritten from CodeMirror merge view to a filterable per-cue table; users can accept or reject each change individually or via Accept All / Reject All; applying navigates back to preview and invalidates the subtitle-content cache.
+
+---
+
 ## [0.25.1-beta] — 2026-03-13
 
 ### Added

--- a/backend/routes/tools.py
+++ b/backend/routes/tools.py
@@ -2722,8 +2722,11 @@ def compute_diff():
     if not modified_content:
         return jsonify({"error": "modified content is required"}), 400
 
-    orig_subs = pysubs2.SSAFile.from_string(original_content)
-    mod_subs = pysubs2.SSAFile.from_string(modified_content)
+    try:
+        orig_subs = pysubs2.SSAFile.from_string(original_content)
+        mod_subs = pysubs2.SSAFile.from_string(modified_content)
+    except Exception as exc:
+        return jsonify({"error": f"Failed to parse subtitle content: {exc}"}), 400
 
     orig_events = [e for e in orig_subs.events if e.type == "Dialogue"]
     mod_events = [e for e in mod_subs.events if e.type == "Dialogue"]

--- a/backend/routes/tools.py
+++ b/backend/routes/tools.py
@@ -2766,3 +2766,140 @@ def compute_diff():
                 changed += 1
 
     return jsonify({"diffs": diffs, "total": len(diffs), "changed": changed})
+
+
+@bp.route("/diff/apply", methods=["POST"])
+def apply_diff():
+    """Apply a selective diff to a subtitle file on disk.
+
+    Accepts original and modified subtitle content plus a list of diff indices
+    to reject.  All non-rejected changes from *modified* are written back to
+    *file_path* using an atomic tempfile + os.replace.  A .bak backup is
+    created before the write.
+    ---
+    post:
+      summary: Apply diff to subtitle file
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [file_path, original, modified, rejected_indices]
+              properties:
+                file_path:
+                  type: string
+                original:
+                  type: string
+                modified:
+                  type: string
+                rejected_indices:
+                  type: array
+                  items:
+                    type: integer
+      responses:
+        200:
+          description: Applied successfully
+        400:
+          description: Missing or malformed input
+        403:
+          description: Path traversal denied
+        404:
+          description: File not found
+    """
+    import difflib
+
+    import pysubs2
+
+    from config import get_settings
+
+    data = request.get_json() or {}
+    file_path = data.get("file_path", "")
+    original_content = data.get("original", "")
+    modified_content = data.get("modified", "")
+    rejected_indices = data.get("rejected_indices") or []
+
+    if not file_path:
+        return jsonify({"error": "file_path is required"}), 400
+    if not original_content:
+        return jsonify({"error": "original content is required"}), 400
+    if not modified_content:
+        return jsonify({"error": "modified content is required"}), 400
+
+    settings = get_settings()
+    abs_path = os.path.abspath(file_path)
+    if not is_safe_path(abs_path, settings.media_path):
+        return jsonify({"error": "Access denied"}), 403
+    if not os.path.isfile(abs_path):
+        return jsonify({"error": "File not found"}), 404
+
+    try:
+        orig_subs = pysubs2.SSAFile.from_string(original_content)
+        mod_subs = pysubs2.SSAFile.from_string(modified_content)
+    except Exception as exc:
+        return jsonify({"error": f"Failed to parse subtitle content: {exc}"}), 400
+
+    orig_events = [e for e in orig_subs.events if e.type == "Dialogue"]
+    mod_events = [e for e in mod_subs.events if e.type == "Dialogue"]
+
+    matcher = difflib.SequenceMatcher(
+        None,
+        [e.plaintext for e in orig_events],
+        [e.plaintext for e in mod_events],
+        autojunk=False,
+    )
+
+    new_events = []
+    diff_index = 0
+    for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+        if tag == "equal":
+            for k in range(i2 - i1):
+                new_events.append(mod_events[j1 + k])
+        elif tag == "replace":
+            orig_slice = orig_events[i1:i2]
+            mod_slice = mod_events[j1:j2]
+            for k in range(max(len(orig_slice), len(mod_slice))):
+                if diff_index in rejected_indices:
+                    if k < len(orig_slice):
+                        new_events.append(orig_slice[k])
+                else:
+                    if k < len(mod_slice):
+                        new_events.append(mod_slice[k])
+                diff_index += 1
+        elif tag == "delete":
+            for k in range(i1, i2):
+                if diff_index in rejected_indices:
+                    new_events.append(orig_events[k])
+                diff_index += 1
+        elif tag == "insert":
+            for k in range(j1, j2):
+                if diff_index not in rejected_indices:
+                    new_events.append(mod_events[k])
+                diff_index += 1
+
+    # Build a new SSAFile — never mutate mod_subs directly
+    result_subs = pysubs2.SSAFile()
+    result_subs.info = mod_subs.info
+    result_subs.styles = mod_subs.styles
+    result_subs.events = new_events
+
+    # Determine output format from file extension
+    ext = os.path.splitext(abs_path)[1].lower().lstrip(".")
+    out_format = ext if ext in ("ass", "srt", "vtt") else "ass"
+    encode = "utf-8-sig" if out_format == "ass" else "utf-8"
+
+    # Create .bak backup before overwriting
+    bak_path = abs_path + ".bak"
+    shutil.copy2(abs_path, bak_path)
+
+    # Atomic write via tempfile + os.replace
+    tmp_fd, tmp_path_str = tempfile.mkstemp(dir=os.path.dirname(abs_path), suffix=f".{out_format}")
+    try:
+        with os.fdopen(tmp_fd, "w", encoding=encode) as fh:
+            fh.write(result_subs.to_string(out_format))
+        os.replace(tmp_path_str, abs_path)
+    except Exception:
+        os.unlink(tmp_path_str)
+        raise
+
+    return jsonify({"status": "applied", "file_path": abs_path, "backup": bak_path})

--- a/backend/routes/tools.py
+++ b/backend/routes/tools.py
@@ -2659,3 +2659,107 @@ def _get_waveform_duration(video_path: str) -> float:
         return float(data.get("format", {}).get("duration", 0))
     except Exception:
         return 0.0
+
+
+# -- Diff ----------------------------------------------------------------------
+
+
+@bp.route("/diff", methods=["POST"])
+def compute_diff():
+    """Compute a cue-level diff between two subtitle file contents.
+    ---
+    post:
+      summary: Diff two subtitle files
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [original, modified]
+              properties:
+                original:
+                  type: string
+                  description: Original subtitle file content (ASS/SRT string)
+                modified:
+                  type: string
+                  description: Modified subtitle file content (ASS/SRT string)
+      responses:
+        200:
+          description: Diff result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  diffs:
+                    type: array
+                  total:
+                    type: integer
+                  changed:
+                    type: integer
+        400:
+          description: Missing required field
+    """
+    import difflib
+
+    import pysubs2
+
+    def _cue_to_dict(event):
+        return {
+            "start": event.start / 1000.0,
+            "end": event.end / 1000.0,
+            "text": event.plaintext,
+            "style": event.style,
+        }
+
+    data = request.get_json() or {}
+    original_content = data.get("original", "")
+    modified_content = data.get("modified", "")
+
+    if not original_content:
+        return jsonify({"error": "original content is required"}), 400
+    if not modified_content:
+        return jsonify({"error": "modified content is required"}), 400
+
+    orig_subs = pysubs2.SSAFile.from_string(original_content)
+    mod_subs = pysubs2.SSAFile.from_string(modified_content)
+
+    orig_events = [e for e in orig_subs.events if e.type == "Dialogue"]
+    mod_events = [e for e in mod_subs.events if e.type == "Dialogue"]
+
+    matcher = difflib.SequenceMatcher(
+        None,
+        [e.plaintext for e in orig_events],
+        [e.plaintext for e in mod_events],
+        autojunk=False,
+    )
+
+    diffs = []
+    changed = 0
+    for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+        if tag == "equal":
+            for k in range(i2 - i1):
+                diffs.append({
+                    "type": "unchanged",
+                    "original": _cue_to_dict(orig_events[i1 + k]),
+                    "modified": _cue_to_dict(mod_events[j1 + k]),
+                })
+        elif tag == "replace":
+            orig_slice = orig_events[i1:i2]
+            mod_slice = mod_events[j1:j2]
+            for k in range(max(len(orig_slice), len(mod_slice))):
+                orig_cue = _cue_to_dict(orig_slice[k]) if k < len(orig_slice) else None
+                mod_cue = _cue_to_dict(mod_slice[k]) if k < len(mod_slice) else None
+                diffs.append({"type": "modified", "original": orig_cue, "modified": mod_cue})
+                changed += 1
+        elif tag == "delete":
+            for k in range(i1, i2):
+                diffs.append({"type": "removed", "original": _cue_to_dict(orig_events[k]), "modified": None})
+                changed += 1
+        elif tag == "insert":
+            for k in range(j1, j2):
+                diffs.append({"type": "added", "original": None, "modified": _cue_to_dict(mod_events[k])})
+                changed += 1
+
+    return jsonify({"diffs": diffs, "total": len(diffs), "changed": changed})

--- a/backend/tests/test_diff_endpoint.py
+++ b/backend/tests/test_diff_endpoint.py
@@ -1,0 +1,58 @@
+"""Tests for POST /tools/diff endpoint."""
+import pytest
+
+
+@pytest.fixture
+def client(tmp_path):
+    import os
+    os.environ["SUBLARR_MEDIA_PATH"] = str(tmp_path)
+    from config import reload_settings
+    reload_settings()
+    from app import create_app
+    app = create_app(testing=True)
+    with app.test_client() as c, app.app_context():
+        yield c
+    del os.environ["SUBLARR_MEDIA_PATH"]
+    reload_settings()
+
+
+ORIG_ASS = """\
+[Script Info]
+ScriptType: v4.00+
+
+[V4+ Styles]
+Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
+Style: Default,Arial,20,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,2,2,2,10,10,10,1
+
+[Events]
+Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
+Dialogue: 0,0:00:01.00,0:00:03.00,Default,,0,0,0,,Hello world
+Dialogue: 0,0:00:04.00,0:00:06.00,Default,,0,0,0,,This is unchanged
+"""
+
+MOD_ASS = """\
+[Script Info]
+ScriptType: v4.00+
+
+[V4+ Styles]
+Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
+Style: Default,Arial,20,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,2,2,2,10,10,10,1
+
+[Events]
+Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
+Dialogue: 0,0:00:01.00,0:00:03.00,Default,,0,0,0,,Hallo Welt
+Dialogue: 0,0:00:04.00,0:00:06.00,Default,,0,0,0,,This is unchanged
+"""
+
+
+def test_diff_returns_diffs(client):
+    resp = client.post("/api/v1/tools/diff", json={"original": ORIG_ASS, "modified": MOD_ASS})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "diffs" in data
+    assert data["changed"] >= 1
+
+
+def test_diff_missing_original(client):
+    resp = client.post("/api/v1/tools/diff", json={"modified": MOD_ASS})
+    assert resp.status_code == 400

--- a/backend/tests/test_diff_endpoint.py
+++ b/backend/tests/test_diff_endpoint.py
@@ -56,3 +56,9 @@ def test_diff_returns_diffs(client):
 def test_diff_missing_original(client):
     resp = client.post("/api/v1/tools/diff", json={"modified": MOD_ASS})
     assert resp.status_code == 400
+
+
+def test_diff_malformed_input(client):
+    resp = client.post("/api/v1/tools/diff", json={"original": "not valid ass content", "modified": MOD_ASS})
+    assert resp.status_code == 400
+    assert "error" in (resp.get_json() or {})

--- a/backend/tests/test_diff_endpoint.py
+++ b/backend/tests/test_diff_endpoint.py
@@ -1,10 +1,11 @@
-"""Tests for POST /tools/diff endpoint."""
+"""Tests for POST /tools/diff and POST /tools/diff/apply endpoints."""
+import os
+
 import pytest
 
 
 @pytest.fixture
 def client(tmp_path):
-    import os
     os.environ["SUBLARR_MEDIA_PATH"] = str(tmp_path)
     from config import reload_settings
     reload_settings()
@@ -45,6 +46,8 @@ Dialogue: 0,0:00:04.00,0:00:06.00,Default,,0,0,0,,This is unchanged
 """
 
 
+# ── POST /tools/diff ────────────────────────────────────────────────────────────
+
 def test_diff_returns_diffs(client):
     resp = client.post("/api/v1/tools/diff", json={"original": ORIG_ASS, "modified": MOD_ASS})
     assert resp.status_code == 200
@@ -62,3 +65,139 @@ def test_diff_malformed_input(client):
     resp = client.post("/api/v1/tools/diff", json={"original": "not valid ass content", "modified": MOD_ASS})
     assert resp.status_code == 400
     assert "error" in (resp.get_json() or {})
+
+
+def test_diff_identical_files_no_changes(client):
+    resp = client.post("/api/v1/tools/diff", json={"original": ORIG_ASS, "modified": ORIG_ASS})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["changed"] == 0
+
+
+def test_diff_missing_modified(client):
+    resp = client.post("/api/v1/tools/diff", json={"original": ORIG_ASS})
+    assert resp.status_code == 400
+
+
+def test_diff_response_structure(client):
+    resp = client.post("/api/v1/tools/diff", json={"original": ORIG_ASS, "modified": MOD_ASS})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "total" in data
+    assert "changed" in data
+    assert "diffs" in data
+    assert isinstance(data["diffs"], list)
+    # Check a modified entry has correct structure
+    modified_entries = [d for d in data["diffs"] if d["type"] == "modified"]
+    assert len(modified_entries) >= 1
+    entry = modified_entries[0]
+    assert "original" in entry
+    assert "modified" in entry
+    assert "start" in entry["original"]
+    assert "end" in entry["original"]
+    assert "text" in entry["original"]
+
+
+# ── POST /tools/diff/apply ──────────────────────────────────────────────────────
+
+def _write_sub_file(tmp_path, content, filename="test.de.ass"):
+    """Write subtitle content to a file in tmp_path and return its path."""
+    sub_file = tmp_path / filename
+    sub_file.write_text(content, encoding="utf-8")
+    return str(sub_file)
+
+
+def test_apply_creates_backup(client, tmp_path):
+    sub_file = _write_sub_file(tmp_path, MOD_ASS)
+    resp = client.post("/api/v1/tools/diff/apply", json={
+        "file_path": sub_file,
+        "original": ORIG_ASS,
+        "modified": MOD_ASS,
+        "rejected_indices": [],
+    })
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "backup" in data
+    assert os.path.exists(data["backup"])
+
+
+def test_apply_returns_status_applied(client, tmp_path):
+    sub_file = _write_sub_file(tmp_path, MOD_ASS)
+    resp = client.post("/api/v1/tools/diff/apply", json={
+        "file_path": sub_file,
+        "original": ORIG_ASS,
+        "modified": MOD_ASS,
+        "rejected_indices": [],
+    })
+    assert resp.status_code == 200
+    assert resp.get_json()["status"] == "applied"
+
+
+def test_apply_accept_all_writes_modified_content(client, tmp_path):
+    sub_file = _write_sub_file(tmp_path, MOD_ASS)
+    resp = client.post("/api/v1/tools/diff/apply", json={
+        "file_path": sub_file,
+        "original": ORIG_ASS,
+        "modified": MOD_ASS,
+        "rejected_indices": [],
+    })
+    assert resp.status_code == 200
+    written = open(sub_file, encoding="utf-8").read()
+    assert "Hallo Welt" in written
+
+
+def test_apply_reject_all_restores_original_content(client, tmp_path):
+    sub_file = _write_sub_file(tmp_path, MOD_ASS)
+    # Compute diff to get the index of the changed cue
+    diff_resp = client.post("/api/v1/tools/diff", json={"original": ORIG_ASS, "modified": MOD_ASS})
+    diffs = diff_resp.get_json()["diffs"]
+    rejected = [i for i, d in enumerate(diffs) if d["type"] != "unchanged"]
+    resp = client.post("/api/v1/tools/diff/apply", json={
+        "file_path": sub_file,
+        "original": ORIG_ASS,
+        "modified": MOD_ASS,
+        "rejected_indices": rejected,
+    })
+    assert resp.status_code == 200
+    written = open(sub_file, encoding="utf-8").read()
+    assert "Hello world" in written
+
+
+def test_apply_missing_file_path(client):
+    resp = client.post("/api/v1/tools/diff/apply", json={
+        "original": ORIG_ASS,
+        "modified": MOD_ASS,
+        "rejected_indices": [],
+    })
+    assert resp.status_code == 400
+
+
+def test_apply_path_traversal_rejected(client, tmp_path):
+    resp = client.post("/api/v1/tools/diff/apply", json={
+        "file_path": "/etc/passwd",
+        "original": ORIG_ASS,
+        "modified": MOD_ASS,
+        "rejected_indices": [],
+    })
+    assert resp.status_code == 403
+
+
+def test_apply_nonexistent_file(client, tmp_path):
+    resp = client.post("/api/v1/tools/diff/apply", json={
+        "file_path": str(tmp_path / "nonexistent.ass"),
+        "original": ORIG_ASS,
+        "modified": MOD_ASS,
+        "rejected_indices": [],
+    })
+    assert resp.status_code == 404
+
+
+def test_apply_malformed_original(client, tmp_path):
+    sub_file = _write_sub_file(tmp_path, MOD_ASS)
+    resp = client.post("/api/v1/tools/diff/apply", json={
+        "file_path": sub_file,
+        "original": "not valid",
+        "modified": MOD_ASS,
+        "rejected_indices": [],
+    })
+    assert resp.status_code == 400

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -21,6 +21,7 @@ import type {
   BazarrMappingReport, CompatBatchResult, ExtendedHealthAllResponse, ExportResult,
   ChapterList,
   SeriesFansubPrefs,
+  SubtitleDiffResult,
 } from '@/lib/types'
 
 const api = axios.create({
@@ -1753,6 +1754,31 @@ export async function setSeriesFansubPrefs(
 
 export async function deleteSeriesFansubPrefs(seriesId: number): Promise<void> {
   await api.delete(`/series/${seriesId}/fansub-prefs`)
+}
+
+// ─── Subtitle Diff ────────────────────────────────────────────────────────────
+
+export async function computeSubtitleDiff(
+  original: string,
+  modified: string,
+): Promise<SubtitleDiffResult> {
+  const { data } = await api.post('/tools/diff', { original, modified })
+  return data
+}
+
+export async function applySubtitleDiff(
+  filePath: string,
+  original: string,
+  modified: string,
+  rejectedIndices: number[],
+): Promise<{ status: string; file_path: string; backup: string }> {
+  const { data } = await api.post('/tools/diff/apply', {
+    file_path: filePath,
+    original,
+    modified,
+    rejected_indices: rejectedIndices,
+  })
+  return data
 }
 
 export default api

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1762,8 +1762,13 @@ export async function computeSubtitleDiff(
   original: string,
   modified: string,
 ): Promise<SubtitleDiffResult> {
-  const { data } = await api.post('/tools/diff', { original, modified })
-  return data
+  try {
+    const { data } = await api.post<SubtitleDiffResult>('/tools/diff', { original, modified })
+    return data
+  } catch (err: unknown) {
+    const msg = (err as { response?: { data?: { error?: string } } })?.response?.data?.error
+    throw new Error(msg ?? `computeSubtitleDiff failed`)
+  }
 }
 
 export async function applySubtitleDiff(
@@ -1772,13 +1777,16 @@ export async function applySubtitleDiff(
   modified: string,
   rejectedIndices: number[],
 ): Promise<{ status: string; file_path: string; backup: string }> {
-  const { data } = await api.post('/tools/diff/apply', {
-    file_path: filePath,
-    original,
-    modified,
-    rejected_indices: rejectedIndices,
-  })
-  return data
+  try {
+    const { data } = await api.post<{ status: string; file_path: string; backup: string }>(
+      '/tools/diff/apply',
+      { file_path: filePath, original, modified, rejected_indices: rejectedIndices },
+    )
+    return data
+  } catch (err: unknown) {
+    const msg = (err as { response?: { data?: { error?: string } } })?.response?.data?.error
+    throw new Error(msg ?? `applySubtitleDiff failed`)
+  }
 }
 
 export default api

--- a/frontend/src/components/editor/SubtitleDiff.tsx
+++ b/frontend/src/components/editor/SubtitleDiff.tsx
@@ -44,6 +44,7 @@ export default function SubtitleDiff({
   const [diffResult, setDiffResult] = useState<SubtitleDiffResult | null>(null)
   const [loading, setLoading] = useState(false)
   const [diffError, setDiffError] = useState<string | null>(null)
+  const [retryCount, setRetryCount] = useState(0)
 
   const [accepted, setAccepted] = useState<Set<number>>(new Set())
   const [showUnchanged, setShowUnchanged] = useState(false)
@@ -82,7 +83,7 @@ export default function SubtitleDiff({
     return () => {
       cancelled = true
     }
-  }, [backup?.content, currentContent])
+  }, [backup?.content, currentContent, retryCount])
 
   const toggleAccepted = (index: number) => {
     setAccepted(prev => {
@@ -163,6 +164,7 @@ export default function SubtitleDiff({
             onClick={() => {
               setDiffError(null)
               setDiffResult(null)
+              setRetryCount(c => c + 1)
             }}
             className="rounded px-4 py-1.5 text-sm transition-colors"
             style={{ backgroundColor: 'var(--bg-surface-hover)', color: 'var(--text-primary)' }}

--- a/frontend/src/components/editor/SubtitleDiff.tsx
+++ b/frontend/src/components/editor/SubtitleDiff.tsx
@@ -1,21 +1,10 @@
-/**
- * Side-by-side diff comparison of backup vs current subtitle content.
- *
- * Uses react-codemirror-merge to render a split view with
- * syntax highlighting and built-in change visualization.
- */
+import { ArrowLeft, Check, CheckSquare, Loader2, SquareX, X } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { applySubtitleDiff, computeSubtitleDiff } from '../../api/client'
+import { useSubtitleBackup } from '../../hooks/useApi'
+import type { SubtitleDiffEntry, SubtitleDiffResult } from '../../lib/types'
 
-import CodeMirrorMerge from 'react-codemirror-merge'
-import { EditorView } from '@codemirror/view'
-import { EditorState } from '@codemirror/state'
-import { assLanguage } from './lang-ass'
-import { srtLanguage } from './lang-srt'
-import { sublarrTheme } from './editor-theme'
-import { useSubtitleBackup } from '@/hooks/useApi'
-import { ArrowLeft, X, Loader2, AlertCircle, FileWarning } from 'lucide-react'
-
-const Original = CodeMirrorMerge.Original
-const Modified = CodeMirrorMerge.Modified
+// ── Types ───────────────────────────────────────────────────────────────────────
 
 interface SubtitleDiffProps {
   filePath: string
@@ -23,26 +12,128 @@ interface SubtitleDiffProps {
   format: 'ass' | 'srt'
   onClose?: () => void
   onBackToEditor?: () => void
+  onApplied?: () => void
 }
 
-export function SubtitleDiff({
+const TYPE_BADGE: Record<string, { label: string; color: string }> = {
+  unchanged: { label: 'Unchanged', color: 'var(--text-muted)' },
+  modified: { label: 'Modified', color: 'var(--warning, #f59e0b)' },
+  added: { label: 'Added', color: 'var(--success, #10b981)' },
+  removed: { label: 'Removed', color: 'var(--error, #ef4444)' },
+}
+
+function formatTime(seconds: number): string {
+  const h = Math.floor(seconds / 3600)
+  const m = Math.floor((seconds % 3600) / 60)
+  const s = (seconds % 60).toFixed(2).padStart(5, '0')
+  return `${String(h).padStart(1, '0')}:${String(m).padStart(2, '0')}:${s}`
+}
+
+// ── Main component ──────────────────────────────────────────────────────────────
+
+export default function SubtitleDiff({
   filePath,
   currentContent,
   format,
   onClose,
   onBackToEditor,
+  onApplied,
 }: SubtitleDiffProps) {
-  const { data: backupData, isLoading, isError, error, refetch } = useSubtitleBackup(filePath)
+  const { data: backup, isLoading: backupLoading } = useSubtitleBackup(filePath)
 
-  const language = format === 'ass' ? assLanguage : srtLanguage
-  const extensions = [language, sublarrTheme, EditorView.lineWrapping]
+  const [diffResult, setDiffResult] = useState<SubtitleDiffResult | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [diffError, setDiffError] = useState<string | null>(null)
 
-  // Loading state
-  if (isLoading) {
+  const [accepted, setAccepted] = useState<Set<number>>(new Set())
+  const [showUnchanged, setShowUnchanged] = useState(false)
+
+  const [applying, setApplying] = useState(false)
+  const [applyError, setApplyError] = useState<string | null>(null)
+
+  // Compute diff when backup and current content are available
+  useEffect(() => {
+    const backupContent = backup?.content
+    if (!backupContent || !currentContent) return
+
+    let cancelled = false
+    setLoading(true)
+    setDiffError(null)
+
+    computeSubtitleDiff(backupContent, currentContent)
+      .then(result => {
+        if (cancelled) return
+        setDiffResult(result)
+        // Pre-accept all changed entries
+        const changedIndices = result.diffs
+          .map((d, i) => ({ type: d.type, i }))
+          .filter(({ type }) => type !== 'unchanged')
+          .map(({ i }) => i)
+        setAccepted(new Set(changedIndices))
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return
+        setDiffError(err instanceof Error ? err.message : 'Failed to compute diff')
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [backup?.content, currentContent])
+
+  const toggleAccepted = (index: number) => {
+    setAccepted(prev => {
+      const next = new Set(prev)
+      if (next.has(index)) {
+        next.delete(index)
+      } else {
+        next.add(index)
+      }
+      return next
+    })
+  }
+
+  const acceptAll = () => {
+    if (!diffResult) return
+    const all = diffResult.diffs
+      .map((d, i) => ({ type: d.type, i }))
+      .filter(({ type }) => type !== 'unchanged')
+      .map(({ i }) => i)
+    setAccepted(new Set(all))
+  }
+
+  const rejectAll = () => {
+    setAccepted(new Set())
+  }
+
+  const handleApply = async () => {
+    if (!diffResult || !backup?.content) return
+    const rejectedIndices = diffResult.diffs
+      .map((_, i) => i)
+      .filter(i => !accepted.has(i) && diffResult.diffs[i].type !== 'unchanged')
+
+    setApplying(true)
+    setApplyError(null)
+    try {
+      await applySubtitleDiff(filePath, backup.content, currentContent, rejectedIndices)
+      onApplied?.()
+    } catch (err: unknown) {
+      setApplyError(err instanceof Error ? err.message : 'Failed to apply changes')
+    } finally {
+      setApplying(false)
+    }
+  }
+
+  // ── Loading / error states ─────────────────────────────────────────────────
+
+  if (backupLoading) {
     return (
       <div className="flex h-full flex-col">
         <DiffHeader onClose={onClose} onBackToEditor={onBackToEditor} />
-        <div className="flex flex-1 items-center justify-center text-slate-400">
+        <div className="flex flex-1 items-center justify-center" style={{ color: 'var(--text-muted)' }}>
           <Loader2 className="mr-2 h-5 w-5 animate-spin" />
           Loading backup...
         </div>
@@ -50,39 +141,31 @@ export function SubtitleDiff({
     )
   }
 
-  // 404: no backup found
-  const axiosErr = error as { response?: { status?: number } } | null
-  if (isError && axiosErr?.response?.status === 404) {
+  if (!backup?.content) {
     return (
       <div className="flex h-full flex-col">
         <DiffHeader onClose={onClose} onBackToEditor={onBackToEditor} />
-        <div className="flex flex-1 flex-col items-center justify-center gap-3 text-slate-400">
-          <FileWarning className="h-10 w-10 text-slate-500" />
-          <p className="text-sm">No backup file found. Save your changes first to create a backup.</p>
-          {onBackToEditor && (
-            <button
-              onClick={onBackToEditor}
-              className="mt-2 rounded bg-teal-600 px-4 py-1.5 text-sm text-white transition-colors hover:bg-teal-500"
-            >
-              Back to Editor
-            </button>
-          )}
+        <div className="flex flex-1 flex-col items-center justify-center gap-2" style={{ color: 'var(--text-muted)' }}>
+          <span className="text-sm">No backup found for this file.</span>
+          <span className="text-xs">Save the file first to create a backup.</span>
         </div>
       </div>
     )
   }
 
-  // General error state
-  if (isError) {
+  if (diffError) {
     return (
       <div className="flex h-full flex-col">
         <DiffHeader onClose={onClose} onBackToEditor={onBackToEditor} />
-        <div className="flex flex-1 flex-col items-center justify-center gap-3 text-slate-400">
-          <AlertCircle className="h-10 w-10 text-red-400" />
-          <p className="text-sm">Failed to load backup file</p>
+        <div className="flex flex-1 flex-col items-center justify-center gap-3" style={{ color: 'var(--error, #ef4444)' }}>
+          <span className="text-sm">{diffError}</span>
           <button
-            onClick={() => void refetch()}
-            className="rounded bg-slate-700 px-4 py-1.5 text-sm text-slate-200 transition-colors hover:bg-slate-600"
+            onClick={() => {
+              setDiffError(null)
+              setDiffResult(null)
+            }}
+            className="rounded px-4 py-1.5 text-sm transition-colors"
+            style={{ backgroundColor: 'var(--bg-surface-hover)', color: 'var(--text-primary)' }}
           >
             Retry
           </button>
@@ -91,37 +174,210 @@ export function SubtitleDiff({
     )
   }
 
+  // ── Main diff table ─────────────────────────────────────────────────────────
+
+  const visibleDiffs = diffResult
+    ? diffResult.diffs
+        .map((d, i) => ({ ...d, index: i }))
+        .filter(d => showUnchanged || d.type !== 'unchanged')
+    : []
+
+  const changedCount = diffResult?.changed ?? 0
+  const acceptedCount = accepted.size
+
   return (
     <div className="flex h-full flex-col">
       <DiffHeader onClose={onClose} onBackToEditor={onBackToEditor} />
 
-      {/* Column labels */}
-      <div className="flex border-b border-slate-700 bg-slate-800/60 text-xs text-slate-400">
-        <div className="flex-1 px-3 py-1">Original (backup)</div>
-        <div className="w-px bg-slate-700" />
-        <div className="flex-1 px-3 py-1">Modified (current)</div>
+      {/* Toolbar */}
+      <div
+        className="flex items-center gap-2 px-4 py-2 flex-shrink-0 flex-wrap"
+        style={{ borderBottom: '1px solid var(--border)', backgroundColor: 'var(--bg-elevated)' }}
+      >
+        {diffResult && (
+          <>
+            <span className="text-xs" style={{ color: 'var(--text-muted)' }}>
+              {changedCount} change{changedCount !== 1 ? 's' : ''} —{' '}
+              {acceptedCount} accepted
+            </span>
+
+            <div className="flex gap-1 ml-2">
+              <button
+                onClick={acceptAll}
+                className="flex items-center gap-1 rounded px-2 py-1 text-xs transition-colors"
+                style={{ backgroundColor: 'var(--bg-surface)', color: 'var(--success)', border: '1px solid var(--border)' }}
+                title="Accept all changes"
+              >
+                <CheckSquare size={12} />
+                Accept All
+              </button>
+              <button
+                onClick={rejectAll}
+                className="flex items-center gap-1 rounded px-2 py-1 text-xs transition-colors"
+                style={{ backgroundColor: 'var(--bg-surface)', color: 'var(--error)', border: '1px solid var(--border)' }}
+                title="Reject all changes"
+              >
+                <SquareX size={12} />
+                Reject All
+              </button>
+            </div>
+
+            <label className="ml-2 flex items-center gap-1.5 text-xs cursor-pointer" style={{ color: 'var(--text-secondary)' }}>
+              <input
+                type="checkbox"
+                checked={showUnchanged}
+                onChange={e => setShowUnchanged(e.target.checked)}
+                className="rounded"
+              />
+              Show unchanged
+            </label>
+
+            <div className="flex-1" />
+
+            <button
+              onClick={() => void handleApply()}
+              disabled={applying || changedCount === 0}
+              className="flex items-center gap-1.5 rounded px-3 py-1.5 text-sm font-medium transition-colors disabled:opacity-50"
+              style={{ backgroundColor: 'var(--accent)', color: 'white' }}
+            >
+              {applying ? <Loader2 size={13} className="animate-spin" /> : <Check size={13} />}
+              Apply Changes
+            </button>
+          </>
+        )}
       </div>
 
-      {/* Merge diff view */}
-      <div className="min-h-0 flex-1 overflow-auto">
-        <CodeMirrorMerge>
-          <Original
-            value={backupData?.content ?? ''}
-            extensions={[
-              ...extensions,
-              EditorState.readOnly.of(true),
-            ]}
-          />
-          <Modified
-            value={currentContent}
-            extensions={[
-              ...extensions,
-              EditorState.readOnly.of(true),
-            ]}
-          />
-        </CodeMirrorMerge>
-      </div>
+      {/* Apply error banner */}
+      {applyError && (
+        <div
+          className="px-4 py-2 text-sm flex-shrink-0"
+          style={{ backgroundColor: 'var(--error-bg)', color: 'var(--error)', borderBottom: '1px solid var(--border)' }}
+        >
+          {applyError}
+        </div>
+      )}
+
+      {/* Diff loading spinner */}
+      {loading && (
+        <div className="flex flex-1 items-center justify-center" style={{ color: 'var(--text-muted)' }}>
+          <Loader2 className="mr-2 h-5 w-5 animate-spin" />
+          Computing diff...
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!loading && diffResult && changedCount === 0 && (
+        <div className="flex flex-1 items-center justify-center text-sm" style={{ color: 'var(--text-muted)' }}>
+          No differences found between backup and current content.
+        </div>
+      )}
+
+      {/* Diff table */}
+      {!loading && diffResult && changedCount > 0 && (
+        <div className="flex-1 overflow-auto">
+          <table className="w-full text-sm border-collapse">
+            <thead>
+              <tr style={{ backgroundColor: 'var(--bg-elevated)', borderBottom: '1px solid var(--border)' }}>
+                <th className="px-3 py-2 text-left text-xs font-medium w-10" style={{ color: 'var(--text-muted)' }}>#</th>
+                <th className="px-3 py-2 text-left text-xs font-medium w-28" style={{ color: 'var(--text-muted)' }}>Time</th>
+                <th className="px-3 py-2 text-left text-xs font-medium w-20" style={{ color: 'var(--text-muted)' }}>Type</th>
+                <th className="px-3 py-2 text-left text-xs font-medium" style={{ color: 'var(--text-muted)' }}>Original</th>
+                <th className="px-3 py-2 text-left text-xs font-medium" style={{ color: 'var(--text-muted)' }}>Modified</th>
+                <th className="px-3 py-2 text-center text-xs font-medium w-20" style={{ color: 'var(--text-muted)' }}>Accept</th>
+              </tr>
+            </thead>
+            <tbody>
+              {visibleDiffs.map(entry => (
+                <DiffRow
+                  key={entry.index}
+                  entry={entry}
+                  entryIndex={entry.index}
+                  accepted={accepted.has(entry.index)}
+                  onToggle={toggleAccepted}
+                  format={format}
+                />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
     </div>
+  )
+}
+
+// ── Sub-components ─────────────────────────────────────────────────────────────
+
+interface DiffRowProps {
+  entry: SubtitleDiffEntry & { index: number }
+  entryIndex: number
+  accepted: boolean
+  onToggle: (index: number) => void
+  format: 'ass' | 'srt'
+}
+
+function DiffRow({ entry, entryIndex, accepted, onToggle, format: _format }: DiffRowProps) {
+  const isChangeable = entry.type !== 'unchanged'
+  const badge = TYPE_BADGE[entry.type]
+  const timeCue = entry.original ?? entry.modified
+
+  const rowBg = !isChangeable
+    ? 'transparent'
+    : accepted
+    ? 'rgba(var(--success-rgb, 16, 185, 129), 0.07)'
+    : 'rgba(var(--error-rgb, 239, 68, 68), 0.07)'
+
+  return (
+    <tr
+      style={{
+        backgroundColor: rowBg,
+        borderBottom: '1px solid var(--border)',
+        opacity: !isChangeable ? 0.5 : 1,
+      }}
+    >
+      {/* Index */}
+      <td className="px-3 py-2 text-xs" style={{ color: 'var(--text-muted)', fontFamily: 'var(--font-mono)' }}>
+        {entryIndex}
+      </td>
+
+      {/* Time range */}
+      <td className="px-3 py-2 text-xs whitespace-nowrap" style={{ color: 'var(--text-secondary)', fontFamily: 'var(--font-mono)' }}>
+        {timeCue ? `${formatTime(timeCue.start)} → ${formatTime(timeCue.end)}` : '—'}
+      </td>
+
+      {/* Type badge */}
+      <td className="px-3 py-2">
+        <span className="text-xs font-medium" style={{ color: badge.color }}>
+          {badge.label}
+        </span>
+      </td>
+
+      {/* Original text */}
+      <td className="px-3 py-2 text-xs align-top" style={{ color: 'var(--text-primary)' }}>
+        {entry.original?.text ?? <span style={{ color: 'var(--text-muted)' }}>—</span>}
+      </td>
+
+      {/* Modified text */}
+      <td className="px-3 py-2 text-xs align-top" style={{ color: 'var(--text-primary)' }}>
+        {entry.modified?.text ?? <span style={{ color: 'var(--text-muted)' }}>—</span>}
+      </td>
+
+      {/* Accept/reject toggle */}
+      <td className="px-3 py-2 text-center">
+        {isChangeable ? (
+          <button
+            onClick={() => onToggle(entryIndex)}
+            className="rounded p-1 transition-colors"
+            style={{
+              color: accepted ? 'var(--success)' : 'var(--error)',
+              backgroundColor: accepted ? 'rgba(var(--success-rgb, 16, 185, 129), 0.12)' : 'rgba(var(--error-rgb, 239, 68, 68), 0.12)',
+            }}
+            title={accepted ? 'Click to reject' : 'Click to accept'}
+          >
+            {accepted ? <Check size={14} /> : <X size={14} />}
+          </button>
+        ) : null}
+      </td>
+    </tr>
   )
 }
 
@@ -134,17 +390,22 @@ function DiffHeader({
   onBackToEditor?: () => void
 }) {
   return (
-    <div className="flex items-center gap-2 border-b border-slate-700 bg-slate-800/80 px-3 py-1.5">
-      <span className="text-sm font-medium text-slate-200">Diff View</span>
+    <div
+      className="flex items-center gap-2 px-3 py-1.5 flex-shrink-0"
+      style={{ borderBottom: '1px solid var(--border)', backgroundColor: 'var(--bg-elevated)' }}
+    >
+      <span className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>Diff View</span>
 
       <div className="flex-1" />
 
       {onBackToEditor && (
         <button
           onClick={onBackToEditor}
-          className="flex items-center gap-1.5 rounded px-2.5 py-1.5 text-sm
-            text-slate-300 transition-colors hover:bg-slate-700"
+          className="flex items-center gap-1.5 rounded px-2.5 py-1.5 text-sm transition-colors"
+          style={{ color: 'var(--text-secondary)' }}
           title="Back to editor"
+          onMouseEnter={e => { e.currentTarget.style.backgroundColor = 'var(--bg-surface-hover)' }}
+          onMouseLeave={e => { e.currentTarget.style.backgroundColor = 'transparent' }}
         >
           <ArrowLeft className="h-4 w-4" />
           Back to Editor
@@ -154,8 +415,11 @@ function DiffHeader({
       {onClose && (
         <button
           onClick={onClose}
-          className="rounded p-1.5 text-slate-400 transition-colors hover:bg-slate-700 hover:text-slate-200"
+          className="rounded p-1.5 transition-colors"
+          style={{ color: 'var(--text-muted)' }}
           title="Close"
+          onMouseEnter={e => { e.currentTarget.style.backgroundColor = 'var(--bg-surface-hover)' }}
+          onMouseLeave={e => { e.currentTarget.style.backgroundColor = 'transparent' }}
         >
           <X className="h-4 w-4" />
         </button>

--- a/frontend/src/components/editor/SubtitleEditorModal.tsx
+++ b/frontend/src/components/editor/SubtitleEditorModal.tsx
@@ -368,6 +368,11 @@ export default function SubtitleEditorModal({
                 format={format}
                 onClose={handleClose}
                 onBackToEditor={() => setMode('edit')}
+                onApplied={() => {
+                  void queryClient.invalidateQueries({ queryKey: ['subtitle-content', filePath] })
+                  void queryClient.invalidateQueries({ queryKey: ['subtitle-backup', filePath] })
+                  setMode('preview')
+                }}
               />
             )}
 

--- a/frontend/src/components/editor/SubtitleEditorModal.tsx
+++ b/frontend/src/components/editor/SubtitleEditorModal.tsx
@@ -20,7 +20,7 @@ const SubtitleEditor = lazy(() =>
   import('@/components/editor/SubtitleEditor').then(m => ({ default: m.SubtitleEditor }))
 )
 const SubtitleDiff = lazy(() =>
-  import('@/components/editor/SubtitleDiff').then(m => ({ default: m.SubtitleDiff }))
+  import('@/components/editor/SubtitleDiff')
 )
 const WaveformTab = lazy(() =>
   import('@/components/editor/WaveformTab').then(m => ({ default: m.WaveformTab }))

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1198,3 +1198,26 @@ export interface SeriesFansubPrefs {
   excluded_groups: string[]
   bonus: number
 }
+
+// ─── Subtitle Diff ────────────────────────────────────────────────────────────
+
+export interface SubtitleDiffCue {
+  start: number
+  end: number
+  text: string
+  style: string
+}
+
+export type SubtitleDiffType = 'unchanged' | 'modified' | 'added' | 'removed'
+
+export interface SubtitleDiffEntry {
+  type: SubtitleDiffType
+  original: SubtitleDiffCue | null
+  modified: SubtitleDiffCue | null
+}
+
+export interface SubtitleDiffResult {
+  diffs: SubtitleDiffEntry[]
+  total: number
+  changed: number
+}


### PR DESCRIPTION
## Summary

- **`POST /tools/diff`** — cue-level diff via pysubs2 + difflib.SequenceMatcher; returns typed entries (`unchanged`/`modified`/`added`/`removed`) with start/end in seconds
- **`POST /tools/diff/apply`** — server-side recompute + merge; respects `rejected_indices`; creates `.bak` backup; atomic write via `tempfile` + `os.replace`; path-traversal protected via `is_safe_path()`
- **`SubtitleDiff.tsx` rewrite** — replaces CodeMirror merge view with a filterable per-cue accept/reject table; Accept All / Reject All toolbar; applying navigates back to preview and invalidates subtitle-content + subtitle-backup cache

## Test plan

- [x] 14 backend tests in `tests/test_diff_endpoint.py` — 549 passed total (6 known Windows-only errors in test_server.py)
- [x] ESLint: no new warnings (5 pre-existing warnings unrelated to this PR)
- [x] TypeScript: verified via CI (Windows path issues prevent local tsc)
- [ ] Manual: open subtitle editor → switch to diff view → verify per-cue table renders
- [ ] Manual: accept/reject individual cues → Apply → verify file written correctly + backup created
- [ ] Manual: Accept All / Reject All buttons