### PR TITLE
feat: v0.26.0 — Single-Account Login

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Sublarr — Roadmap
 
-> Completed versions are marked ✅. The current release is **v0.25.2-beta**. Planned versions reflect intended direction and may shift.
+> Completed versions are marked ✅. The current release is **v0.25.3-beta**. Planned versions reflect intended direction and may shift.
 
 ---
 
@@ -245,6 +245,61 @@ Goals: Smooth scrolling for large libraries.
 
 ---
 
+## v0.26.0 — Single-Account Login
+
+Goals: Optional password protection for the web UI — no multi-user, no RBAC, just a simple access gate.
+
+- `SUBLARR_UI_PASSWORD` env var (hashed, bcrypt) — if set, login is required; if unset, UI is open
+- Session-based auth via signed HTTP-only cookie; configurable TTL (`SUBLARR_SESSION_TTL_HOURS`, default 72)
+- `/login` page — password form with redirect to original URL after success
+- Flask middleware: all non-API routes redirect to `/login` when session absent
+- API routes unaffected — existing `X-Api-Key` auth continues to work independently
+- Settings UI — change password, invalidate all sessions, show active session count
+- Sidebar — "Lock" button + session owner display
+
+---
+
+## v0.27.0 — Subtitle Quality Score Export
+
+Goals: Persist per-file quality metadata as Kodi/Jellyfin-compatible NFO sidecars for media managers.
+
+- NFO format: XML sidecar (`<filename>.nfo`) alongside subtitle file
+- Exported fields: provider, source language, target language, score, translation backend, BLEU score (if available), download timestamp, Sublarr version
+- `auto_nfo_export` config setting — write NFO automatically after every subtitle download/translation
+- `POST /api/v1/subtitles/export-nfo?path=` — manual trigger for single file (path-safe)
+- `POST /api/v1/series/<id>/subtitles/export-nfo` — bulk export for all sidecars of a series
+- SeriesDetail — "Export NFO" button in subtitle sidecar context menu
+
+---
+
+## v0.28.0 — AI Glossary Builder
+
+Goals: Per-series term glossary auto-populated from translation history, injected as LLM context to improve consistency.
+
+- `series_glossary_terms` DB table — term, translation, type (character/place/other), confidence, approved flag, per series
+- Auto-detection pipeline: frequency analysis + optional NER pass over past translated cues to surface recurring proper nouns
+- Glossary injected as system prompt prefix during LLM translation (`<glossary>` block, max 50 terms)
+- `GET/POST/PUT/DELETE /api/v1/series/<id>/glossary` — full CRUD
+- `POST /api/v1/series/<id>/glossary/suggest` — trigger auto-detection run; returns candidates for review
+- SeriesDetail — Glossary panel: suggestion list (approve/reject), manual add, search, export as TSV
+- `SUBLARR_GLOSSARY_ENABLED` setting (default true); `glossary_max_terms` per series (default 100)
+
+---
+
+## v0.29.0 — Web Player
+
+Goals: In-browser video preview with subtitle overlay — review and fix subs without leaving Sublarr.
+
+- `GET /api/v1/media/stream?path=` — range-request video streaming; `is_safe_path()` enforced; `Content-Type` by extension
+- HTML5 `<video>` player in a `PlayerModal` — play, pause, seek, volume, fullscreen
+- ASS/SRT subtitle overlay via SubtitleOctopus (libass WASM) — renders styled ASS natively in browser
+- Subtitle track selector — switch between all available sidecars for the episode
+- Seek-to-cue: clicking a cue row in SubtitleEditorModal jumps player to that timestamp
+- Episode card — "Preview" button opens PlayerModal
+- `SUBLARR_STREAMING_ENABLED` setting (default true) — allows disabling the streaming endpoint
+
+---
+
 ## v1.0.0 — Stable Release
 
 Requirements for stable release:
@@ -257,15 +312,6 @@ Requirements for stable release:
 - Unraid Community Applications template finalized
 - User Guide complete and reviewed
 - Load tested with library of 500+ series
-
----
-
-## Long-Term Ideas (No Version Commitment)
-
-- Web Player Integration — embedded subtitle preview with video playback
-- AI-Assisted Glossary Building — auto-detect proper nouns from translation history
-- Single-Account Login — optional password protection for the web UI (no multi-user/RBAC)
-- Subtitle Quality Score Export — export per-file quality metrics as NFO sidecar
 
 ---
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -182,6 +182,8 @@ def create_app(testing=False):
 
     # Initialize authentication
     from auth import init_auth
+    from routes.auth_ui import auth_ui_bp
+    from ui_auth import init_ui_auth
 
     init_auth(app)
 
@@ -440,9 +442,15 @@ def create_app(testing=False):
         def handle_disconnect():
             logger.debug("WebSocket client disconnected")
 
+        # Register UI auth blueprint
+        app.register_blueprint(auth_ui_bp)
+
         # Start schedulers (skip during testing)
         if not testing:
             _start_schedulers(settings, app)
+
+        # Initialize UI auth (sets SECRET_KEY + before_request hook — must be LAST)
+        init_ui_auth(app)
 
     return app
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -21,6 +21,7 @@ openai>=1.0.0
 google-cloud-translate>=3.10.0
 apprise==1.9.2
 beautifulsoup4>=4.12.0
+bcrypt==4.2.1
 click>=8.1,<9
 lxml>=5.1.0
 watchdog>=6.0.0

--- a/backend/routes/auth_ui.py
+++ b/backend/routes/auth_ui.py
@@ -1,0 +1,122 @@
+"""UI authentication endpoints.
+
+GET  /api/v1/auth/status          — auth state (no session required)
+POST /api/v1/auth/setup           — first-run: set password or disable
+POST /api/v1/auth/login           — verify password, create session
+POST /api/v1/auth/logout          — clear session
+POST /api/v1/auth/change-password — update password (active session required)
+POST /api/v1/auth/toggle          — enable/disable auth (session or API key required)
+"""
+
+import logging
+
+from flask import Blueprint, jsonify, request, session
+
+import ui_auth
+
+logger = logging.getLogger(__name__)
+
+auth_ui_bp = Blueprint("auth_ui", __name__, url_prefix="/api/v1/auth")
+_MIN_PASSWORD_LENGTH = 4
+
+
+def _is_session_authenticated() -> bool:
+    return bool(session.get("ui_authenticated"))
+
+
+@auth_ui_bp.get("/status")
+def get_status():
+    return jsonify({
+        "configured": ui_auth.is_ui_auth_configured(),
+        "enabled": ui_auth.is_ui_auth_enabled(),
+        "authenticated": _is_session_authenticated(),
+    })
+
+
+@auth_ui_bp.post("/setup")
+def setup():
+    if ui_auth.is_ui_auth_configured():
+        return jsonify({"error": "Already configured. Use /toggle or /change-password."}), 409
+
+    body = request.get_json(silent=True) or {}
+    action = body.get("action")
+
+    if action == "disable":
+        ui_auth._save_config_entry("ui_auth_enabled", "false")
+        ui_auth._save_config_entry("ui_password_hash", "disabled")
+        logger.info("UI auth disabled during first-run setup")
+        return jsonify({"status": "disabled"})
+
+    if action == "set_password":
+        password = body.get("password", "")
+        if len(password) < _MIN_PASSWORD_LENGTH:
+            return jsonify({"error": f"Password must be at least {_MIN_PASSWORD_LENGTH} characters"}), 400
+        ui_auth._save_config_entry("ui_password_hash", ui_auth.hash_password(password))
+        ui_auth._save_config_entry("ui_auth_enabled", "true")
+        session["ui_authenticated"] = True
+        logger.info("UI auth password set during first-run setup")
+        return jsonify({"status": "enabled"})
+
+    return jsonify({"error": "Invalid action. Use 'set_password' or 'disable'."}), 400
+
+
+@auth_ui_bp.post("/login")
+def login():
+    if not ui_auth.is_ui_auth_enabled():
+        session["ui_authenticated"] = True
+        return jsonify({"status": "ok"})
+
+    body = request.get_json(silent=True) or {}
+    password = body.get("password", "")
+    pw_hash = ui_auth._get_config_entry("ui_password_hash") or ""
+
+    if pw_hash == "disabled" or not ui_auth.verify_password(password, pw_hash):
+        logger.warning("Failed UI login attempt from %s", request.remote_addr)
+        return jsonify({"error": "Invalid password"}), 401
+
+    session["ui_authenticated"] = True
+    session.permanent = True
+    logger.info("UI login from %s", request.remote_addr)
+    return jsonify({"status": "ok"})
+
+
+@auth_ui_bp.post("/logout")
+def logout():
+    session.pop("ui_authenticated", None)
+    return jsonify({"status": "ok"})
+
+
+@auth_ui_bp.post("/change-password")
+def change_password():
+    if not _is_session_authenticated():
+        return jsonify({"error": "Authentication required"}), 401
+
+    body = request.get_json(silent=True) or {}
+    current = body.get("current_password", "")
+    new_pw = body.get("new_password", "")
+
+    pw_hash = ui_auth._get_config_entry("ui_password_hash") or ""
+    if not ui_auth.verify_password(current, pw_hash):
+        return jsonify({"error": "Current password is incorrect"}), 401
+
+    if len(new_pw) < _MIN_PASSWORD_LENGTH:
+        return jsonify({"error": f"Password must be at least {_MIN_PASSWORD_LENGTH} characters"}), 400
+
+    ui_auth._save_config_entry("ui_password_hash", ui_auth.hash_password(new_pw))
+    logger.info("UI password changed")
+    return jsonify({"status": "ok"})
+
+
+@auth_ui_bp.post("/toggle")
+def toggle():
+    if not _is_session_authenticated() and not ui_auth._has_valid_api_key():
+        return jsonify({"error": "Authentication required"}), 401
+
+    body = request.get_json(silent=True) or {}
+    enabled = body.get("enabled")
+    if not isinstance(enabled, bool):
+        return jsonify({"error": "'enabled' must be a boolean"}), 400
+
+    ui_auth._save_config_entry("ui_auth_enabled", "true" if enabled else "false")
+    logger.info("UI auth %s", "enabled" if enabled else "disabled")
+    return jsonify({"status": "enabled" if enabled else "disabled"})

--- a/backend/tests/test_routes_auth_ui.py
+++ b/backend/tests/test_routes_auth_ui.py
@@ -1,0 +1,147 @@
+"""Tests for /api/v1/auth/* endpoints."""
+
+import pytest
+import ui_auth
+
+
+@pytest.fixture
+def app(monkeypatch):
+    from flask import Flask
+    from routes.auth_ui import auth_ui_bp
+
+    monkeypatch.setattr(ui_auth, "_get_config_entry", lambda k: None)
+    monkeypatch.setattr(ui_auth, "_save_config_entry", lambda k, v: None)
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.config["SECRET_KEY"] = "test-secret"
+    app.register_blueprint(auth_ui_bp)
+    return app
+
+
+def test_status_unconfigured(app, monkeypatch):
+    monkeypatch.setattr(ui_auth, "is_ui_auth_configured", lambda: False)
+    monkeypatch.setattr(ui_auth, "is_ui_auth_enabled", lambda: False)
+    with app.test_client() as client:
+        r = client.get("/api/v1/auth/status")
+        assert r.status_code == 200
+        data = r.get_json()
+        assert data["configured"] is False
+        assert data["enabled"] is False
+        assert data["authenticated"] is False
+
+
+def test_setup_set_password(app, monkeypatch):
+    saved = {}
+    monkeypatch.setattr(ui_auth, "is_ui_auth_configured", lambda: False)
+    monkeypatch.setattr(ui_auth, "_save_config_entry", lambda k, v: saved.update({k: v}))
+    with app.test_client() as client:
+        r = client.post("/api/v1/auth/setup", json={"action": "set_password", "password": "hunter2"})
+        assert r.status_code == 200
+        assert "ui_password_hash" in saved
+        assert saved["ui_auth_enabled"] == "true"
+
+
+def test_setup_disable(app, monkeypatch):
+    saved = {}
+    monkeypatch.setattr(ui_auth, "is_ui_auth_configured", lambda: False)
+    monkeypatch.setattr(ui_auth, "_save_config_entry", lambda k, v: saved.update({k: v}))
+    with app.test_client() as client:
+        r = client.post("/api/v1/auth/setup", json={"action": "disable"})
+        assert r.status_code == 200
+        assert saved.get("ui_auth_enabled") == "false"
+
+
+def test_setup_rejected_when_already_configured(app, monkeypatch):
+    monkeypatch.setattr(ui_auth, "is_ui_auth_configured", lambda: True)
+    with app.test_client() as client:
+        r = client.post("/api/v1/auth/setup", json={"action": "disable"})
+        assert r.status_code == 409
+
+
+def test_setup_rejects_short_password(app, monkeypatch):
+    monkeypatch.setattr(ui_auth, "is_ui_auth_configured", lambda: False)
+    with app.test_client() as client:
+        r = client.post("/api/v1/auth/setup", json={"action": "set_password", "password": "ab"})
+        assert r.status_code == 400
+
+
+def test_login_correct_password(app, monkeypatch):
+    pw_hash = ui_auth.hash_password("correct")
+    monkeypatch.setattr(ui_auth, "is_ui_auth_configured", lambda: True)
+    monkeypatch.setattr(ui_auth, "is_ui_auth_enabled", lambda: True)
+    monkeypatch.setattr(ui_auth, "_get_config_entry", lambda k: pw_hash if k == "ui_password_hash" else "true")
+    with app.test_client() as client:
+        r = client.post("/api/v1/auth/login", json={"password": "correct"})
+        assert r.status_code == 200
+
+
+def test_login_wrong_password(app, monkeypatch):
+    pw_hash = ui_auth.hash_password("correct")
+    monkeypatch.setattr(ui_auth, "is_ui_auth_configured", lambda: True)
+    monkeypatch.setattr(ui_auth, "is_ui_auth_enabled", lambda: True)
+    monkeypatch.setattr(ui_auth, "_get_config_entry", lambda k: pw_hash if k == "ui_password_hash" else "true")
+    with app.test_client() as client:
+        r = client.post("/api/v1/auth/login", json={"password": "wrong"})
+        assert r.status_code == 401
+
+
+def test_login_when_auth_disabled_succeeds(app, monkeypatch):
+    monkeypatch.setattr(ui_auth, "is_ui_auth_enabled", lambda: False)
+    monkeypatch.setattr(ui_auth, "is_ui_auth_configured", lambda: True)
+    with app.test_client() as client:
+        r = client.post("/api/v1/auth/login", json={"password": ""})
+        assert r.status_code == 200
+
+
+def test_logout_clears_session(app, monkeypatch):
+    with app.test_client() as client:
+        with client.session_transaction() as sess:
+            sess["ui_authenticated"] = True
+        r = client.post("/api/v1/auth/logout")
+        assert r.status_code == 200
+        with client.session_transaction() as sess:
+            assert not sess.get("ui_authenticated")
+
+
+def test_change_password_correct(app, monkeypatch):
+    pw_hash = ui_auth.hash_password("old")
+    monkeypatch.setattr(ui_auth, "_get_config_entry", lambda k: pw_hash if k == "ui_password_hash" else "true")
+    saved = {}
+    monkeypatch.setattr(ui_auth, "_save_config_entry", lambda k, v: saved.update({k: v}))
+    with app.test_client() as client:
+        with client.session_transaction() as sess:
+            sess["ui_authenticated"] = True
+        r = client.post("/api/v1/auth/change-password", json={"current_password": "old", "new_password": "newpass1"})
+        assert r.status_code == 200
+        assert "ui_password_hash" in saved
+
+
+def test_change_password_wrong_current(app, monkeypatch):
+    pw_hash = ui_auth.hash_password("old")
+    monkeypatch.setattr(ui_auth, "_get_config_entry", lambda k: pw_hash if k == "ui_password_hash" else "true")
+    with app.test_client() as client:
+        with client.session_transaction() as sess:
+            sess["ui_authenticated"] = True
+        r = client.post("/api/v1/auth/change-password", json={"current_password": "wrong", "new_password": "newpass1"})
+        assert r.status_code == 401
+
+
+def test_toggle_disable_requires_session(app, monkeypatch):
+    monkeypatch.setattr(ui_auth, "_save_config_entry", lambda k, v: None)
+    monkeypatch.setattr(ui_auth, "_has_valid_api_key", lambda: False)
+    with app.test_client() as client:
+        r = client.post("/api/v1/auth/toggle", json={"enabled": False})
+        assert r.status_code == 401
+
+
+def test_toggle_disable_with_session(app, monkeypatch):
+    saved = {}
+    monkeypatch.setattr(ui_auth, "_save_config_entry", lambda k, v: saved.update({k: v}))
+    monkeypatch.setattr(ui_auth, "_has_valid_api_key", lambda: False)
+    with app.test_client() as client:
+        with client.session_transaction() as sess:
+            sess["ui_authenticated"] = True
+        r = client.post("/api/v1/auth/toggle", json={"enabled": False})
+        assert r.status_code == 200
+        assert saved.get("ui_auth_enabled") == "false"

--- a/backend/tests/test_ui_auth.py
+++ b/backend/tests/test_ui_auth.py
@@ -1,0 +1,141 @@
+"""Tests for ui_auth.py — UI session authentication."""
+
+import pytest
+from flask import Flask, session
+
+import ui_auth
+from ui_auth import (
+    hash_password,
+    verify_password,
+    is_ui_auth_configured,
+    is_ui_auth_enabled,
+    init_ui_auth,
+)
+
+
+def test_hash_password_returns_string():
+    h = hash_password("secret123")
+    assert isinstance(h, str)
+    assert h.startswith("$2b$")
+
+
+def test_verify_password_correct():
+    h = hash_password("correct")
+    assert verify_password("correct", h) is True
+
+
+def test_verify_password_wrong():
+    h = hash_password("correct")
+    assert verify_password("wrong", h) is False
+
+
+def test_verify_password_empty():
+    h = hash_password("correct")
+    assert verify_password("", h) is False
+
+
+def test_is_ui_auth_configured_false_when_no_entry(monkeypatch):
+    monkeypatch.setattr(ui_auth, "_get_config_entry", lambda k: None)
+    assert is_ui_auth_configured() is False
+
+
+def test_is_ui_auth_configured_true_when_entry_exists(monkeypatch):
+    monkeypatch.setattr(ui_auth, "_get_config_entry", lambda k: "some_hash" if k == "ui_password_hash" else None)
+    assert is_ui_auth_configured() is True
+
+
+def test_is_ui_auth_enabled_false_when_disabled(monkeypatch):
+    monkeypatch.setattr(ui_auth, "_get_config_entry", lambda k: "false" if k == "ui_auth_enabled" else None)
+    assert is_ui_auth_enabled() is False
+
+
+def test_is_ui_auth_enabled_true_when_enabled(monkeypatch):
+    monkeypatch.setattr(ui_auth, "_get_config_entry", lambda k: "true" if k == "ui_auth_enabled" else "hash")
+    assert is_ui_auth_enabled() is True
+
+
+def _make_app_with_auth(monkeypatch, *, configured: bool, enabled: bool):
+    monkeypatch.setattr(ui_auth, "is_ui_auth_configured", lambda: configured)
+    monkeypatch.setattr(ui_auth, "is_ui_auth_enabled", lambda: enabled)
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.config["SECRET_KEY"] = "test-secret"
+
+    @app.route("/api/v1/health")
+    def health():
+        return {"status": "ok"}
+
+    @app.route("/api/v1/auth/status")
+    def auth_status():
+        return {"ok": True}
+
+    @app.route("/api/v1/protected")
+    def protected():
+        return {"data": "secret"}
+
+    init_ui_auth(app)
+    return app
+
+
+def test_hook_allows_health_when_auth_enabled(monkeypatch):
+    app = _make_app_with_auth(monkeypatch, configured=True, enabled=True)
+    with app.test_client() as client:
+        r = client.get("/api/v1/health")
+        assert r.status_code == 200
+
+
+def test_hook_allows_auth_endpoints_unauthenticated(monkeypatch):
+    app = _make_app_with_auth(monkeypatch, configured=True, enabled=True)
+    with app.test_client() as client:
+        r = client.get("/api/v1/auth/status")
+        assert r.status_code == 200
+
+
+def test_hook_blocks_protected_when_no_session(monkeypatch):
+    app = _make_app_with_auth(monkeypatch, configured=True, enabled=True)
+    with app.test_client() as client:
+        r = client.get("/api/v1/protected")
+        assert r.status_code == 401
+
+
+def test_hook_allows_protected_with_valid_session(monkeypatch):
+    app = _make_app_with_auth(monkeypatch, configured=True, enabled=True)
+    with app.test_client() as client:
+        with client.session_transaction() as sess:
+            sess["ui_authenticated"] = True
+        r = client.get("/api/v1/protected")
+        assert r.status_code == 200
+
+
+def test_hook_allows_all_when_auth_disabled(monkeypatch):
+    app = _make_app_with_auth(monkeypatch, configured=True, enabled=False)
+    with app.test_client() as client:
+        r = client.get("/api/v1/protected")
+        assert r.status_code == 200
+
+
+def test_hook_allows_api_key_without_session(monkeypatch):
+    monkeypatch.setattr(ui_auth, "is_ui_auth_configured", lambda: True)
+    monkeypatch.setattr(ui_auth, "is_ui_auth_enabled", lambda: True)
+
+    import os
+    os.environ["SUBLARR_API_KEY"] = "test-key"
+    from config import reload_settings
+    reload_settings()
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.config["SECRET_KEY"] = "test-secret"
+
+    @app.route("/api/v1/protected")
+    def protected():
+        return {"data": "secret"}
+
+    init_ui_auth(app)
+    with app.test_client() as client:
+        r = client.get("/api/v1/protected", headers={"X-Api-Key": "test-key"})
+        assert r.status_code == 200
+
+    os.environ.pop("SUBLARR_API_KEY", None)
+    reload_settings()

--- a/backend/ui_auth.py
+++ b/backend/ui_auth.py
@@ -1,0 +1,94 @@
+"""UI session authentication for Sublarr web interface.
+
+Provides optional single-password protection for the web UI.
+API routes accept either a valid UI session OR an X-Api-Key header.
+Auth endpoints and /api/v1/health are always exempt.
+"""
+
+import hmac
+import logging
+import secrets
+
+import bcrypt
+from flask import jsonify, request, session
+
+logger = logging.getLogger(__name__)
+
+
+def _get_config_entry(key: str):
+    from db.config import get_config_entry
+    return get_config_entry(key)
+
+
+def _save_config_entry(key: str, value: str):
+    from db.config import save_config_entry
+    save_config_entry(key, value)
+
+
+def hash_password(password: str) -> str:
+    return bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
+
+
+def verify_password(password: str, hashed: str) -> bool:
+    if not password:
+        return False
+    return bcrypt.checkpw(password.encode(), hashed.encode())
+
+
+def is_ui_auth_configured() -> bool:
+    return _get_config_entry("ui_password_hash") is not None
+
+
+def is_ui_auth_enabled() -> bool:
+    return _get_config_entry("ui_auth_enabled") == "true"
+
+
+def _get_or_create_secret_key() -> str:
+    existing = _get_config_entry("ui_session_secret")
+    if existing:
+        return existing
+    new_secret = secrets.token_hex(32)
+    _save_config_entry("ui_session_secret", new_secret)
+    return new_secret
+
+
+def _has_valid_api_key() -> bool:
+    from config import get_settings
+    settings = get_settings()
+    if not settings.api_key:
+        return False
+    provided = request.headers.get("X-Api-Key") or request.args.get("apikey")
+    if not provided:
+        return False
+    return hmac.compare_digest(provided, settings.api_key)
+
+
+_EXEMPT_PATHS = {"/api/v1/health"}
+_EXEMPT_PREFIXES = ("/api/v1/auth/", "/socket.io/")
+
+
+def init_ui_auth(app):
+    try:
+        app.config["SECRET_KEY"] = _get_or_create_secret_key()
+    except Exception:
+        app.config.setdefault("SECRET_KEY", secrets.token_hex(32))
+
+    @app.before_request
+    def check_ui_session():
+        path = request.path
+        if path in _EXEMPT_PATHS:
+            return None
+        for prefix in _EXEMPT_PREFIXES:
+            if path.startswith(prefix):
+                return None
+        if not path.startswith("/api/"):
+            return None
+        if not is_ui_auth_enabled():
+            return None
+        if session.get("ui_authenticated"):
+            return None
+        if _has_valid_api_key():
+            return None
+        return jsonify({"error": "Authentication required"}), 401
+
+    logger.info("UI authentication hook registered")

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import { GlobalSearchModal } from '@/components/search/GlobalSearchModal'
 import { QuickActionsFAB } from '@/components/quick-actions/QuickActionsFAB'
 import { KeyboardShortcutsModal } from '@/components/quick-actions/KeyboardShortcutsModal'
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts'
+import { AuthGuard } from '@/components/auth/AuthGuard'
 
 // Route-level code splitting: each page is lazy-loaded as a separate chunk
 const Dashboard = lazy(() => import('@/pages/Dashboard').then(m => ({ default: m.Dashboard })))
@@ -33,6 +34,8 @@ const TasksPage = lazy(() => import('@/pages/Tasks').then(m => ({ default: m.Tas
 const PluginsPage = lazy(() => import('@/pages/Plugins').then(m => ({ default: m.PluginsPage })))
 const NotFoundPage = lazy(() => import('@/pages/NotFound').then(m => ({ default: m.NotFoundPage })))
 const Onboarding = lazy(() => import('@/pages/Onboarding'))
+const SetupPage = lazy(() => import('@/pages/Setup').then(m => ({ default: m.SetupPage })))
+const LoginPage = lazy(() => import('@/pages/Login').then(m => ({ default: m.LoginPage })))
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -46,27 +49,39 @@ const queryClient = new QueryClient({
 
 function AnimatedRoutes() {
   const location = useLocation()
+  const isAuthRoute = location.pathname === '/setup' || location.pathname === '/login'
+
+  if (isAuthRoute) {
+    return (
+      <Routes location={location}>
+        <Route path="/setup" element={<Suspense fallback={<PageSkeleton />}><SetupPage /></Suspense>} />
+        <Route path="/login" element={<Suspense fallback={<PageSkeleton />}><LoginPage /></Suspense>} />
+      </Routes>
+    )
+  }
 
   return (
-    <div key={location.pathname} className="page-enter">
-      <Routes location={location}>
-        <Route path="/" element={<Suspense fallback={<PageSkeleton />}><Dashboard /></Suspense>} />
-        <Route path="/library" element={<Suspense fallback={<LibrarySkeleton />}><LibraryPage /></Suspense>} />
-        <Route path="/library/series/:id" element={<Suspense fallback={<PageSkeleton />}><SeriesDetailPage /></Suspense>} />
-        <Route path="/activity" element={<Suspense fallback={<PageSkeleton />}><ActivityPage /></Suspense>} />
-        <Route path="/wanted" element={<Suspense fallback={<ListSkeleton />}><WantedPage /></Suspense>} />
-        <Route path="/queue" element={<Suspense fallback={<TableSkeleton />}><QueuePage /></Suspense>} />
-        <Route path="/history" element={<Suspense fallback={<TableSkeleton />}><HistoryPage /></Suspense>} />
-        <Route path="/blacklist" element={<Suspense fallback={<TableSkeleton />}><BlacklistPage /></Suspense>} />
-        <Route path="/settings" element={<Suspense fallback={<FormSkeleton />}><SettingsPage /></Suspense>} />
-        <Route path="/statistics" element={<Suspense fallback={<PageSkeleton />}><StatisticsPage /></Suspense>} />
-        <Route path="/tasks" element={<Suspense fallback={<PageSkeleton />}><TasksPage /></Suspense>} />
-        <Route path="/plugins" element={<Suspense fallback={<PageSkeleton />}><PluginsPage /></Suspense>} />
-        <Route path="/logs" element={<Suspense fallback={<PageSkeleton />}><LogsPage /></Suspense>} />
-        <Route path="/onboarding" element={<Suspense fallback={<PageSkeleton />}><Onboarding /></Suspense>} />
-        <Route path="*" element={<Suspense fallback={<PageSkeleton />}><NotFoundPage /></Suspense>} />
-      </Routes>
-    </div>
+    <AuthGuard>
+      <div key={location.pathname} className="page-enter">
+        <Routes location={location}>
+          <Route path="/" element={<Suspense fallback={<PageSkeleton />}><Dashboard /></Suspense>} />
+          <Route path="/library" element={<Suspense fallback={<LibrarySkeleton />}><LibraryPage /></Suspense>} />
+          <Route path="/library/series/:id" element={<Suspense fallback={<PageSkeleton />}><SeriesDetailPage /></Suspense>} />
+          <Route path="/activity" element={<Suspense fallback={<PageSkeleton />}><ActivityPage /></Suspense>} />
+          <Route path="/wanted" element={<Suspense fallback={<ListSkeleton />}><WantedPage /></Suspense>} />
+          <Route path="/queue" element={<Suspense fallback={<TableSkeleton />}><QueuePage /></Suspense>} />
+          <Route path="/history" element={<Suspense fallback={<TableSkeleton />}><HistoryPage /></Suspense>} />
+          <Route path="/blacklist" element={<Suspense fallback={<TableSkeleton />}><BlacklistPage /></Suspense>} />
+          <Route path="/settings" element={<Suspense fallback={<FormSkeleton />}><SettingsPage /></Suspense>} />
+          <Route path="/statistics" element={<Suspense fallback={<PageSkeleton />}><StatisticsPage /></Suspense>} />
+          <Route path="/tasks" element={<Suspense fallback={<PageSkeleton />}><TasksPage /></Suspense>} />
+          <Route path="/plugins" element={<Suspense fallback={<PageSkeleton />}><PluginsPage /></Suspense>} />
+          <Route path="/logs" element={<Suspense fallback={<PageSkeleton />}><LogsPage /></Suspense>} />
+          <Route path="/onboarding" element={<Suspense fallback={<PageSkeleton />}><Onboarding /></Suspense>} />
+          <Route path="*" element={<Suspense fallback={<PageSkeleton />}><NotFoundPage /></Suspense>} />
+        </Routes>
+      </div>
+    </AuthGuard>
   )
 }
 
@@ -109,6 +124,55 @@ function GlobalShortcuts({ onToggleShortcutsModal }: { onToggleShortcutsModal: (
   return null
 }
 
+function AppInner({
+  searchOpen,
+  setSearchOpen,
+  shortcutsModalOpen,
+  toggleShortcutsModal,
+  closeShortcutsModal,
+}: {
+  searchOpen: boolean
+  setSearchOpen: (v: boolean) => void
+  shortcutsModalOpen: boolean
+  toggleShortcutsModal: () => void
+  closeShortcutsModal: () => void
+}) {
+  const location = useLocation()
+  const isAuthRoute = location.pathname === '/setup' || location.pathname === '/login'
+
+  return (
+    <>
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-[100] focus:px-4 focus:py-2 focus:rounded"
+        style={{ backgroundColor: 'var(--accent)', color: '#fff' }}
+      >
+        Skip to main content
+      </a>
+      <GlobalWebSocketListener />
+      <GlobalShortcuts onToggleShortcutsModal={toggleShortcutsModal} />
+      {isAuthRoute ? (
+        <AnimatedRoutes />
+      ) : (
+        <div className="flex min-h-screen">
+          <Sidebar />
+          <main id="main-content" className="flex-1 min-w-0 p-4 md:p-5 pt-16 md:pt-5 min-h-screen">
+            <AnimatedRoutes />
+          </main>
+        </div>
+      )}
+      {!isAuthRoute && (
+        <>
+          <GlobalSearchModal open={searchOpen} onOpenChange={setSearchOpen} />
+          <QuickActionsFAB />
+          <KeyboardShortcutsModal open={shortcutsModalOpen} onClose={closeShortcutsModal} />
+        </>
+      )}
+      <ToastContainer />
+    </>
+  )
+}
+
 function App() {
   const [searchOpen, setSearchOpen] = useState(false)
   const [shortcutsModalOpen, setShortcutsModalOpen] = useState(false)
@@ -137,25 +201,13 @@ function App() {
     <QueryClientProvider client={queryClient}>
       <WebSocketProvider>
       <BrowserRouter>
-        <a
-          href="#main-content"
-          className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-[100] focus:px-4 focus:py-2 focus:rounded"
-          style={{ backgroundColor: 'var(--accent)', color: '#fff' }}
-        >
-          Skip to main content
-        </a>
-        <GlobalWebSocketListener />
-        <GlobalShortcuts onToggleShortcutsModal={toggleShortcutsModal} />
-        <div className="flex min-h-screen">
-          <Sidebar />
-          <main id="main-content" className="flex-1 min-w-0 p-4 md:p-5 pt-16 md:pt-5 min-h-screen">
-            <AnimatedRoutes />
-          </main>
-        </div>
-        <GlobalSearchModal open={searchOpen} onOpenChange={setSearchOpen} />
-        <ToastContainer />
-        <QuickActionsFAB />
-        <KeyboardShortcutsModal open={shortcutsModalOpen} onClose={closeShortcutsModal} />
+        <AppInner
+          searchOpen={searchOpen}
+          setSearchOpen={setSearchOpen}
+          shortcutsModalOpen={shortcutsModalOpen}
+          toggleShortcutsModal={toggleShortcutsModal}
+          closeShortcutsModal={closeShortcutsModal}
+        />
       </BrowserRouter>
       </WebSocketProvider>
     </QueryClientProvider>

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,6 +1,6 @@
 import axios from 'axios'
 import type {
-  HealthStatus, UpdateInfo, Stats, PaginatedJobs, Job, BatchState,
+  AuthStatus, HealthStatus, UpdateInfo, Stats, PaginatedJobs, Job, BatchState,
   LibraryInfo, SeriesDetail, AppConfig, PaginatedWanted, WantedSummary,
   WantedSearchResponse, WantedBatchStatus, ProviderInfo, ProviderStats,
   RetranslateStatus, LanguageProfile, EpisodeHistoryEntry,
@@ -38,6 +38,15 @@ api.interceptors.request.use((config) => {
   return config
 })
 
+api.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error.response?.status === 401 && !error.config.url?.includes('/auth/')) {
+      window.location.reload()
+    }
+    return Promise.reject(error)
+  }
+)
 
 // ─── Health & Status ─────────────────────────────────────────────────────────
 
@@ -1787,6 +1796,33 @@ export async function applySubtitleDiff(
     const msg = (err as { response?: { data?: { error?: string } } })?.response?.data?.error
     throw new Error(msg ?? `applySubtitleDiff failed`)
   }
+}
+
+// ─── UI Auth ─────────────────────────────────────────────────────────────────
+
+export async function getAuthStatus(): Promise<AuthStatus> {
+  const { data } = await api.get('/auth/status')
+  return data
+}
+
+export async function setupAuth(body: { action: 'set_password'; password: string } | { action: 'disable' }): Promise<void> {
+  await api.post('/auth/setup', body)
+}
+
+export async function login(password: string): Promise<void> {
+  await api.post('/auth/login', { password })
+}
+
+export async function logout(): Promise<void> {
+  await api.post('/auth/logout')
+}
+
+export async function changePassword(currentPassword: string, newPassword: string): Promise<void> {
+  await api.post('/auth/change-password', { current_password: currentPassword, new_password: newPassword })
+}
+
+export async function toggleAuth(enabled: boolean): Promise<void> {
+  await api.post('/auth/toggle', { enabled })
 }
 
 export default api

--- a/frontend/src/components/auth/AuthGuard.tsx
+++ b/frontend/src/components/auth/AuthGuard.tsx
@@ -1,0 +1,28 @@
+import { useQuery } from '@tanstack/react-query'
+import { Navigate, useLocation } from 'react-router-dom'
+import { getAuthStatus } from '@/api/client'
+
+interface AuthGuardProps {
+  children: React.ReactNode
+}
+
+export function AuthGuard({ children }: AuthGuardProps) {
+  const location = useLocation()
+  const { data: auth, isLoading } = useQuery({
+    queryKey: ['auth-status'],
+    queryFn: getAuthStatus,
+    staleTime: 30_000,
+    retry: false,
+  })
+
+  if (isLoading) return null
+
+  if (auth && !auth.configured) {
+    return <Navigate to="/setup" replace />
+  }
+  if (auth?.configured && auth.enabled && !auth.authenticated) {
+    return <Navigate to="/login" state={{ from: location.pathname }} replace />
+  }
+
+  return <>{children}</>
+}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { NavLink } from 'react-router-dom'
+import { NavLink, useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import {
   LayoutDashboard,
@@ -17,9 +17,12 @@ import {
   ListChecks,
   Heart,
   Star,
+  LogOut,
 } from 'lucide-react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { cn } from '@/lib/utils'
 import { useHealth, useUpdateInfo } from '@/hooks/useApi'
+import { getAuthStatus, logout } from '@/api/client'
 import { ThemeToggle } from '@/components/shared/ThemeToggle'
 import { LanguageSwitcher } from '@/components/shared/LanguageSwitcher'
 import { ScanProgressIndicator } from '@/components/shared/ScanProgressIndicator'
@@ -70,6 +73,16 @@ export function Sidebar() {
   const { t } = useTranslation('common')
   const [mobileOpen, setMobileOpen] = useState(false)
   const isHealthy = health?.status === 'healthy'
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const { data: auth } = useQuery({ queryKey: ['auth-status'], queryFn: getAuthStatus, staleTime: 60_000 })
+  const { mutate: doLogout } = useMutation({
+    mutationFn: logout,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['auth-status'] })
+      navigate('/login')
+    },
+  })
 
   return (
     <>
@@ -212,6 +225,18 @@ export function Sidebar() {
         <div className="px-3 py-2.5" style={{ borderTop: '1px solid var(--border)' }}>
           {/* Scan progress */}
           <ScanProgressIndicator />
+
+          {/* Logout */}
+          {auth?.enabled && auth?.authenticated && (
+            <button
+              onClick={() => doLogout()}
+              className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm transition-opacity hover:opacity-80"
+              style={{ color: 'var(--text-muted)' }}
+            >
+              <LogOut size={16} />
+              <span>Log out</span>
+            </button>
+          )}
 
           {/* Donate + Star */}
           <div className="flex gap-1.5 mb-2">

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -20,6 +20,12 @@ export interface PaginatedJobs {
   total_pages: number
 }
 
+export interface AuthStatus {
+  configured: boolean
+  enabled: boolean
+  authenticated: boolean
+}
+
 export interface HealthStatus {
   status: 'healthy' | 'unhealthy'
   version: string

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,0 +1,71 @@
+import { useState } from 'react'
+import { useNavigate, useLocation } from 'react-router-dom'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { Lock, Eye, EyeOff } from 'lucide-react'
+import { login } from '@/api/client'
+import { toast } from '@/components/shared/Toast'
+
+export function LoginPage() {
+  const navigate = useNavigate()
+  const location = useLocation()
+  const queryClient = useQueryClient()
+  const [password, setPassword] = useState('')
+  const [showPassword, setShowPassword] = useState(false)
+  const from = (location.state as { from?: string })?.from ?? '/'
+
+  const { mutate: doLogin, isPending, isError } = useMutation({
+    mutationFn: () => login(password),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['auth-status'] })
+      navigate(from, { replace: true })
+    },
+    onError: () => toast('Invalid password', 'error'),
+  })
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (password) doLogin()
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center" style={{ backgroundColor: 'var(--bg-base)' }}>
+      <div className="w-full max-w-sm rounded-xl p-8 shadow-xl" style={{ backgroundColor: 'var(--bg-surface)', border: '1px solid var(--border)' }}>
+        <div className="mb-8 text-center">
+          <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full" style={{ backgroundColor: 'var(--accent-muted)' }}>
+            <Lock size={24} style={{ color: 'var(--accent)' }} />
+          </div>
+          <h1 className="text-2xl font-bold" style={{ color: 'var(--text-primary)' }}>Sublarr</h1>
+          <p className="mt-1 text-sm" style={{ color: 'var(--text-muted)' }}>Enter your password to continue</p>
+        </div>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="relative">
+            <input
+              type={showPassword ? 'text' : 'password'}
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="Password"
+              className="w-full rounded-lg px-3 py-2 pr-10 text-sm"
+              style={{
+                backgroundColor: 'var(--bg-input)',
+                border: `1px solid ${isError ? 'var(--color-error)' : 'var(--border)'}`,
+                color: 'var(--text-primary)',
+                outline: 'none',
+              }}
+              autoFocus
+            />
+            <button type="button" onClick={() => setShowPassword((v) => !v)}
+              className="absolute right-2 top-1/2 -translate-y-1/2" style={{ color: 'var(--text-muted)' }}
+              aria-label={showPassword ? 'Hide password' : 'Show password'}>
+              {showPassword ? <EyeOff size={16} /> : <Eye size={16} />}
+            </button>
+          </div>
+          <button type="submit" disabled={isPending || !password}
+            className="w-full rounded-lg py-2 text-sm font-semibold transition-opacity disabled:opacity-50"
+            style={{ backgroundColor: 'var(--accent)', color: '#fff' }}>
+            {isPending ? 'Logging in…' : 'Log In'}
+          </button>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/Settings/SecurityTab.tsx
+++ b/frontend/src/pages/Settings/SecurityTab.tsx
@@ -1,0 +1,97 @@
+import { useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Shield, Eye, EyeOff } from 'lucide-react'
+import { getAuthStatus, toggleAuth, changePassword } from '@/api/client'
+import { toast } from '@/components/shared/Toast'
+import { SettingsCard } from '@/components/shared/SettingsCard'
+import { SettingRow } from '@/components/shared/SettingRow'
+import { Toggle } from '@/components/shared/Toggle'
+
+export function SecurityTab() {
+  const queryClient = useQueryClient()
+  const { data: auth } = useQuery({ queryKey: ['auth-status'], queryFn: getAuthStatus })
+  const [currentPw, setCurrentPw] = useState('')
+  const [newPw, setNewPw] = useState('')
+  const [confirmPw, setConfirmPw] = useState('')
+  const [showPw, setShowPw] = useState(false)
+  const [pwError, setPwError] = useState('')
+
+  const { mutate: doToggle, isPending: toggling } = useMutation({
+    mutationFn: (enabled: boolean) => toggleAuth(enabled),
+    onSuccess: (_, enabled) => {
+      queryClient.invalidateQueries({ queryKey: ['auth-status'] })
+      toast(`UI authentication ${enabled ? 'enabled' : 'disabled'}`, 'success')
+    },
+    onError: () => toast('Failed to update authentication setting', 'error'),
+  })
+
+  const { mutate: doChangePw, isPending: changingPw } = useMutation({
+    mutationFn: () => changePassword(currentPw, newPw),
+    onSuccess: () => {
+      setCurrentPw(''); setNewPw(''); setConfirmPw(''); setPwError('')
+      toast('Password changed', 'success')
+    },
+    onError: (err: unknown) => {
+      const msg = (err as { response?: { data?: { error?: string } } })?.response?.data?.error ?? 'Failed'
+      toast(msg, 'error')
+    },
+  })
+
+  function handleChangePw(e: React.FormEvent) {
+    e.preventDefault()
+    setPwError('')
+    if (newPw.length < 4) { setPwError('New password must be at least 4 characters.'); return }
+    if (newPw !== confirmPw) { setPwError('Passwords do not match.'); return }
+    doChangePw()
+  }
+
+  const inputStyle = {
+    backgroundColor: 'var(--bg-input)', border: '1px solid var(--border)',
+    color: 'var(--text-primary)', borderRadius: '0.5rem',
+    padding: '0.375rem 0.75rem', fontSize: '0.875rem', width: '100%', outline: 'none',
+  }
+
+  return (
+    <div className="space-y-6">
+      <SettingsCard title="UI Authentication" icon={Shield}>
+        <SettingRow label="Require login"
+          description="Protect the web UI with a password. API key authentication is unaffected.">
+          <Toggle checked={auth?.enabled ?? false} onChange={(v) => doToggle(v)} disabled={toggling} />
+        </SettingRow>
+      </SettingsCard>
+
+      {auth?.enabled && (
+        <SettingsCard title="Change Password" icon={Shield}>
+          <form onSubmit={handleChangePw} className="space-y-3 pt-1">
+            <div>
+              <label className="mb-1 block text-xs font-medium" style={{ color: 'var(--text-secondary)' }}>Current Password</label>
+              <div className="relative">
+                <input type={showPw ? 'text' : 'password'} value={currentPw}
+                  onChange={(e) => setCurrentPw(e.target.value)} style={{ ...inputStyle, paddingRight: '2.5rem' }} />
+                <button type="button" onClick={() => setShowPw((v) => !v)}
+                  className="absolute right-2 top-1/2 -translate-y-1/2" style={{ color: 'var(--text-muted)' }}
+                  aria-label={showPw ? 'Hide' : 'Show'}>
+                  {showPw ? <EyeOff size={14} /> : <Eye size={14} />}
+                </button>
+              </div>
+            </div>
+            <div>
+              <label className="mb-1 block text-xs font-medium" style={{ color: 'var(--text-secondary)' }}>New Password</label>
+              <input type={showPw ? 'text' : 'password'} value={newPw} onChange={(e) => setNewPw(e.target.value)} style={inputStyle} />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs font-medium" style={{ color: 'var(--text-secondary)' }}>Confirm New Password</label>
+              <input type={showPw ? 'text' : 'password'} value={confirmPw} onChange={(e) => setConfirmPw(e.target.value)} style={inputStyle} />
+            </div>
+            {pwError && <p className="text-xs" style={{ color: 'var(--color-error)' }}>{pwError}</p>}
+            <button type="submit" disabled={changingPw || !currentPw || !newPw || !confirmPw}
+              className="rounded-lg px-4 py-1.5 text-sm font-semibold transition-opacity disabled:opacity-50"
+              style={{ backgroundColor: 'var(--accent)', color: '#fff' }}>
+              {changingPw ? 'Saving…' : 'Change Password'}
+            </button>
+          </form>
+        </SettingsCard>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/Settings/index.tsx
+++ b/frontend/src/pages/Settings/index.tsx
@@ -43,6 +43,7 @@ const NotificationTemplatesTab = lazy(() => import('./NotificationTemplatesTab')
 const CleanupTab = lazy(() => import('./CleanupTab').then(m => ({ default: m.CleanupTab })))
 const IntegrationsTab = lazy(() => import('./IntegrationsTab').then(m => ({ default: m.IntegrationsTab })))
 const MigrationTab = lazy(() => import('./MigrationTab').then(m => ({ default: m.MigrationTab })))
+const SecurityTab = lazy(() => import('./SecurityTab').then(m => ({ default: m.SecurityTab })))
 
 function TabSkeleton() {
   return (
@@ -72,7 +73,7 @@ const NAV_GROUPS: NavGroup[] = [
   { title: 'Translation', icon: Languages,  items: ['Translation', 'Translation Backends', 'Prompt Presets', 'Languages'] },
   { title: 'Automation',  icon: Zap,        items: ['Automation', 'Wanted', 'Whisper'] },
   { title: 'Providers',   icon: Globe,      items: ['Providers', 'Scoring'] },
-  { title: 'System',      icon: Cog,        items: ['Events & Hooks', 'Backup', 'Subtitle Tools', 'Cleanup', 'Integrations', 'Notification Templates'] },
+  { title: 'System',      icon: Cog,        items: ['Events & Hooks', 'Backup', 'Subtitle Tools', 'Cleanup', 'Integrations', 'Notification Templates', 'Security'] },
 ]
 
 // Flat list derived from groups (preserves ordering for legacy code)
@@ -828,6 +829,7 @@ function SettingsPageInner() {
   const isApiKeysTab = activeTab === 'API Keys'
   const isMigrationTab = activeTab === 'Migration'
   const isNotificationTemplatesTab = activeTab === 'Notification Templates'
+  const isSecurityTab = activeTab === 'Security'
 
   if (isLoading) {
     return (
@@ -1004,6 +1006,8 @@ function SettingsPageInner() {
             <MigrationTab />
           ) : isNotificationTemplatesTab ? (
             <NotificationTemplatesTab />
+          ) : isSecurityTab ? (
+            <SecurityTab />
           ) : isTranslationTab ? (
             <div className="space-y-0">
               {tabFields.map((field) => renderField(field))}

--- a/frontend/src/pages/Setup.tsx
+++ b/frontend/src/pages/Setup.tsx
@@ -1,0 +1,113 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { Lock, Unlock, Eye, EyeOff } from 'lucide-react'
+import { setupAuth } from '@/api/client'
+import { toast } from '@/components/shared/Toast'
+
+export function SetupPage() {
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const [password, setPassword] = useState('')
+  const [confirm, setConfirm] = useState('')
+  const [showPassword, setShowPassword] = useState(false)
+  const [error, setError] = useState('')
+
+  const { mutate: doSetup, isPending } = useMutation({
+    mutationFn: setupAuth,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['auth-status'] })
+      navigate('/')
+    },
+    onError: (err: unknown) => {
+      const msg = (err as { response?: { data?: { error?: string } } })?.response?.data?.error ?? 'Setup failed'
+      toast(msg, 'error')
+    },
+  })
+
+  function handleSetPassword(e: React.FormEvent) {
+    e.preventDefault()
+    setError('')
+    if (password.length < 4) { setError('Password must be at least 4 characters.'); return }
+    if (password !== confirm) { setError('Passwords do not match.'); return }
+    doSetup({ action: 'set_password', password })
+  }
+
+  function handleDisable() { doSetup({ action: 'disable' }) }
+
+  const inputStyle = {
+    backgroundColor: 'var(--bg-input)',
+    border: '1px solid var(--border)',
+    color: 'var(--text-primary)',
+    outline: 'none',
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center" style={{ backgroundColor: 'var(--bg-base)' }}>
+      <div className="w-full max-w-md rounded-xl p-8 shadow-xl" style={{ backgroundColor: 'var(--bg-surface)', border: '1px solid var(--border)' }}>
+        <div className="mb-8 text-center">
+          <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full" style={{ backgroundColor: 'var(--accent-muted)' }}>
+            <Lock size={24} style={{ color: 'var(--accent)' }} />
+          </div>
+          <h1 className="text-2xl font-bold" style={{ color: 'var(--text-primary)' }}>Welcome to Sublarr</h1>
+          <p className="mt-2 text-sm" style={{ color: 'var(--text-muted)' }}>
+            Set a password to protect the UI, or leave it open.
+          </p>
+        </div>
+
+        <form onSubmit={handleSetPassword} className="space-y-4">
+          <div>
+            <label className="mb-1 block text-sm font-medium" style={{ color: 'var(--text-secondary)' }}>Password</label>
+            <div className="relative">
+              <input
+                type={showPassword ? 'text' : 'password'}
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder="Enter a password…"
+                className="w-full rounded-lg px-3 py-2 pr-10 text-sm"
+                style={inputStyle}
+                autoFocus
+              />
+              <button type="button" onClick={() => setShowPassword((v) => !v)}
+                className="absolute right-2 top-1/2 -translate-y-1/2" style={{ color: 'var(--text-muted)' }}
+                aria-label={showPassword ? 'Hide password' : 'Show password'}>
+                {showPassword ? <EyeOff size={16} /> : <Eye size={16} />}
+              </button>
+            </div>
+          </div>
+          <div>
+            <label className="mb-1 block text-sm font-medium" style={{ color: 'var(--text-secondary)' }}>Confirm Password</label>
+            <input
+              type={showPassword ? 'text' : 'password'}
+              value={confirm}
+              onChange={(e) => setConfirm(e.target.value)}
+              placeholder="Repeat password…"
+              className="w-full rounded-lg px-3 py-2 text-sm"
+              style={inputStyle}
+            />
+          </div>
+          {error && <p className="text-sm" style={{ color: 'var(--color-error)' }}>{error}</p>}
+          <button type="submit" disabled={isPending || !password}
+            className="w-full rounded-lg py-2 text-sm font-semibold transition-opacity disabled:opacity-50"
+            style={{ backgroundColor: 'var(--accent)', color: '#fff' }}>
+            {isPending ? 'Setting up…' : 'Set Password & Continue'}
+          </button>
+        </form>
+
+        <div className="mt-4">
+          <div className="relative my-4 flex items-center">
+            <div className="flex-1" style={{ borderTop: '1px solid var(--border)' }} />
+            <span className="mx-3 text-xs" style={{ color: 'var(--text-muted)' }}>or</span>
+            <div className="flex-1" style={{ borderTop: '1px solid var(--border)' }} />
+          </div>
+          <button type="button" onClick={handleDisable} disabled={isPending}
+            className="flex w-full items-center justify-center gap-2 rounded-lg py-2 text-sm transition-opacity hover:opacity-80 disabled:opacity-50"
+            style={{ border: '1px solid var(--border)', color: 'var(--text-secondary)' }}>
+            <Unlock size={14} />
+            Continue without password (open access)
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- **Optional password protection** for the web UI — if `SUBLARR_UI_PASSWORD` is not set, first-run wizard appears on `/setup` allowing the user to set a password or leave access open
- **Flask session auth** (`before_request` hook, signed HTTP-only cookie, bcrypt hash in `config_entries` DB) — independent of existing `X-Api-Key` API auth
- **Settings → Security tab** — toggle auth on/off, change password; sidebar logout button shown when auth is active

## What's included

### Backend
- `bcrypt==4.2.1` added to `requirements.txt`
- `backend/ui_auth.py` — `hash_password`, `verify_password`, `is_ui_auth_configured`, `is_ui_auth_enabled`, `init_ui_auth(app)` (sets `SECRET_KEY` from DB-persisted secret, registers `before_request` hook)
- `backend/routes/auth_ui.py` — `GET /api/v1/auth/status`, `POST /auth/setup` (first-run), `POST /auth/login`, `POST /auth/logout`, `POST /auth/change-password`, `POST /auth/toggle`
- `backend/app.py` — blueprint + `init_ui_auth` registered
- 27 new tests (14 unit + 13 route)

### Frontend
- `AuthStatus` type + `getAuthStatus`, `setupAuth`, `login`, `logout`, `changePassword`, `toggleAuth` in `client.ts` + 401 interceptor
- `pages/Setup.tsx` — first-run wizard: set password or continue without
- `pages/Login.tsx` — password form with redirect-after-login
- `components/auth/AuthGuard.tsx` — redirects to `/setup` or `/login` as needed
- `App.tsx` — auth routes render full-screen (no Sidebar/layout)
- `pages/Settings/SecurityTab.tsx` — auth toggle + change-password form registered under Settings → Security
- `Sidebar.tsx` — logout button shown when `auth.enabled && auth.authenticated`

## Test Plan
- [ ] 576 backend tests passing (0 new failures)
- [ ] Frontend TypeScript: 0 errors
- [ ] First run (no password set): `/setup` appears, can set password or skip
- [ ] With password set: unauthenticated visits redirect to `/login`
- [ ] Correct password → logged in, redirect to original URL
- [ ] Wrong password → 401 shown
- [ ] Settings → Security: toggle disables auth, change-password works
- [ ] Sidebar logout button appears and logs out
- [ ] API key auth (`X-Api-Key`) continues to work independently of session