### PR TITLE
feat: v0.27.0 — Subtitle NFO Export

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -180,6 +180,9 @@ class Settings(BaseSettings):
     auto_sync_after_download: bool = False  # Auto-sync subtitle against video after download
     auto_sync_engine: str = "ffsubsync"  # Engine for auto-sync: "ffsubsync" | "alass"
 
+    # NFO Export
+    auto_nfo_export: bool = False  # Expert: write XML NFO sidecar after every download/translation
+
     # Wanted Search Scheduler
     wanted_search_interval_hours: int = 24  # 0 = disabled
     wanted_search_on_startup: bool = False

--- a/backend/nfo_export.py
+++ b/backend/nfo_export.py
@@ -2,6 +2,7 @@
 
 This is an expert feature disabled by default (auto_nfo_export = false).
 """
+
 import logging
 import xml.etree.ElementTree as ET
 from datetime import datetime
@@ -23,6 +24,7 @@ _FIELDS = [
 def _is_enabled() -> bool:
     try:
         from config import get_settings
+
         return bool(getattr(get_settings(), "auto_nfo_export", False))
     except Exception:
         return False
@@ -31,6 +33,7 @@ def _is_enabled() -> bool:
 def _get_version() -> str:
     try:
         from version import __version__
+
         return __version__
     except Exception:
         return ""

--- a/backend/nfo_export.py
+++ b/backend/nfo_export.py
@@ -1,0 +1,67 @@
+"""NFO sidecar export — writes Kodi/Jellyfin-compatible XML metadata alongside subtitle files.
+
+This is an expert feature disabled by default (auto_nfo_export = false).
+"""
+import logging
+import xml.etree.ElementTree as ET
+from datetime import datetime
+
+logger = logging.getLogger(__name__)
+
+_FIELDS = [
+    "provider",
+    "source_language",
+    "target_language",
+    "score",
+    "translation_backend",
+    "bleu_score",
+    "downloaded_at",
+    "sublarr_version",
+]
+
+
+def _is_enabled() -> bool:
+    try:
+        from config import get_settings
+        return bool(getattr(get_settings(), "auto_nfo_export", False))
+    except Exception:
+        return False
+
+
+def _get_version() -> str:
+    try:
+        from version import __version__
+        return __version__
+    except Exception:
+        return ""
+
+
+def write_nfo(subtitle_path: str, metadata: dict) -> None:
+    """Write an NFO XML sidecar to ``{subtitle_path}.nfo``.
+
+    Errors are logged and swallowed — NFO writing must never interrupt the
+    subtitle pipeline.
+    """
+    nfo_path = subtitle_path + ".nfo"
+    try:
+        root = ET.Element("subtitle")
+        meta = dict(metadata)
+        meta.setdefault("sublarr_version", _get_version())
+        meta.setdefault("downloaded_at", datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S"))
+        for field in _FIELDS:
+            val = meta.get(field)
+            ET.SubElement(root, field).text = "" if val is None else str(val)
+        tree = ET.ElementTree(root)
+        ET.indent(tree, space="  ")
+        with open(nfo_path, "wb") as f:
+            tree.write(f, xml_declaration=True, encoding="utf-8")
+        logger.debug("Wrote NFO sidecar: %s", nfo_path)
+    except Exception as exc:
+        logger.warning("Failed to write NFO sidecar %s: %s", nfo_path, exc)
+
+
+def maybe_write_nfo(subtitle_path: str, metadata: dict) -> None:
+    """Write NFO only when auto_nfo_export is enabled in settings."""
+    if not _is_enabled():
+        return
+    write_nfo(subtitle_path, metadata)

--- a/backend/routes/__init__.py
+++ b/backend/routes/__init__.py
@@ -38,6 +38,7 @@ def register_blueprints(app):
     from routes.translate import bp as translate_bp
     from routes.video import bp as video_bp
     from routes.video_sync import bp as video_sync_bp
+    from routes.nfo import bp as nfo_bp
     from routes.wanted import bp as wanted_bp
     from routes.webhooks import bp as webhooks_bp
     from routes.whisper import bp as whisper_bp
@@ -77,5 +78,6 @@ def register_blueprints(app):
         subtitles_bp,
         remux_bp,
         series_audio_bp,
+        nfo_bp,
     ]:
         app.register_blueprint(blueprint)

--- a/backend/routes/__init__.py
+++ b/backend/routes/__init__.py
@@ -21,6 +21,7 @@ def register_blueprints(app):
     from routes.library import bp as library_bp
     from routes.marketplace import bp as marketplace_bp
     from routes.mediaservers import bp as mediaservers_bp
+    from routes.nfo import bp as nfo_bp
     from routes.notifications_mgmt import bp as notifications_mgmt_bp
     from routes.ocr import bp as ocr_bp
     from routes.plugins import bp as plugins_bp
@@ -38,7 +39,6 @@ def register_blueprints(app):
     from routes.translate import bp as translate_bp
     from routes.video import bp as video_bp
     from routes.video_sync import bp as video_sync_bp
-    from routes.nfo import bp as nfo_bp
     from routes.wanted import bp as wanted_bp
     from routes.webhooks import bp as webhooks_bp
     from routes.whisper import bp as whisper_bp

--- a/backend/routes/auth_ui.py
+++ b/backend/routes/auth_ui.py
@@ -26,11 +26,13 @@ def _is_session_authenticated() -> bool:
 
 @auth_ui_bp.get("/status")
 def get_status():
-    return jsonify({
-        "configured": ui_auth.is_ui_auth_configured(),
-        "enabled": ui_auth.is_ui_auth_enabled(),
-        "authenticated": _is_session_authenticated(),
-    })
+    return jsonify(
+        {
+            "configured": ui_auth.is_ui_auth_configured(),
+            "enabled": ui_auth.is_ui_auth_enabled(),
+            "authenticated": _is_session_authenticated(),
+        }
+    )
 
 
 @auth_ui_bp.post("/setup")
@@ -50,7 +52,9 @@ def setup():
     if action == "set_password":
         password = body.get("password", "")
         if len(password) < _MIN_PASSWORD_LENGTH:
-            return jsonify({"error": f"Password must be at least {_MIN_PASSWORD_LENGTH} characters"}), 400
+            return jsonify(
+                {"error": f"Password must be at least {_MIN_PASSWORD_LENGTH} characters"}
+            ), 400
         ui_auth._save_config_entry("ui_password_hash", ui_auth.hash_password(password))
         ui_auth._save_config_entry("ui_auth_enabled", "true")
         session["ui_authenticated"] = True
@@ -100,7 +104,9 @@ def change_password():
         return jsonify({"error": "Current password is incorrect"}), 401
 
     if len(new_pw) < _MIN_PASSWORD_LENGTH:
-        return jsonify({"error": f"Password must be at least {_MIN_PASSWORD_LENGTH} characters"}), 400
+        return jsonify(
+            {"error": f"Password must be at least {_MIN_PASSWORD_LENGTH} characters"}
+        ), 400
 
     ui_auth._save_config_entry("ui_password_hash", ui_auth.hash_password(new_pw))
     logger.info("UI password changed")

--- a/backend/routes/nfo.py
+++ b/backend/routes/nfo.py
@@ -128,8 +128,7 @@ def export_series_nfo(series_id: int):
 
             rows = conn.execute(
                 _text(
-                    "SELECT DISTINCT file_path FROM subtitle_downloads"
-                    " WHERE file_path LIKE :pat"
+                    "SELECT DISTINCT file_path FROM subtitle_downloads WHERE file_path LIKE :pat"
                 ),
                 {"pat": prefix + "%"},
             ).fetchall()

--- a/backend/routes/nfo.py
+++ b/backend/routes/nfo.py
@@ -1,0 +1,148 @@
+"""NFO export API endpoints.
+
+POST /api/v1/subtitles/export-nfo
+    Trigger NFO sidecar export for a single subtitle file.
+
+POST /api/v1/series/<series_id>/subtitles/export-nfo
+    Trigger NFO sidecar export for all subtitles belonging to a series.
+"""
+
+import logging
+import os
+
+from flask import Blueprint, abort, jsonify, request
+
+from nfo_export import write_nfo
+from security_utils import is_safe_path
+
+bp = Blueprint("nfo", __name__, url_prefix="/api/v1")
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers — thin wrappers so tests can monkeypatch them cleanly
+# ---------------------------------------------------------------------------
+
+
+def _get_series_path_for_nfo(series_id: int) -> str | None:
+    """Return the local filesystem path for a series, or None if not found."""
+    try:
+        from sonarr_client import get_sonarr_client
+
+        client = get_sonarr_client()
+        series = client.get_series_by_id(series_id)
+        if not series:
+            return None
+        raw_path = series.get("path", "")
+        if not raw_path:
+            return None
+        from path_mapper import map_path
+
+        return map_path(raw_path)
+    except Exception as exc:
+        logger.warning("NFO export: could not resolve series path for id=%s: %s", series_id, exc)
+        return None
+
+
+def _get_db_engine():
+    """Return the SQLAlchemy db object (monkeypatch-friendly)."""
+    from extensions import db
+
+    return db
+
+
+# ---------------------------------------------------------------------------
+# Single subtitle export
+# ---------------------------------------------------------------------------
+
+
+@bp.route("/subtitles/export-nfo", methods=["POST"])
+def export_subtitle_nfo():
+    """Write an NFO sidecar for a single subtitle file.
+
+    Query parameters:
+        path (str, required): Absolute path to the subtitle file.
+
+    Returns:
+        200 {"status": "ok", "nfo_path": "..."} on success.
+        400 if path is missing.
+        403 if path is outside the configured media_path.
+        404 if the subtitle file does not exist on disk.
+    """
+    path = request.args.get("path", "").strip()
+    if not path:
+        return jsonify({"error": "path parameter is required"}), 400
+
+    from config import get_settings
+
+    settings = get_settings()
+    media_path = getattr(settings, "media_path", "/media")
+
+    if not is_safe_path(path, media_path):
+        abort(403)
+
+    if not os.path.exists(path):
+        return jsonify({"error": "Subtitle file not found"}), 404
+
+    write_nfo(path, {})
+    nfo_path = path + ".nfo"
+    return jsonify({"status": "ok", "nfo_path": nfo_path}), 200
+
+
+# ---------------------------------------------------------------------------
+# Series-wide export
+# ---------------------------------------------------------------------------
+
+
+@bp.route("/series/<int:series_id>/subtitles/export-nfo", methods=["POST"])
+def export_series_nfo(series_id: int):
+    """Write NFO sidecars for all subtitle files in a series.
+
+    Resolves the series filesystem path via Sonarr, then queries
+    subtitle_downloads for all matching file_path entries.
+
+    Returns:
+        200 {"status": "ok", "exported": N, "skipped": M} on success.
+        404 if the series cannot be found.
+        500 on DB errors.
+    """
+    series_path = _get_series_path_for_nfo(series_id)
+    if not series_path:
+        return jsonify({"error": "Series not found"}), 404
+
+    from config import get_settings
+
+    settings = get_settings()
+    media_path = getattr(settings, "media_path", "/media")
+
+    if not is_safe_path(series_path, media_path):
+        return jsonify({"error": "Access denied"}), 403
+
+    try:
+        db = _get_db_engine()
+        prefix = series_path.rstrip("/\\") + "/"
+        with db.engine.connect() as conn:
+            from sqlalchemy import text as _text
+
+            rows = conn.execute(
+                _text(
+                    "SELECT DISTINCT file_path FROM subtitle_downloads"
+                    " WHERE file_path LIKE :pat"
+                ),
+                {"pat": prefix + "%"},
+            ).fetchall()
+    except Exception as exc:
+        logger.error("NFO export: DB error for series %s: %s", series_id, exc)
+        return jsonify({"error": "Database error"}), 500
+
+    exported = 0
+    skipped = 0
+    for (fp,) in rows:
+        if os.path.exists(fp):
+            write_nfo(fp, {})
+            exported += 1
+        else:
+            skipped += 1
+            logger.debug("NFO export: skipping missing file %s", fp)
+
+    return jsonify({"status": "ok", "exported": exported, "skipped": skipped}), 200

--- a/backend/routes/nfo.py
+++ b/backend/routes/nfo.py
@@ -86,6 +86,8 @@ def export_subtitle_nfo():
 
     write_nfo(path, {})
     nfo_path = path + ".nfo"
+    if not os.path.exists(nfo_path):
+        return jsonify({"error": "NFO write failed"}), 500
     return jsonify({"status": "ok", "nfo_path": nfo_path}), 200
 
 
@@ -138,11 +140,15 @@ def export_series_nfo(series_id: int):
     exported = 0
     skipped = 0
     for (fp,) in rows:
-        if os.path.exists(fp):
-            write_nfo(fp, {})
-            exported += 1
-        else:
+        if not is_safe_path(fp, media_path):
+            skipped += 1
+            logger.debug("NFO export: skipping unsafe path %s", fp)
+            continue
+        if not os.path.exists(fp):
             skipped += 1
             logger.debug("NFO export: skipping missing file %s", fp)
+            continue
+        write_nfo(fp, {})
+        exported += 1
 
     return jsonify({"status": "ok", "exported": exported, "skipped": skipped}), 200

--- a/backend/tests/test_nfo_export.py
+++ b/backend/tests/test_nfo_export.py
@@ -1,4 +1,5 @@
 """Tests for nfo_export.py — XML sidecar writing."""
+
 import os
 import xml.etree.ElementTree as ET
 
@@ -10,7 +11,15 @@ import nfo_export
 def test_write_nfo_creates_file(tmp_path):
     sub = tmp_path / "ep01.de.ass"
     sub.write_text("dummy")
-    nfo_export.write_nfo(str(sub), {"provider": "OpenSubtitles", "score": 720, "source_language": "en", "target_language": "de"})
+    nfo_export.write_nfo(
+        str(sub),
+        {
+            "provider": "OpenSubtitles",
+            "score": 720,
+            "source_language": "en",
+            "target_language": "de",
+        },
+    )
     nfo = tmp_path / "ep01.de.ass.nfo"
     assert nfo.exists()
 
@@ -18,15 +27,18 @@ def test_write_nfo_creates_file(tmp_path):
 def test_write_nfo_xml_content(tmp_path):
     sub = tmp_path / "ep01.de.ass"
     sub.write_text("dummy")
-    nfo_export.write_nfo(str(sub), {
-        "provider": "OpenSubtitles",
-        "score": 720,
-        "source_language": "en",
-        "target_language": "de",
-        "translation_backend": "gpt-4o-mini",
-        "bleu_score": 0.41,
-        "downloaded_at": "2026-03-14T11:30:00",
-    })
+    nfo_export.write_nfo(
+        str(sub),
+        {
+            "provider": "OpenSubtitles",
+            "score": 720,
+            "source_language": "en",
+            "target_language": "de",
+            "translation_backend": "gpt-4o-mini",
+            "bleu_score": 0.41,
+            "downloaded_at": "2026-03-14T11:30:00",
+        },
+    )
     tree = ET.parse(str(tmp_path / "ep01.de.ass.nfo"))
     root = tree.getroot()
     assert root.tag == "subtitle"

--- a/backend/tests/test_nfo_export.py
+++ b/backend/tests/test_nfo_export.py
@@ -1,0 +1,65 @@
+"""Tests for nfo_export.py — XML sidecar writing."""
+import os
+import xml.etree.ElementTree as ET
+import pytest
+import nfo_export
+
+
+def test_write_nfo_creates_file(tmp_path):
+    sub = tmp_path / "ep01.de.ass"
+    sub.write_text("dummy")
+    nfo_export.write_nfo(str(sub), {"provider": "OpenSubtitles", "score": 720, "source_language": "en", "target_language": "de"})
+    nfo = tmp_path / "ep01.de.ass.nfo"
+    assert nfo.exists()
+
+
+def test_write_nfo_xml_content(tmp_path):
+    sub = tmp_path / "ep01.de.ass"
+    sub.write_text("dummy")
+    nfo_export.write_nfo(str(sub), {
+        "provider": "OpenSubtitles",
+        "score": 720,
+        "source_language": "en",
+        "target_language": "de",
+        "translation_backend": "gpt-4o-mini",
+        "bleu_score": 0.41,
+        "downloaded_at": "2026-03-14T11:30:00",
+    })
+    tree = ET.parse(str(tmp_path / "ep01.de.ass.nfo"))
+    root = tree.getroot()
+    assert root.tag == "subtitle"
+    assert root.findtext("provider") == "OpenSubtitles"
+    assert root.findtext("score") == "720"
+    assert root.findtext("target_language") == "de"
+    assert root.findtext("translation_backend") == "gpt-4o-mini"
+
+
+def test_write_nfo_missing_fields_writes_empty_elements(tmp_path):
+    sub = tmp_path / "ep01.de.ass"
+    sub.write_text("dummy")
+    nfo_export.write_nfo(str(sub), {})
+    tree = ET.parse(str(tmp_path / "ep01.de.ass.nfo"))
+    root = tree.getroot()
+    assert root.findtext("provider") == ""
+    assert root.findtext("score") == ""
+
+
+def test_write_nfo_error_does_not_raise(tmp_path):
+    # Non-existent directory — should log but not raise
+    nfo_export.write_nfo("/nonexistent/dir/ep01.de.ass", {"provider": "X"})
+
+
+def test_maybe_write_nfo_skips_when_disabled(tmp_path, monkeypatch):
+    sub = tmp_path / "ep01.de.ass"
+    sub.write_text("dummy")
+    monkeypatch.setattr(nfo_export, "_is_enabled", lambda: False)
+    nfo_export.maybe_write_nfo(str(sub), {})
+    assert not (tmp_path / "ep01.de.ass.nfo").exists()
+
+
+def test_maybe_write_nfo_writes_when_enabled(tmp_path, monkeypatch):
+    sub = tmp_path / "ep01.de.ass"
+    sub.write_text("dummy")
+    monkeypatch.setattr(nfo_export, "_is_enabled", lambda: True)
+    nfo_export.maybe_write_nfo(str(sub), {"provider": "Test"})
+    assert (tmp_path / "ep01.de.ass.nfo").exists()

--- a/backend/tests/test_nfo_export.py
+++ b/backend/tests/test_nfo_export.py
@@ -1,7 +1,9 @@
 """Tests for nfo_export.py — XML sidecar writing."""
 import os
 import xml.etree.ElementTree as ET
+
 import pytest
+
 import nfo_export
 
 

--- a/backend/tests/test_routes_auth_ui.py
+++ b/backend/tests/test_routes_auth_ui.py
@@ -38,7 +38,9 @@ def test_setup_set_password(app, monkeypatch):
     monkeypatch.setattr(ui_auth, "is_ui_auth_configured", lambda: False)
     monkeypatch.setattr(ui_auth, "_save_config_entry", lambda k, v: saved.update({k: v}))
     with app.test_client() as client:
-        r = client.post("/api/v1/auth/setup", json={"action": "set_password", "password": "hunter2"})
+        r = client.post(
+            "/api/v1/auth/setup", json={"action": "set_password", "password": "hunter2"}
+        )
         assert r.status_code == 200
         assert "ui_password_hash" in saved
         assert saved["ui_auth_enabled"] == "true"
@@ -72,7 +74,9 @@ def test_login_correct_password(app, monkeypatch):
     pw_hash = ui_auth.hash_password("correct")
     monkeypatch.setattr(ui_auth, "is_ui_auth_configured", lambda: True)
     monkeypatch.setattr(ui_auth, "is_ui_auth_enabled", lambda: True)
-    monkeypatch.setattr(ui_auth, "_get_config_entry", lambda k: pw_hash if k == "ui_password_hash" else "true")
+    monkeypatch.setattr(
+        ui_auth, "_get_config_entry", lambda k: pw_hash if k == "ui_password_hash" else "true"
+    )
     with app.test_client() as client:
         r = client.post("/api/v1/auth/login", json={"password": "correct"})
         assert r.status_code == 200
@@ -82,7 +86,9 @@ def test_login_wrong_password(app, monkeypatch):
     pw_hash = ui_auth.hash_password("correct")
     monkeypatch.setattr(ui_auth, "is_ui_auth_configured", lambda: True)
     monkeypatch.setattr(ui_auth, "is_ui_auth_enabled", lambda: True)
-    monkeypatch.setattr(ui_auth, "_get_config_entry", lambda k: pw_hash if k == "ui_password_hash" else "true")
+    monkeypatch.setattr(
+        ui_auth, "_get_config_entry", lambda k: pw_hash if k == "ui_password_hash" else "true"
+    )
     with app.test_client() as client:
         r = client.post("/api/v1/auth/login", json={"password": "wrong"})
         assert r.status_code == 401
@@ -108,24 +114,34 @@ def test_logout_clears_session(app, monkeypatch):
 
 def test_change_password_correct(app, monkeypatch):
     pw_hash = ui_auth.hash_password("old")
-    monkeypatch.setattr(ui_auth, "_get_config_entry", lambda k: pw_hash if k == "ui_password_hash" else "true")
+    monkeypatch.setattr(
+        ui_auth, "_get_config_entry", lambda k: pw_hash if k == "ui_password_hash" else "true"
+    )
     saved = {}
     monkeypatch.setattr(ui_auth, "_save_config_entry", lambda k, v: saved.update({k: v}))
     with app.test_client() as client:
         with client.session_transaction() as sess:
             sess["ui_authenticated"] = True
-        r = client.post("/api/v1/auth/change-password", json={"current_password": "old", "new_password": "newpass1"})
+        r = client.post(
+            "/api/v1/auth/change-password",
+            json={"current_password": "old", "new_password": "newpass1"},
+        )
         assert r.status_code == 200
         assert "ui_password_hash" in saved
 
 
 def test_change_password_wrong_current(app, monkeypatch):
     pw_hash = ui_auth.hash_password("old")
-    monkeypatch.setattr(ui_auth, "_get_config_entry", lambda k: pw_hash if k == "ui_password_hash" else "true")
+    monkeypatch.setattr(
+        ui_auth, "_get_config_entry", lambda k: pw_hash if k == "ui_password_hash" else "true"
+    )
     with app.test_client() as client:
         with client.session_transaction() as sess:
             sess["ui_authenticated"] = True
-        r = client.post("/api/v1/auth/change-password", json={"current_password": "wrong", "new_password": "newpass1"})
+        r = client.post(
+            "/api/v1/auth/change-password",
+            json={"current_password": "wrong", "new_password": "newpass1"},
+        )
         assert r.status_code == 401
 
 

--- a/backend/tests/test_routes_auth_ui.py
+++ b/backend/tests/test_routes_auth_ui.py
@@ -1,12 +1,14 @@
 """Tests for /api/v1/auth/* endpoints."""
 
 import pytest
+
 import ui_auth
 
 
 @pytest.fixture
 def app(monkeypatch):
     from flask import Flask
+
     from routes.auth_ui import auth_ui_bp
 
     monkeypatch.setattr(ui_auth, "_get_config_entry", lambda k: None)

--- a/backend/tests/test_routes_nfo.py
+++ b/backend/tests/test_routes_nfo.py
@@ -1,0 +1,169 @@
+"""Tests for NFO export API endpoints (/api/v1/subtitles/export-nfo and
+/api/v1/series/<id>/subtitles/export-nfo).
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+from flask import Flask
+
+import routes.nfo as nfo_module
+from routes.nfo import bp as nfo_bp
+
+
+# ---------------------------------------------------------------------------
+# App fixture — isolated Flask app with just the nfo blueprint
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def app(tmp_path):
+    """Minimal Flask app with nfo blueprint and temp media_path."""
+    _app = Flask(__name__)
+    _app.config["TESTING"] = True
+    _app.config["SECRET_KEY"] = "test-secret"
+
+    # Point SUBLARR_MEDIA_PATH at tmp_path so security checks use a real dir
+    os.environ["SUBLARR_MEDIA_PATH"] = str(tmp_path)
+
+    _app.register_blueprint(nfo_bp)
+    return _app
+
+
+# ---------------------------------------------------------------------------
+# Single-subtitle endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_export_single_missing_path(app):
+    """POST without ?path query param → 400."""
+    with app.test_client() as client:
+        r = client.post("/api/v1/subtitles/export-nfo")
+    assert r.status_code == 400
+    data = r.get_json()
+    assert "error" in data
+
+
+def test_export_single_unsafe_path(app, monkeypatch, tmp_path):
+    """Path outside media_path → 403."""
+    monkeypatch.setattr(nfo_module, "is_safe_path", lambda path, root: False)
+    sub = tmp_path / "ep01.de.ass"
+    sub.write_text("dummy")
+
+    with app.test_client() as client:
+        r = client.post(f"/api/v1/subtitles/export-nfo?path={sub}")
+    assert r.status_code == 403
+
+
+def test_export_single_file_not_found(app, monkeypatch, tmp_path):
+    """Path passes security check but file does not exist on disk → 404."""
+    monkeypatch.setattr(nfo_module, "is_safe_path", lambda path, root: True)
+    nonexistent = str(tmp_path / "ghost.de.ass")
+
+    with app.test_client() as client:
+        r = client.post(f"/api/v1/subtitles/export-nfo?path={nonexistent}")
+    assert r.status_code == 404
+
+
+def test_export_single_success(app, monkeypatch, tmp_path):
+    """File exists, write_nfo called, returns {status: ok, nfo_path: ...}."""
+    sub = tmp_path / "ep01.de.ass"
+    sub.write_text("dummy")
+
+    called_with = []
+
+    def _fake_write_nfo(path, meta):
+        called_with.append(path)
+
+    monkeypatch.setattr(nfo_module, "is_safe_path", lambda path, root: True)
+    monkeypatch.setattr(nfo_module, "write_nfo", _fake_write_nfo)
+
+    with app.test_client() as client:
+        r = client.post(f"/api/v1/subtitles/export-nfo?path={sub}")
+
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["status"] == "ok"
+    assert data["nfo_path"] == str(sub) + ".nfo"
+    assert called_with == [str(sub)]
+
+
+# ---------------------------------------------------------------------------
+# Series endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_export_series_not_found(app, monkeypatch):
+    """Series not resolvable via sonarr_client → 404."""
+
+    def _fake_get_series_path(series_id):
+        return None
+
+    monkeypatch.setattr(nfo_module, "_get_series_path_for_nfo", _fake_get_series_path)
+
+    with app.test_client() as client:
+        r = client.post("/api/v1/series/99/subtitles/export-nfo")
+
+    assert r.status_code == 404
+    data = r.get_json()
+    assert "error" in data
+
+
+def test_export_series_success(app, monkeypatch, tmp_path):
+    """Series found, 2 files in subtitle_downloads (1 exists on disk) → exported=1, skipped=1."""
+    # Create one real subtitle file
+    existing_sub = tmp_path / "ep01.de.ass"
+    existing_sub.write_text("dummy")
+    missing_sub = str(tmp_path / "ep02.de.ass")  # does not exist on disk
+
+    series_path = str(tmp_path)
+
+    monkeypatch.setattr(nfo_module, "_get_series_path_for_nfo", lambda sid: series_path)
+    monkeypatch.setattr(nfo_module, "is_safe_path", lambda path, root: True)
+
+    # Fake DB query returns two file_path rows
+    fake_rows = [(str(existing_sub),), (missing_sub,)]
+
+    class _FakeResult:
+        def __init__(self, rows):
+            self._rows = rows
+
+        def fetchall(self):
+            return self._rows
+
+    class _FakeConn:
+        def execute(self, stmt, params=None):
+            return _FakeResult(fake_rows)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            pass
+
+    class _FakeEngine:
+        def connect(self):
+            return _FakeConn()
+
+    class _FakeDb:
+        engine = _FakeEngine()
+
+    monkeypatch.setattr(nfo_module, "_get_db_engine", lambda: _FakeDb())
+
+    written = []
+
+    def _fake_write_nfo(path, meta):
+        written.append(path)
+
+    monkeypatch.setattr(nfo_module, "write_nfo", _fake_write_nfo)
+
+    with app.test_client() as client:
+        r = client.post("/api/v1/series/1/subtitles/export-nfo")
+
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["status"] == "ok"
+    assert data["exported"] == 1
+    assert data["skipped"] == 1
+    assert written == [str(existing_sub)]

--- a/backend/tests/test_routes_nfo.py
+++ b/backend/tests/test_routes_nfo.py
@@ -11,7 +11,6 @@ from flask import Flask
 import routes.nfo as nfo_module
 from routes.nfo import bp as nfo_bp
 
-
 # ---------------------------------------------------------------------------
 # App fixture — isolated Flask app with just the nfo blueprint
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_routes_nfo.py
+++ b/backend/tests/test_routes_nfo.py
@@ -28,7 +28,8 @@ def app(tmp_path):
     os.environ["SUBLARR_MEDIA_PATH"] = str(tmp_path)
 
     _app.register_blueprint(nfo_bp)
-    return _app
+    yield _app
+    os.environ.pop("SUBLARR_MEDIA_PATH", None)
 
 
 # ---------------------------------------------------------------------------
@@ -75,6 +76,8 @@ def test_export_single_success(app, monkeypatch, tmp_path):
 
     def _fake_write_nfo(path, meta):
         called_with.append(path)
+        # Simulate successful write by creating the .nfo file
+        open(path + ".nfo", "w").close()
 
     monkeypatch.setattr(nfo_module, "is_safe_path", lambda path, root: True)
     monkeypatch.setattr(nfo_module, "write_nfo", _fake_write_nfo)
@@ -167,3 +170,78 @@ def test_export_series_success(app, monkeypatch, tmp_path):
     assert data["exported"] == 1
     assert data["skipped"] == 1
     assert written == [str(existing_sub)]
+
+
+def test_export_single_write_failure(app, monkeypatch, tmp_path):
+    """write_nfo does not create the .nfo file → 500."""
+    sub = tmp_path / "ep01.de.ass"
+    sub.write_text("dummy")
+
+    def _fake_write_nfo_no_op(path, meta):
+        pass  # deliberately does NOT create the .nfo file
+
+    monkeypatch.setattr(nfo_module, "is_safe_path", lambda path, root: True)
+    monkeypatch.setattr(nfo_module, "write_nfo", _fake_write_nfo_no_op)
+
+    with app.test_client() as client:
+        r = client.post(f"/api/v1/subtitles/export-nfo?path={sub}")
+
+    assert r.status_code == 500
+    data = r.get_json()
+    assert "error" in data
+
+
+def test_export_series_unsafe_db_path(app, monkeypatch, tmp_path):
+    """DB row path passes the LIKE prefix but is_safe_path rejects it → counted as skipped."""
+    series_path = str(tmp_path)
+
+    monkeypatch.setattr(nfo_module, "_get_series_path_for_nfo", lambda sid: series_path)
+
+    # Series-level check passes, per-file check rejects
+    call_count = [0]
+
+    def _is_safe_path(path, root):
+        call_count[0] += 1
+        # First call: series_path validation (should pass), subsequent: per-file (fail)
+        return call_count[0] == 1
+
+    monkeypatch.setattr(nfo_module, "is_safe_path", _is_safe_path)
+
+    # DB returns a path that passes the LIKE prefix but is outside media_path
+    unsafe_path = str(tmp_path / "../../etc/passwd.de.ass")
+    fake_rows = [(unsafe_path,)]
+
+    class _FakeResult:
+        def fetchall(self):
+            return fake_rows
+
+    class _FakeConn:
+        def execute(self, stmt, params=None):
+            return _FakeResult()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            pass
+
+    class _FakeEngine:
+        def connect(self):
+            return _FakeConn()
+
+    class _FakeDb:
+        engine = _FakeEngine()
+
+    monkeypatch.setattr(nfo_module, "_get_db_engine", lambda: _FakeDb())
+
+    written = []
+    monkeypatch.setattr(nfo_module, "write_nfo", lambda path, meta: written.append(path))
+
+    with app.test_client() as client:
+        r = client.post("/api/v1/series/1/subtitles/export-nfo")
+
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["exported"] == 0
+    assert data["skipped"] == 1
+    assert written == []  # write_nfo must NOT have been called

--- a/backend/tests/test_ui_auth.py
+++ b/backend/tests/test_ui_auth.py
@@ -6,10 +6,10 @@ from flask import Flask, session
 import ui_auth
 from ui_auth import (
     hash_password,
-    verify_password,
+    init_ui_auth,
     is_ui_auth_configured,
     is_ui_auth_enabled,
-    init_ui_auth,
+    verify_password,
 )
 
 

--- a/backend/tests/test_ui_auth.py
+++ b/backend/tests/test_ui_auth.py
@@ -40,17 +40,23 @@ def test_is_ui_auth_configured_false_when_no_entry(monkeypatch):
 
 
 def test_is_ui_auth_configured_true_when_entry_exists(monkeypatch):
-    monkeypatch.setattr(ui_auth, "_get_config_entry", lambda k: "some_hash" if k == "ui_password_hash" else None)
+    monkeypatch.setattr(
+        ui_auth, "_get_config_entry", lambda k: "some_hash" if k == "ui_password_hash" else None
+    )
     assert is_ui_auth_configured() is True
 
 
 def test_is_ui_auth_enabled_false_when_disabled(monkeypatch):
-    monkeypatch.setattr(ui_auth, "_get_config_entry", lambda k: "false" if k == "ui_auth_enabled" else None)
+    monkeypatch.setattr(
+        ui_auth, "_get_config_entry", lambda k: "false" if k == "ui_auth_enabled" else None
+    )
     assert is_ui_auth_enabled() is False
 
 
 def test_is_ui_auth_enabled_true_when_enabled(monkeypatch):
-    monkeypatch.setattr(ui_auth, "_get_config_entry", lambda k: "true" if k == "ui_auth_enabled" else "hash")
+    monkeypatch.setattr(
+        ui_auth, "_get_config_entry", lambda k: "true" if k == "ui_auth_enabled" else "hash"
+    )
     assert is_ui_auth_enabled() is True
 
 
@@ -120,8 +126,10 @@ def test_hook_allows_api_key_without_session(monkeypatch):
     monkeypatch.setattr(ui_auth, "is_ui_auth_enabled", lambda: True)
 
     import os
+
     os.environ["SUBLARR_API_KEY"] = "test-key"
     from config import reload_settings
+
     reload_settings()
 
     app = Flask(__name__)

--- a/backend/translator.py
+++ b/backend/translator.py
@@ -863,11 +863,17 @@ def translate_ass(
 
         _write_quality_sidecar(output_path, quality_scores)
         from nfo_export import maybe_write_nfo
-        maybe_write_nfo(output_path, {
-            "translation_backend": translation_result.backend_name if 'translation_result' in dir() else "",
-            "source_language": getattr(settings, "source_language", ""),
-            "target_language": tgt_lang or getattr(settings, "target_language", ""),
-        })
+
+        maybe_write_nfo(
+            output_path,
+            {
+                "translation_backend": translation_result.backend_name
+                if "translation_result" in dir()
+                else "",
+                "source_language": getattr(settings, "source_language", ""),
+                "target_language": tgt_lang or getattr(settings, "target_language", ""),
+            },
+        )
         _quality_stats = (
             _compute_quality_stats(quality_scores, _q_threshold) if quality_scores else {}
         )
@@ -1047,11 +1053,17 @@ def _translate_srt(srt_path, output_path, source="srt", target_language=None, ar
 
     _write_quality_sidecar(output_path, quality_scores)
     from nfo_export import maybe_write_nfo
-    maybe_write_nfo(output_path, {
-        "translation_backend": translation_result.backend_name if 'translation_result' in dir() else "",
-        "source_language": settings.source_language,
-        "target_language": target_language or settings.target_language,
-    })
+
+    maybe_write_nfo(
+        output_path,
+        {
+            "translation_backend": translation_result.backend_name
+            if "translation_result" in dir()
+            else "",
+            "source_language": settings.source_language,
+            "target_language": target_language or settings.target_language,
+        },
+    )
     _quality_stats = _compute_quality_stats(quality_scores, _q_threshold) if quality_scores else {}
 
     return {
@@ -1554,11 +1566,17 @@ def _translate_external_ass(
 
         _write_quality_sidecar(output_path, quality_scores)
         from nfo_export import maybe_write_nfo
-        maybe_write_nfo(output_path, {
-            "translation_backend": translation_result.backend_name if 'translation_result' in dir() else "",
-            "source_language": settings.source_language,
-            "target_language": target_language or settings.target_language,
-        })
+
+        maybe_write_nfo(
+            output_path,
+            {
+                "translation_backend": translation_result.backend_name
+                if "translation_result" in dir()
+                else "",
+                "source_language": settings.source_language,
+                "target_language": target_language or settings.target_language,
+            },
+        )
         _quality_stats = (
             _compute_quality_stats(quality_scores, _q_threshold) if quality_scores else {}
         )

--- a/backend/translator.py
+++ b/backend/translator.py
@@ -862,6 +862,12 @@ def translate_ass(
         logger.info("Saved ASS translation: %s", output_path)
 
         _write_quality_sidecar(output_path, quality_scores)
+        from nfo_export import maybe_write_nfo
+        maybe_write_nfo(output_path, {
+            "translation_backend": translation_result.backend_name if 'translation_result' in dir() else "",
+            "source_language": getattr(settings, "source_language", ""),
+            "target_language": tgt_lang or getattr(settings, "target_language", ""),
+        })
         _quality_stats = (
             _compute_quality_stats(quality_scores, _q_threshold) if quality_scores else {}
         )
@@ -1040,6 +1046,12 @@ def _translate_srt(srt_path, output_path, source="srt", target_language=None, ar
     logger.info("Saved SRT translation: %s", output_path)
 
     _write_quality_sidecar(output_path, quality_scores)
+    from nfo_export import maybe_write_nfo
+    maybe_write_nfo(output_path, {
+        "translation_backend": translation_result.backend_name if 'translation_result' in dir() else "",
+        "source_language": settings.source_language,
+        "target_language": target_language or settings.target_language,
+    })
     _quality_stats = _compute_quality_stats(quality_scores, _q_threshold) if quality_scores else {}
 
     return {
@@ -1541,6 +1553,12 @@ def _translate_external_ass(
         logger.info("Saved ASS translation from external source: %s", output_path)
 
         _write_quality_sidecar(output_path, quality_scores)
+        from nfo_export import maybe_write_nfo
+        maybe_write_nfo(output_path, {
+            "translation_backend": translation_result.backend_name if 'translation_result' in dir() else "",
+            "source_language": settings.source_language,
+            "target_language": target_language or settings.target_language,
+        })
         _quality_stats = (
             _compute_quality_stats(quality_scores, _q_threshold) if quality_scores else {}
         )

--- a/backend/ui_auth.py
+++ b/backend/ui_auth.py
@@ -17,11 +17,13 @@ logger = logging.getLogger(__name__)
 
 def _get_config_entry(key: str):
     from db.config import get_config_entry
+
     return get_config_entry(key)
 
 
 def _save_config_entry(key: str, value: str):
     from db.config import save_config_entry
+
     save_config_entry(key, value)
 
 
@@ -54,6 +56,7 @@ def _get_or_create_secret_key() -> str:
 
 def _has_valid_api_key() -> bool:
     from config import get_settings
+
     settings = get_settings()
     if not settings.api_key:
         return False

--- a/backend/wanted_search.py
+++ b/backend/wanted_search.py
@@ -687,6 +687,13 @@ def process_wanted_item(item_id: int) -> dict:
                     item_id,
                     result.provider_name,
                 )
+                from nfo_export import maybe_write_nfo
+                maybe_write_nfo(output_path, {
+                    "provider": result.provider_name,
+                    "source_language": getattr(result, "language", ""),
+                    "target_language": item_lang,
+                    "score": result.score,
+                })
                 update_wanted_status(item_id, "found")
                 return {
                     "wanted_id": item_id,
@@ -878,6 +885,13 @@ def process_wanted_item(item_id: int) -> dict:
                         item_id,
                         result.provider_name,
                     )
+                    from nfo_export import maybe_write_nfo
+                    maybe_write_nfo(output_path, {
+                        "provider": result.provider_name,
+                        "source_language": getattr(result, "language", ""),
+                        "target_language": item_lang,
+                        "score": result.score,
+                    })
                     update_wanted_status(item_id, "found")
                     return {
                         "wanted_id": item_id,

--- a/backend/wanted_search.py
+++ b/backend/wanted_search.py
@@ -688,12 +688,16 @@ def process_wanted_item(item_id: int) -> dict:
                     result.provider_name,
                 )
                 from nfo_export import maybe_write_nfo
-                maybe_write_nfo(output_path, {
-                    "provider": result.provider_name,
-                    "source_language": getattr(result, "language", ""),
-                    "target_language": item_lang,
-                    "score": result.score,
-                })
+
+                maybe_write_nfo(
+                    output_path,
+                    {
+                        "provider": result.provider_name,
+                        "source_language": getattr(result, "language", ""),
+                        "target_language": item_lang,
+                        "score": result.score,
+                    },
+                )
                 update_wanted_status(item_id, "found")
                 return {
                     "wanted_id": item_id,
@@ -886,12 +890,16 @@ def process_wanted_item(item_id: int) -> dict:
                         result.provider_name,
                     )
                     from nfo_export import maybe_write_nfo
-                    maybe_write_nfo(output_path, {
-                        "provider": result.provider_name,
-                        "source_language": getattr(result, "language", ""),
-                        "target_language": item_lang,
-                        "score": result.score,
-                    })
+
+                    maybe_write_nfo(
+                        output_path,
+                        {
+                            "provider": result.provider_name,
+                            "source_language": getattr(result, "language", ""),
+                            "target_language": item_lang,
+                            "score": result.score,
+                        },
+                    )
                     update_wanted_status(item_id, "found")
                     return {
                         "wanted_id": item_id,

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1663,6 +1663,11 @@ export async function deleteSubtitles(paths: string[], blacklist = false): Promi
   return data
 }
 
+export async function exportSubtitleNfo(path: string): Promise<{ status: string; nfo_path: string }> {
+  const { data } = await api.post('/subtitles/export-nfo', null, { params: { path } })
+  return data
+}
+
 export async function batchDeleteSeriesSubtitles(
   seriesId: number,
   filter: { languages?: string[]; formats?: string[] }

--- a/frontend/src/pages/SeriesDetail.tsx
+++ b/frontend/src/pages/SeriesDetail.tsx
@@ -9,13 +9,13 @@ import {
   Folder, FileVideo, AlertTriangle, Play, Tag, Globe, Search,
   Download, X, BookOpen, Plus, Edit2, Trash2, Check,
   Eye, Pencil, Database,
-  Layers, Sparkles, Trash,
+  Layers, Sparkles, Trash, FileCode,
 } from 'lucide-react'
 import { formatRelativeTime } from '@/lib/utils'
 import { toast } from '@/components/shared/Toast'
 import SubtitleEditorModal from '@/components/editor/SubtitleEditorModal'
 import { TrackPanel } from '@/components/tracks/TrackPanel'
-import { autoSyncFile, startWantedBatchSearch, batchExtractAllTracks, listSeriesSubtitles, deleteSubtitles, getSubtitleDownloadUrl, getSeriesSubtitleExportUrl } from '@/api/client'
+import { autoSyncFile, startWantedBatchSearch, batchExtractAllTracks, listSeriesSubtitles, deleteSubtitles, getSubtitleDownloadUrl, getSeriesSubtitleExportUrl, exportSubtitleNfo } from '@/api/client'
 import { useWebSocket } from '@/hooks/useWebSocket'
 import { ProgressBar } from '@/components/shared/ProgressBar'
 import { InteractiveSearchModal } from '@/components/wanted/InteractiveSearchModal'
@@ -834,6 +834,16 @@ function SeasonGroup({ season, episodes, targetLanguages, seriesId: _seriesId, i
                                         />
                                       </svg>
                                     </a>
+                                    <button
+                                      onClick={(e) => { e.stopPropagation(); exportSubtitleNfo(matchingSidecar.path).then(() => toast.success('NFO exported')).catch(() => toast.error('NFO export failed')) }}
+                                      className="p-0.5 rounded transition-colors"
+                                      style={{ color: 'var(--text-muted)', lineHeight: 1 }}
+                                      title="Export NFO sidecar"
+                                      onMouseEnter={(e) => { e.currentTarget.style.color = 'var(--accent)' }}
+                                      onMouseLeave={(e) => { e.currentTarget.style.color = 'var(--text-muted)' }}
+                                    >
+                                      <FileCode size={11} />
+                                    </button>
                                   </>
                                 )}
                                 {(subFormat === 'ass' || subFormat === 'srt') && (

--- a/frontend/src/pages/Settings/index.tsx
+++ b/frontend/src/pages/Settings/index.tsx
@@ -245,6 +245,10 @@ const FIELDS: FieldConfig[] = [
   // Automation — Subtitle Trash
   { key: 'subtitle_trash_retention_days', label: 'Papierkorb-Aufbewahrung (Tage)', type: 'number', placeholder: '7', tab: 'Automation',
     description: 'Gelöschte Sidecar-Dateien werden N Tage im Papierkorb behalten und können wiederhergestellt werden. 0 = dauerhaft behalten.' },
+  // Automation — NFO Export (expert)
+  { key: 'auto_nfo_export', label: 'Auto NFO Export', type: 'toggle', tab: 'Automation',
+    description: 'Write an XML sidecar (.nfo) next to every downloaded or translated subtitle. Contains provider, language, score, and translation metadata. Off by default.',
+    advanced: true },
 ]
 
 // ─── Path Mapping Editor ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **NFO sidecar export** — writes an XML `.nfo` file alongside every downloaded or translated subtitle, containing provider, language, score, translation backend, BLEU score, and timestamp
- **Expert setting off by default** — `auto_nfo_export` toggle in Settings → Automation (advanced) fires `maybe_write_nfo()` automatically after every download/translation; manual export always available via per-subtitle button
- **API routes** — `POST /api/v1/subtitles/export-nfo?path=<path>` (single) and `POST /api/v1/series/<id>/subtitles/export-nfo` (bulk); per-file `is_safe_path()` validation on all paths
- **UI** — `FileCode` export button on sidecar badges in SeriesDetail; success/error toast feedback

## Test Plan

- [ ] Backend tests green: 590 passed, 0 new failures
- [ ] Frontend TypeScript: 0 errors (`tsc --noEmit`)
- [ ] `auto_nfo_export` toggle visible in Settings → Automation under "Show advanced"
- [ ] Export NFO button appears on subtitle badges in SeriesDetail
- [ ] Clicking button calls `POST /subtitles/export-nfo` and shows toast
- [ ] Series bulk export respects `is_safe_path` for each DB path