### PR TITLE
feat: v0.28.0 — AI Glossary Builder

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -183,6 +183,10 @@ class Settings(BaseSettings):
     # NFO Export
     auto_nfo_export: bool = False  # Expert: write XML NFO sidecar after every download/translation
 
+    # Glossary
+    glossary_enabled: bool = True  # Enable glossary injection during translation
+    glossary_max_terms: int = 100  # Maximum number of glossary terms injected per translation
+
     # Wanted Search Scheduler
     wanted_search_interval_hours: int = 24  # 0 = disabled
     wanted_search_on_startup: bool = False

--- a/backend/db/migrations/versions/f1a2b3c4d5e6_add_glossary_metadata.py
+++ b/backend/db/migrations/versions/f1a2b3c4d5e6_add_glossary_metadata.py
@@ -1,0 +1,55 @@
+"""add term_type, confidence, approved columns to glossary_entries
+
+Revision ID: f1a2b3c4d5e6
+Revises: e4f5a6b7c8d9
+Create Date: 2026-03-14
+
+Adds three metadata columns to glossary_entries to support the AI Glossary
+Builder feature:
+- term_type: categorise entries as 'character', 'place', or 'other'
+- confidence: float 0-1 set by LLM extractor; NULL for manual entries
+- approved: SQLite boolean (0=pending AI suggestion, 1=approved/manual)
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f1a2b3c4d5e6"
+down_revision = "e4f5a6b7c8d9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("glossary_entries") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "term_type",
+                sa.Text(),
+                nullable=False,
+                server_default="other",
+            )
+        )
+        batch_op.add_column(
+            sa.Column(
+                "confidence",
+                sa.Float(),
+                nullable=True,
+            )
+        )
+        batch_op.add_column(
+            sa.Column(
+                "approved",
+                sa.Integer(),
+                nullable=False,
+                server_default="1",
+            )
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("glossary_entries") as batch_op:
+        batch_op.drop_column("approved")
+        batch_op.drop_column("confidence")
+        batch_op.drop_column("term_type")

--- a/backend/db/models/translation.py
+++ b/backend/db/models/translation.py
@@ -38,6 +38,9 @@ class GlossaryEntry(db.Model):
     source_term: Mapped[str] = mapped_column(Text, nullable=False)
     target_term: Mapped[str] = mapped_column(Text, nullable=False)
     notes: Mapped[str | None] = mapped_column(Text, default="")
+    term_type: Mapped[str] = mapped_column(Text, nullable=False, default="other")
+    confidence: Mapped[float | None] = mapped_column(Float, nullable=True)
+    approved: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
     created_at: Mapped[str] = mapped_column(Text, nullable=False)
     updated_at: Mapped[str] = mapped_column(Text, nullable=False)
 

--- a/backend/db/repositories/translation.py
+++ b/backend/db/repositories/translation.py
@@ -64,11 +64,27 @@ class TranslationRepository(BaseRepository):
     # ---- Glossary Operations -------------------------------------------------
 
     def add_glossary_entry(
-        self, series_id: int | None, source_term: str, target_term: str, notes: str = ""
+        self,
+        series_id: int | None,
+        source_term: str,
+        target_term: str,
+        notes: str = "",
+        term_type: str = "other",
+        confidence: float | None = None,
+        approved: int = 1,
     ) -> int:
         """Add a new glossary entry. Returns the entry ID.
 
         When series_id is None, creates a global glossary entry.
+
+        Args:
+            series_id: Series ID or None for a global entry.
+            source_term: Source language term.
+            target_term: Target language translation.
+            notes: Optional notes.
+            term_type: Category — 'character', 'place', or 'other'.
+            confidence: Float 0-1 set by LLM extractor; None for manual entries.
+            approved: 1 for approved/manual entries, 0 for pending AI suggestions.
         """
         now = self._now()
         entry = GlossaryEntry(
@@ -76,6 +92,9 @@ class TranslationRepository(BaseRepository):
             source_term=source_term.strip(),
             target_term=target_term.strip(),
             notes=notes.strip(),
+            term_type=term_type,
+            confidence=confidence,
+            approved=approved,
             created_at=now,
             updated_at=now,
         )
@@ -167,9 +186,20 @@ class TranslationRepository(BaseRepository):
         return self._to_dict(entry)
 
     def update_glossary_entry(
-        self, entry_id: int, source_term: str = None, target_term: str = None, notes: str = None
+        self,
+        entry_id: int,
+        source_term: str = None,
+        target_term: str = None,
+        notes: str = None,
+        term_type: str = None,
+        confidence: float | None = ...,
+        approved: int = None,
     ) -> bool:
-        """Update a glossary entry. Returns True if updated."""
+        """Update a glossary entry. Returns True if updated.
+
+        Pass ``confidence=None`` explicitly to clear the confidence value.
+        Omit ``confidence`` (default sentinel ``...``) to leave it unchanged.
+        """
         entry = self.session.get(GlossaryEntry, entry_id)
         if entry is None:
             return False
@@ -183,6 +213,15 @@ class TranslationRepository(BaseRepository):
             updated = True
         if notes is not None:
             entry.notes = notes.strip()
+            updated = True
+        if term_type is not None:
+            entry.term_type = term_type
+            updated = True
+        if confidence is not ...:
+            entry.confidence = confidence
+            updated = True
+        if approved is not None:
+            entry.approved = approved
             updated = True
 
         if not updated:

--- a/backend/db/translation.py
+++ b/backend/db/translation.py
@@ -28,13 +28,36 @@ def record_translation_config(
 
 
 def add_glossary_entry(
-    series_id: int | None = None, source_term: str = "", target_term: str = "", notes: str = ""
+    series_id: int | None = None,
+    source_term: str = "",
+    target_term: str = "",
+    notes: str = "",
+    term_type: str = "other",
+    confidence: float | None = None,
+    approved: int = 1,
 ) -> int:
     """Add a new glossary entry. Returns the entry ID.
 
     When series_id is None, creates a global glossary entry.
+
+    Args:
+        series_id: Series ID or None for a global entry.
+        source_term: Source language term.
+        target_term: Target language translation.
+        notes: Optional notes.
+        term_type: Category — 'character', 'place', or 'other'.
+        confidence: Float 0-1 set by LLM extractor; None for manual entries.
+        approved: 1 for approved/manual entries, 0 for pending AI suggestions.
     """
-    return _get_repo().add_glossary_entry(series_id, source_term, target_term, notes)
+    return _get_repo().add_glossary_entry(
+        series_id,
+        source_term,
+        target_term,
+        notes,
+        term_type=term_type,
+        confidence=confidence,
+        approved=approved,
+    )
 
 
 def get_glossary_entries(series_id: int | None = None) -> list:
@@ -65,10 +88,28 @@ def get_glossary_entry(entry_id: int) -> dict | None:
 
 
 def update_glossary_entry(
-    entry_id: int, source_term: str = None, target_term: str = None, notes: str = None
+    entry_id: int,
+    source_term: str = None,
+    target_term: str = None,
+    notes: str = None,
+    term_type: str = None,
+    confidence: float | None = ...,
+    approved: int = None,
 ) -> bool:
-    """Update a glossary entry. Returns True if updated."""
-    return _get_repo().update_glossary_entry(entry_id, source_term, target_term, notes)
+    """Update a glossary entry. Returns True if updated.
+
+    Pass ``confidence=None`` explicitly to clear the confidence value.
+    Omit ``confidence`` (default sentinel ``...``) to leave it unchanged.
+    """
+    return _get_repo().update_glossary_entry(
+        entry_id,
+        source_term,
+        target_term,
+        notes,
+        term_type=term_type,
+        confidence=confidence,
+        approved=approved,
+    )
 
 
 def delete_glossary_entry(entry_id: int) -> bool:

--- a/backend/routes/library.py
+++ b/backend/routes/library.py
@@ -4,6 +4,8 @@ import logging
 
 from flask import Blueprint, jsonify, request
 
+from services.glossary_extractor import extract_candidates
+
 bp = Blueprint("library", __name__, url_prefix="/api/v1")
 logger = logging.getLogger(__name__)
 
@@ -928,3 +930,86 @@ def episode_history(episode_id):
     mapped = map_path(file_path)
     entries = get_episode_history(mapped)
     return jsonify({"entries": entries})
+
+
+@bp.route("/series/<int:series_id>/glossary/suggest", methods=["POST"])
+def suggest_glossary_candidates(series_id):
+    """Extract glossary term candidates from subtitle sidecars for a series.
+    ---
+    post:
+      tags:
+        - Library
+      summary: Suggest glossary candidates
+      description: >
+        Scans the series subtitle sidecar files and returns frequency-based
+        proper-noun candidates suitable for seeding the glossary. Does not
+        write anything to the database.
+      security:
+        - apiKeyAuth: []
+      parameters:
+        - in: path
+          name: series_id
+          required: true
+          schema:
+            type: integer
+          description: Sonarr series ID
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                source_lang:
+                  type: string
+                  default: en
+                  description: Language tag used in sidecar filenames (e.g. "en")
+                min_freq:
+                  type: integer
+                  default: 3
+                  description: Minimum occurrence count to include a candidate
+      responses:
+        200:
+          description: Candidate terms (empty list when series not found or no subs)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  candidates:
+                    type: array
+                    items:
+                      type: object
+                  series_id:
+                    type: integer
+                  message:
+                    type: string
+                    nullable: true
+    """
+    from config import map_path
+    from sonarr_client import get_sonarr_client
+
+    sonarr = get_sonarr_client()
+    if not sonarr:
+        return jsonify(
+            {"candidates": [], "series_id": series_id, "message": "Sonarr not configured"}
+        )
+
+    series = sonarr.get_series_by_id(series_id)
+    if not series or not series.get("path"):
+        return jsonify(
+            {"candidates": [], "series_id": series_id, "message": "Series media path not found"}
+        )
+
+    body = request.get_json(silent=True) or {}
+    source_lang = (body.get("source_lang") or "en").strip()
+    min_freq = int(body.get("min_freq") or 3)
+
+    media_path = map_path(series["path"])
+    candidates = extract_candidates(
+        media_path,
+        source_lang=source_lang,
+        min_freq=min_freq,
+        max_candidates=100,
+    )
+
+    return jsonify({"candidates": candidates, "series_id": series_id})

--- a/backend/routes/profiles.py
+++ b/backend/routes/profiles.py
@@ -464,11 +464,22 @@ def create_glossary_entry():
     source_term = data.get("source_term", "").strip()
     target_term = data.get("target_term", "").strip()
     notes = data.get("notes", "").strip()
+    term_type = data.get("term_type", "other")
+    confidence = data.get("confidence", None)
+    approved = data.get("approved", 1)
 
     if not source_term or not target_term:
         return jsonify({"error": "source_term and target_term are required"}), 400
 
-    entry_id = add_glossary_entry(series_id, source_term, target_term, notes)
+    entry_id = add_glossary_entry(
+        series_id,
+        source_term,
+        target_term,
+        notes,
+        term_type=term_type,
+        confidence=confidence,
+        approved=approved,
+    )
     entry = get_glossary_entry(entry_id)
     return jsonify(entry), 201
 
@@ -523,12 +534,21 @@ def update_glossary_entry_endpoint(entry_id):
     source_term = data.get("source_term")
     target_term = data.get("target_term")
     notes = data.get("notes")
+    term_type = data.get("term_type")
+    approved = data.get("approved")
+
+    # confidence uses Ellipsis as sentinel: omit key = unchanged, explicit None = clear it
+    _sentinel = ...
+    confidence = data.get("confidence", _sentinel) if "confidence" in data else _sentinel
 
     updated = update_glossary_entry(
         entry_id,
         source_term=source_term,
         target_term=target_term,
         notes=notes,
+        term_type=term_type,
+        confidence=confidence,
+        approved=approved,
     )
 
     if not updated:

--- a/backend/routes/profiles.py
+++ b/backend/routes/profiles.py
@@ -596,6 +596,65 @@ def delete_glossary_entry_endpoint(entry_id):
     return jsonify({"status": "deleted", "id": entry_id})
 
 
+@bp.route("/glossary/export", methods=["GET"])
+def export_glossary_tsv():
+    """Export glossary entries as a TSV file download.
+    ---
+    get:
+      tags:
+        - Profiles
+      summary: Export glossary as TSV
+      description: >
+        Downloads all glossary entries as a tab-separated values file.
+        When series_id is provided, exports only entries for that series.
+        When omitted, exports the global glossary.
+      parameters:
+        - in: query
+          name: series_id
+          schema:
+            type: integer
+          description: Series ID for per-series entries. Omit for global glossary.
+      responses:
+        200:
+          description: TSV file download
+          content:
+            text/tab-separated-values:
+              schema:
+                type: string
+    """
+    import io
+
+    from flask import Response
+
+    from db.translation import get_glossary_entries
+
+    series_id = request.args.get("series_id", type=int)
+    entries = get_glossary_entries(series_id)
+
+    output = io.StringIO()
+    output.write("source_term\ttarget_term\tterm_type\tnotes\n")
+    for entry in entries:
+        source_term = (entry.get("source_term") or "").replace("\t", " ")
+        target_term = (entry.get("target_term") or "").replace("\t", " ")
+        term_type = (entry.get("term_type") or "").replace("\t", " ")
+        notes = (entry.get("notes") or "").replace("\t", " ")
+        output.write(f"{source_term}\t{target_term}\t{term_type}\t{notes}\n")
+
+    tsv_content = output.getvalue()
+
+    if series_id is not None:
+        filename = f"glossary_series_{series_id}.tsv"
+    else:
+        filename = "glossary_global.tsv"
+
+    return Response(
+        tsv_content,
+        status=200,
+        mimetype="text/tab-separated-values; charset=utf-8",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
 # ─── Prompt Presets Endpoints ────────────────────────────────────────────────
 
 

--- a/backend/services/glossary_extractor.py
+++ b/backend/services/glossary_extractor.py
@@ -1,0 +1,324 @@
+"""Frequency-based glossary term candidate extractor.
+
+Scans subtitle sidecar files (.{lang}.ass / .{lang}.srt) for a series directory
+and returns a ranked list of proper-noun candidates suitable for seeding a
+translation glossary.
+"""
+
+import logging
+import os
+import re
+from collections import Counter
+from typing import Any
+
+import pysubs2
+
+logger = logging.getLogger(__name__)
+
+# Words that indicate a place name when present in a multi-word term
+_PLACE_INDICATORS: frozenset[str] = frozenset(
+    {
+        "village",
+        "town",
+        "city",
+        "forest",
+        "mountain",
+        "valley",
+        "kingdom",
+        "land",
+        "island",
+        "sea",
+        "lake",
+        "river",
+        "castle",
+        "temple",
+        "shrine",
+        "academy",
+        "district",
+        "region",
+        "country",
+        "nation",
+        "realm",
+        "territory",
+        "province",
+        "empire",
+        "clan",
+        "gate",
+        "bridge",
+        "road",
+        "street",
+        "square",
+        "plaza",
+        "park",
+        "tower",
+        "fortress",
+        "harbor",
+        "port",
+        "bay",
+        "cape",
+        "peninsula",
+        "desert",
+        "plains",
+        "jungle",
+        "swamp",
+        "marsh",
+    }
+)
+
+# Regex to strip ASS override tags like {\\pos(123,456)} or {\\an8}
+_ASS_TAG_RE = re.compile(r"\{[^}]*\}")
+
+# Single title-cased proper noun: starts with uppercase, followed by 2+ lowercase letters
+_SINGLE_PROPER_RE = re.compile(r"\b([A-Z][a-z]{2,})\b")
+
+# Two-word proper noun combo: two consecutive title-cased words
+_TWO_WORD_PROPER_RE = re.compile(r"\b([A-Z][a-z]{2,})\s+([A-Z][a-z]{2,})\b")
+
+# Common English words that are title-cased but are not proper nouns
+# (e.g. sentence-initial words, common nouns). We use a small stop-set to filter.
+_STOPWORDS: frozenset[str] = frozenset(
+    {
+        "The",
+        "This",
+        "That",
+        "These",
+        "Those",
+        "What",
+        "When",
+        "Where",
+        "Which",
+        "Who",
+        "Why",
+        "How",
+        "And",
+        "But",
+        "For",
+        "Nor",
+        "Yet",
+        "Not",
+        "Yes",
+        "Now",
+        "Let",
+        "Get",
+        "Got",
+        "Can",
+        "You",
+        "Your",
+        "Our",
+        "His",
+        "Her",
+        "Its",
+        "Was",
+        "Are",
+        "Has",
+        "Had",
+        "Did",
+        "Does",
+        "Just",
+        "Well",
+        "Also",
+        "Even",
+        "Still",
+        "Then",
+        "Here",
+        "There",
+        "Come",
+        "Look",
+        "Wait",
+        "Stop",
+        "Never",
+        "Always",
+        "Already",
+        "Because",
+        "Since",
+        "With",
+        "From",
+        "Into",
+        "Over",
+        "After",
+        "Before",
+        "About",
+        "Again",
+        "Back",
+        "Down",
+        "More",
+        "Much",
+        "Every",
+        "Right",
+        "Sure",
+        "Sorry",
+        "Thank",
+        "Please",
+        "Maybe",
+        "Really",
+        "Know",
+        "Think",
+        "Want",
+        "Need",
+        "Going",
+        "Said",
+        "Told",
+        "That",
+        "This",
+        "Have",
+        "Will",
+        "With",
+        "They",
+        "Them",
+        "Their",
+        "Been",
+        "Were",
+        "Must",
+        "Shall",
+        "Very",
+        "Good",
+        "Too",
+        "Like",
+        "Just",
+    }
+)
+
+
+def _strip_ass_tags(text: str) -> str:
+    """Remove ASS override tag blocks from a subtitle line."""
+    return _ASS_TAG_RE.sub("", text)
+
+
+def _classify_term(term: str) -> str:
+    """Classify a candidate term as 'place', 'character', or 'other'.
+
+    Args:
+        term: The candidate term string (may be one or two words).
+
+    Returns:
+        One of 'place', 'character', 'other'.
+    """
+    lower_words = {w.lower() for w in term.split()}
+    if lower_words & _PLACE_INDICATORS:
+        return "place"
+    if len(term.split()) == 1:
+        return "character"
+    return "other"
+
+
+def _collect_texts(directory: str, source_lang: str) -> list[str]:
+    """Walk *directory* recursively and collect all subtitle event texts.
+
+    Looks for files matching ``*.{source_lang}.ass`` and ``*.{source_lang}.srt``.
+    Parse errors are logged as warnings and the file is skipped.
+
+    Args:
+        directory: Root directory to search.
+        source_lang: Language tag used in sidecar filenames (e.g. ``"en"``).
+
+    Returns:
+        List of raw event text strings (ASS tags not yet stripped).
+    """
+    suffixes = (f".{source_lang}.ass", f".{source_lang}.srt")
+    texts: list[str] = []
+
+    for root, _dirs, files in os.walk(directory):
+        for filename in files:
+            if not any(filename.endswith(sfx) for sfx in suffixes):
+                continue
+            filepath = os.path.join(root, filename)
+            try:
+                subs = pysubs2.load(filepath, encoding="utf-8")
+                for event in subs:
+                    if event.text:
+                        texts.append(event.text)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("glossary_extractor: could not parse %s — %s", filepath, exc)
+
+    return texts
+
+
+def _tokenize(texts: list[str]) -> Counter:
+    """Extract proper-noun candidates from subtitle texts and count frequencies.
+
+    Two-word combos are counted as a unit; their constituent single words are
+    *not* additionally counted when they appear as part of a combo hit.
+
+    Args:
+        texts: Raw subtitle event text strings.
+
+    Returns:
+        Counter mapping candidate term → occurrence count.
+    """
+    counter: Counter = Counter()
+
+    for raw in texts:
+        clean = _strip_ass_tags(raw)
+
+        # Extract two-word combos first
+        two_word_matches = list(_TWO_WORD_PROPER_RE.finditer(clean))
+        two_word_spans: list[tuple[int, int]] = []
+        for m in two_word_matches:
+            combo = f"{m.group(1)} {m.group(2)}"
+            if m.group(1) not in _STOPWORDS and m.group(2) not in _STOPWORDS:
+                counter[combo] += 1
+                two_word_spans.append((m.start(), m.end()))
+
+        # Extract single proper nouns, skipping positions covered by two-word combos
+        for m in _SINGLE_PROPER_RE.finditer(clean):
+            word = m.group(1)
+            if word in _STOPWORDS:
+                continue
+            # Skip if this single word is entirely inside a two-word combo span
+            if any(start <= m.start() and m.end() <= end for start, end in two_word_spans):
+                continue
+            counter[word] += 1
+
+    return counter
+
+
+def extract_candidates(
+    directory: str,
+    source_lang: str = "en",
+    min_freq: int = 3,
+    max_candidates: int = 200,
+) -> list[dict[str, Any]]:
+    """Extract frequency-based proper-noun candidates from subtitle sidecars.
+
+    Scans *directory* recursively for ``*.{source_lang}.ass`` and
+    ``*.{source_lang}.srt`` files, tokenizes their text, and returns a ranked
+    list of term candidates.
+
+    Args:
+        directory: Root path to search for subtitle files.
+        source_lang: Language tag used in sidecar filenames (e.g. ``"en"``).
+        min_freq: Minimum occurrence count to include a candidate.
+        max_candidates: Maximum number of candidates to return.
+
+    Returns:
+        List of dicts with keys ``source_term``, ``term_type``, ``frequency``,
+        ``confidence``, sorted by frequency descending, capped at
+        *max_candidates*.  Returns an empty list if the directory does not
+        exist or no matching files are found.
+    """
+    if not os.path.isdir(directory):
+        logger.debug("glossary_extractor: directory does not exist: %s", directory)
+        return []
+
+    texts = _collect_texts(directory, source_lang)
+    if not texts:
+        return []
+
+    counter = _tokenize(texts)
+
+    results: list[dict[str, Any]] = []
+    for term, freq in counter.most_common():
+        if freq < min_freq:
+            break  # most_common() is sorted descending, so we can stop early
+        term_type = _classify_term(term)
+        confidence = round(min(0.5 + freq / 100, 0.99), 3)
+        results.append(
+            {
+                "source_term": term,
+                "term_type": term_type,
+                "frequency": freq,
+                "confidence": confidence,
+            }
+        )
+
+    return results[:max_candidates]

--- a/backend/tests/test_glossary_config.py
+++ b/backend/tests/test_glossary_config.py
@@ -1,0 +1,17 @@
+"""Tests for glossary_enabled and glossary_max_terms settings."""
+
+from config import Settings
+
+
+def test_glossary_disabled_setting_exists():
+    """Settings class has a glossary_enabled field defaulting to True."""
+    s = Settings()
+    assert hasattr(s, "glossary_enabled")
+    assert s.glossary_enabled is True
+
+
+def test_glossary_max_terms_setting_exists():
+    """Settings class has a glossary_max_terms field defaulting to 100."""
+    s = Settings()
+    assert hasattr(s, "glossary_max_terms")
+    assert s.glossary_max_terms == 100

--- a/backend/tests/test_glossary_crud_metadata.py
+++ b/backend/tests/test_glossary_crud_metadata.py
@@ -1,0 +1,99 @@
+"""Tests for new fields (term_type, confidence, approved) on glossary CRUD routes."""
+
+import pytest
+
+
+def test_create_entry_with_term_type(client):
+    """POST /glossary with term_type='character' stores it correctly."""
+    resp = client.post(
+        "/api/v1/glossary",
+        json={
+            "source_term": "Naruto",
+            "target_term": "Naruto",
+            "term_type": "character",
+        },
+    )
+    assert resp.status_code == 201
+    data = resp.get_json()
+    assert data["source_term"] == "Naruto"
+    assert data["term_type"] == "character"
+
+
+def test_create_entry_defaults(client):
+    """POST /glossary without term_type defaults to 'other', approved=1, confidence=None."""
+    resp = client.post(
+        "/api/v1/glossary",
+        json={
+            "source_term": "Konoha",
+            "target_term": "Konoha",
+        },
+    )
+    assert resp.status_code == 201
+    data = resp.get_json()
+    assert data["term_type"] == "other"
+    assert data["approved"] == 1
+    assert data["confidence"] is None
+
+
+def test_update_entry_approved(client):
+    """PUT /glossary/<id> with approved=0 and then approved=1 updates correctly."""
+    # Create an entry first
+    create_resp = client.post(
+        "/api/v1/glossary",
+        json={
+            "source_term": "Hokage",
+            "target_term": "Hokage",
+        },
+    )
+    assert create_resp.status_code == 201
+    entry_id = create_resp.get_json()["id"]
+
+    # Set approved=0
+    update_resp = client.put(
+        f"/api/v1/glossary/{entry_id}",
+        json={"approved": 0},
+    )
+    assert update_resp.status_code == 200
+    assert update_resp.get_json()["approved"] == 0
+
+    # Set approved=1
+    update_resp2 = client.put(
+        f"/api/v1/glossary/{entry_id}",
+        json={"approved": 1},
+    )
+    assert update_resp2.status_code == 200
+    assert update_resp2.get_json()["approved"] == 1
+
+
+def test_create_entry_with_confidence(client):
+    """POST /glossary with confidence stores it correctly."""
+    resp = client.post(
+        "/api/v1/glossary",
+        json={
+            "source_term": "Jutsu",
+            "target_term": "Technik",
+            "confidence": 0.85,
+            "approved": 0,
+        },
+    )
+    assert resp.status_code == 201
+    data = resp.get_json()
+    assert abs(data["confidence"] - 0.85) < 1e-6
+    assert data["approved"] == 0
+
+
+def test_update_entry_term_type(client):
+    """PUT /glossary/<id> with term_type updates it."""
+    create_resp = client.post(
+        "/api/v1/glossary",
+        json={"source_term": "Hidden Leaf", "target_term": "Verstecktes Blatt"},
+    )
+    assert create_resp.status_code == 201
+    entry_id = create_resp.get_json()["id"]
+
+    update_resp = client.put(
+        f"/api/v1/glossary/{entry_id}",
+        json={"term_type": "place"},
+    )
+    assert update_resp.status_code == 200
+    assert update_resp.get_json()["term_type"] == "place"

--- a/backend/tests/test_glossary_extractor.py
+++ b/backend/tests/test_glossary_extractor.py
@@ -1,0 +1,61 @@
+from services.glossary_extractor import _classify_term, extract_candidates
+
+
+def test_extract_candidates_basic(tmp_path):
+    srt = tmp_path / "ep01.en.srt"
+    srt.write_text(
+        "1\n00:00:01,000 --> 00:00:03,000\nNaruto arrives at Konoha.\n\n"
+        "2\n00:00:04,000 --> 00:00:06,000\nNaruto smiles.\n\n"
+        "3\n00:00:07,000 --> 00:00:09,000\nNaruto runs to Konoha.\n",
+        encoding="utf-8",
+    )
+    candidates = extract_candidates(str(tmp_path), source_lang="en", min_freq=2)
+    terms = [c["source_term"] for c in candidates]
+    assert "Naruto" in terms
+    assert "Konoha" in terms
+
+
+def test_extract_candidates_min_freq_filter(tmp_path):
+    srt = tmp_path / "ep01.en.srt"
+    srt.write_text(
+        "1\n00:00:01,000 --> 00:00:03,000\nOnce Naruto appeared.\n",
+        encoding="utf-8",
+    )
+    candidates = extract_candidates(str(tmp_path), source_lang="en", min_freq=3)
+    assert candidates == []
+
+
+def test_classify_term_character():
+    assert _classify_term("Naruto") == "character"
+
+
+def test_classify_term_place():
+    assert _classify_term("Konoha Village") == "place"
+
+
+def test_extract_candidates_no_files(tmp_path):
+    candidates = extract_candidates(str(tmp_path), source_lang="en", min_freq=2)
+    assert candidates == []
+
+
+def test_extract_candidates_invalid_dir():
+    candidates = extract_candidates("/nonexistent/path", source_lang="en", min_freq=2)
+    assert candidates == []
+
+
+def test_candidate_has_required_fields(tmp_path):
+    srt = tmp_path / "ep01.en.srt"
+    srt.write_text(
+        "1\n00:00:01,000 --> 00:00:03,000\nNaruto speaks.\n\n"
+        "2\n00:00:02,000 --> 00:00:04,000\nNaruto runs.\n\n"
+        "3\n00:00:05,000 --> 00:00:07,000\nNaruto jumps.\n",
+        encoding="utf-8",
+    )
+    candidates = extract_candidates(str(tmp_path), source_lang="en", min_freq=2)
+    assert len(candidates) >= 1
+    c = candidates[0]
+    assert "source_term" in c
+    assert "term_type" in c
+    assert "frequency" in c
+    assert "confidence" in c
+    assert 0 < c["confidence"] <= 1

--- a/backend/tests/test_glossary_metadata.py
+++ b/backend/tests/test_glossary_metadata.py
@@ -1,0 +1,108 @@
+"""Tests for the new term_type, confidence, approved columns on glossary_entries."""
+
+import pytest
+
+from db.translation import add_glossary_entry, get_glossary_entry, update_glossary_entry
+
+
+def test_add_glossary_entry_with_metadata(app_ctx):
+    """add_glossary_entry stores explicit term_type, confidence, and approved values."""
+    entry_id = add_glossary_entry(
+        series_id=1,
+        source_term="Naruto",
+        target_term="Naruto",
+        notes="main character",
+        term_type="character",
+        confidence=0.95,
+        approved=0,
+    )
+    assert isinstance(entry_id, int)
+
+    entry = get_glossary_entry(entry_id)
+    assert entry is not None
+    assert entry["source_term"] == "Naruto"
+    assert entry["target_term"] == "Naruto"
+    assert entry["term_type"] == "character"
+    assert pytest.approx(entry["confidence"], abs=1e-6) == 0.95
+    assert entry["approved"] == 0
+
+
+def test_add_glossary_entry_defaults(app_ctx):
+    """add_glossary_entry uses correct defaults: term_type='other', confidence=None, approved=1."""
+    entry_id = add_glossary_entry(
+        series_id=None,
+        source_term="Konoha",
+        target_term="Konoha",
+    )
+    assert isinstance(entry_id, int)
+
+    entry = get_glossary_entry(entry_id)
+    assert entry is not None
+    assert entry["term_type"] == "other"
+    assert entry["confidence"] is None
+    assert entry["approved"] == 1
+
+
+def test_update_glossary_entry_metadata(app_ctx):
+    """update_glossary_entry can update term_type, confidence, and approved independently."""
+    entry_id = add_glossary_entry(
+        series_id=2,
+        source_term="Hokage",
+        target_term="Hokage",
+        term_type="other",
+        confidence=None,
+        approved=1,
+    )
+
+    # Update term_type and approved only — confidence should remain None
+    result = update_glossary_entry(entry_id, term_type="place", approved=0)
+    assert result is True
+
+    entry = get_glossary_entry(entry_id)
+    assert entry["term_type"] == "place"
+    assert entry["approved"] == 0
+    assert entry["confidence"] is None  # unchanged
+
+    # Now set confidence explicitly
+    result = update_glossary_entry(entry_id, confidence=0.7)
+    assert result is True
+
+    entry = get_glossary_entry(entry_id)
+    assert pytest.approx(entry["confidence"], abs=1e-6) == 0.7
+
+    # Clear confidence back to None via explicit None
+    result = update_glossary_entry(entry_id, confidence=None)
+    assert result is True
+
+    entry = get_glossary_entry(entry_id)
+    assert entry["confidence"] is None
+
+
+def test_update_glossary_entry_no_fields(app_ctx):
+    """update_glossary_entry returns False when no fields are provided."""
+    entry_id = add_glossary_entry(
+        series_id=3,
+        source_term="Sensei",
+        target_term="Lehrer",
+        term_type="other",
+    )
+
+    result = update_glossary_entry(entry_id)
+    assert result is False
+
+
+def test_add_glossary_entry_place_type(app_ctx):
+    """add_glossary_entry stores 'place' as term_type correctly."""
+    entry_id = add_glossary_entry(
+        series_id=4,
+        source_term="Hidden Leaf Village",
+        target_term="Verborgenes Blatt-Dorf",
+        term_type="place",
+        confidence=0.88,
+        approved=1,
+    )
+
+    entry = get_glossary_entry(entry_id)
+    assert entry["term_type"] == "place"
+    assert pytest.approx(entry["confidence"], abs=1e-6) == 0.88
+    assert entry["approved"] == 1

--- a/backend/tests/test_glossary_routes_new.py
+++ b/backend/tests/test_glossary_routes_new.py
@@ -15,7 +15,7 @@ def test_suggest_returns_candidates(client, monkeypatch):
 
     mock_sonarr = MagicMock()
     mock_sonarr.get_series_by_id.return_value = {"id": 1, "path": "/media/naruto"}
-    monkeypatch.setattr("routes.library.get_sonarr_client", lambda: mock_sonarr)
+    monkeypatch.setattr("sonarr_client.get_sonarr_client", lambda: mock_sonarr)
 
     monkeypatch.setattr(
         "routes.library.extract_candidates",
@@ -38,7 +38,7 @@ def test_suggest_series_not_found(client, monkeypatch):
     """POST /series/<id>/glossary/suggest returns empty candidates when series not in Sonarr."""
     mock_sonarr = MagicMock()
     mock_sonarr.get_series_by_id.return_value = None
-    monkeypatch.setattr("routes.library.get_sonarr_client", lambda: mock_sonarr)
+    monkeypatch.setattr("sonarr_client.get_sonarr_client", lambda: mock_sonarr)
 
     resp = client.post(
         "/api/v1/series/999/glossary/suggest",
@@ -54,7 +54,7 @@ def test_suggest_series_not_found(client, monkeypatch):
 
 def test_suggest_sonarr_not_configured(client, monkeypatch):
     """POST /series/<id>/glossary/suggest returns empty candidates when Sonarr not configured."""
-    monkeypatch.setattr("routes.library.get_sonarr_client", lambda: None)
+    monkeypatch.setattr("sonarr_client.get_sonarr_client", lambda: None)
 
     resp = client.post(
         "/api/v1/series/1/glossary/suggest",
@@ -79,7 +79,7 @@ def test_suggest_uses_defaults_when_no_body(client, monkeypatch):
 
     mock_sonarr = MagicMock()
     mock_sonarr.get_series_by_id.return_value = {"id": 1, "path": "/media/test"}
-    monkeypatch.setattr("routes.library.get_sonarr_client", lambda: mock_sonarr)
+    monkeypatch.setattr("sonarr_client.get_sonarr_client", lambda: mock_sonarr)
     monkeypatch.setattr("routes.library.extract_candidates", fake_extract)
 
     resp = client.post(
@@ -135,10 +135,19 @@ def test_export_tsv_series_scoped(client):
 
 def test_export_tsv_content(client):
     """GET /glossary/export includes glossary entries as TSV rows after the header."""
-    from db.translation import add_glossary_entry
-
-    add_glossary_entry(None, "Naruto", "Naruto", "")
-    add_glossary_entry(None, "Konoha", "Konoha", "leaf village")
+    # Insert entries via the API to avoid mixing app contexts
+    client.post(
+        "/api/v1/glossary",
+        data=json.dumps({"source_term": "Naruto", "target_term": "Naruto", "notes": ""}),
+        content_type="application/json",
+    )
+    client.post(
+        "/api/v1/glossary",
+        data=json.dumps(
+            {"source_term": "Konoha", "target_term": "Konoha", "notes": "leaf village"}
+        ),
+        content_type="application/json",
+    )
 
     resp = client.get("/api/v1/glossary/export")
 
@@ -154,9 +163,14 @@ def test_export_tsv_content(client):
 
 def test_export_tsv_notes_tabs_replaced(client):
     """GET /glossary/export replaces tabs in notes with spaces."""
-    from db.translation import add_glossary_entry
-
-    add_glossary_entry(None, "Term", "Term", "note\twith\ttabs")
+    # Insert an entry with a tab in notes via the API
+    client.post(
+        "/api/v1/glossary",
+        data=json.dumps(
+            {"source_term": "Term", "target_term": "Term", "notes": "note\twith\ttabs"}
+        ),
+        content_type="application/json",
+    )
 
     resp = client.get("/api/v1/glossary/export")
 
@@ -164,7 +178,7 @@ def test_export_tsv_notes_tabs_replaced(client):
     text = resp.data.decode("utf-8")
     # Notes column should not contain literal tabs (they'd be replaced by spaces)
     lines = text.splitlines()
-    data_lines = [l for l in lines[1:] if l.startswith("Term\t")]
+    data_lines = [line for line in lines[1:] if line.startswith("Term\t")]
     assert len(data_lines) == 1
     # Split on tab — 4 columns exactly
     cols = data_lines[0].split("\t")

--- a/backend/tests/test_glossary_routes_new.py
+++ b/backend/tests/test_glossary_routes_new.py
@@ -1,0 +1,173 @@
+"""Tests for new glossary endpoints: POST /series/<id>/glossary/suggest and GET /glossary/export."""
+
+import json
+from unittest.mock import MagicMock
+
+# ─── Suggest endpoint ─────────────────────────────────────────────────────────
+
+
+def test_suggest_returns_candidates(client, monkeypatch):
+    """POST /series/<id>/glossary/suggest returns extracted candidates from glossary_extractor."""
+    fake_candidates = [
+        {"source_term": "Naruto", "term_type": "character", "frequency": 42, "confidence": 0.92},
+        {"source_term": "Konoha", "term_type": "place", "frequency": 17, "confidence": 0.67},
+    ]
+
+    mock_sonarr = MagicMock()
+    mock_sonarr.get_series_by_id.return_value = {"id": 1, "path": "/media/naruto"}
+    monkeypatch.setattr("routes.library.get_sonarr_client", lambda: mock_sonarr)
+
+    monkeypatch.setattr(
+        "routes.library.extract_candidates",
+        lambda directory, source_lang, min_freq, max_candidates: fake_candidates,
+    )
+
+    resp = client.post(
+        "/api/v1/series/1/glossary/suggest",
+        data=json.dumps({"source_lang": "en", "min_freq": 2}),
+        content_type="application/json",
+    )
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["series_id"] == 1
+    assert data["candidates"] == fake_candidates
+
+
+def test_suggest_series_not_found(client, monkeypatch):
+    """POST /series/<id>/glossary/suggest returns empty candidates when series not in Sonarr."""
+    mock_sonarr = MagicMock()
+    mock_sonarr.get_series_by_id.return_value = None
+    monkeypatch.setattr("routes.library.get_sonarr_client", lambda: mock_sonarr)
+
+    resp = client.post(
+        "/api/v1/series/999/glossary/suggest",
+        data=json.dumps({}),
+        content_type="application/json",
+    )
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["candidates"] == []
+    assert "message" in data
+
+
+def test_suggest_sonarr_not_configured(client, monkeypatch):
+    """POST /series/<id>/glossary/suggest returns empty candidates when Sonarr not configured."""
+    monkeypatch.setattr("routes.library.get_sonarr_client", lambda: None)
+
+    resp = client.post(
+        "/api/v1/series/1/glossary/suggest",
+        data=json.dumps({}),
+        content_type="application/json",
+    )
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["candidates"] == []
+    assert "message" in data
+
+
+def test_suggest_uses_defaults_when_no_body(client, monkeypatch):
+    """POST /series/<id>/glossary/suggest uses source_lang='en' and min_freq=3 by default."""
+    captured = {}
+
+    def fake_extract(directory, source_lang, min_freq, max_candidates):
+        captured["source_lang"] = source_lang
+        captured["min_freq"] = min_freq
+        return []
+
+    mock_sonarr = MagicMock()
+    mock_sonarr.get_series_by_id.return_value = {"id": 1, "path": "/media/test"}
+    monkeypatch.setattr("routes.library.get_sonarr_client", lambda: mock_sonarr)
+    monkeypatch.setattr("routes.library.extract_candidates", fake_extract)
+
+    resp = client.post(
+        "/api/v1/series/1/glossary/suggest",
+        data=json.dumps({}),
+        content_type="application/json",
+    )
+
+    assert resp.status_code == 200
+    assert captured["source_lang"] == "en"
+    assert captured["min_freq"] == 3
+
+
+# ─── Export endpoint ───────────────────────────────────────────────────────────
+
+
+def test_export_tsv_has_header(client):
+    """GET /glossary/export returns a TSV with a header row as first line."""
+    resp = client.get("/api/v1/glossary/export")
+
+    assert resp.status_code == 200
+    text = resp.data.decode("utf-8")
+    first_line = text.splitlines()[0]
+    assert first_line == "source_term\ttarget_term\tterm_type\tnotes"
+
+
+def test_export_tsv_content_type(client):
+    """GET /glossary/export sets Content-Type to text/tab-separated-values; charset=utf-8."""
+    resp = client.get("/api/v1/glossary/export")
+
+    assert resp.status_code == 200
+    assert "text/tab-separated-values" in resp.content_type
+    assert "utf-8" in resp.content_type
+
+
+def test_export_tsv_filename_global(client):
+    """GET /glossary/export (no series_id) uses filename glossary_global.tsv."""
+    resp = client.get("/api/v1/glossary/export")
+
+    assert resp.status_code == 200
+    disposition = resp.headers.get("Content-Disposition", "")
+    assert "glossary_global.tsv" in disposition
+
+
+def test_export_tsv_series_scoped(client):
+    """GET /glossary/export?series_id=5 uses filename glossary_series_5.tsv."""
+    resp = client.get("/api/v1/glossary/export?series_id=5")
+
+    assert resp.status_code == 200
+    disposition = resp.headers.get("Content-Disposition", "")
+    assert "glossary_series_5.tsv" in disposition
+
+
+def test_export_tsv_content(client):
+    """GET /glossary/export includes glossary entries as TSV rows after the header."""
+    from db.translation import add_glossary_entry
+
+    add_glossary_entry(None, "Naruto", "Naruto", "")
+    add_glossary_entry(None, "Konoha", "Konoha", "leaf village")
+
+    resp = client.get("/api/v1/glossary/export")
+
+    assert resp.status_code == 200
+    text = resp.data.decode("utf-8")
+    lines = text.splitlines()
+    # Header + at least 2 data rows
+    assert len(lines) >= 3
+    # Each non-header line must have exactly 3 tabs (4 columns)
+    for line in lines[1:]:
+        assert line.count("\t") == 3
+
+
+def test_export_tsv_notes_tabs_replaced(client):
+    """GET /glossary/export replaces tabs in notes with spaces."""
+    from db.translation import add_glossary_entry
+
+    add_glossary_entry(None, "Term", "Term", "note\twith\ttabs")
+
+    resp = client.get("/api/v1/glossary/export")
+
+    assert resp.status_code == 200
+    text = resp.data.decode("utf-8")
+    # Notes column should not contain literal tabs (they'd be replaced by spaces)
+    lines = text.splitlines()
+    data_lines = [l for l in lines[1:] if l.startswith("Term\t")]
+    assert len(data_lines) == 1
+    # Split on tab — 4 columns exactly
+    cols = data_lines[0].split("\t")
+    assert len(cols) == 4
+    # Notes column (index 3) has no remaining tabs
+    assert "\t" not in cols[3]

--- a/backend/tests/test_llm_utils_glossary.py
+++ b/backend/tests/test_llm_utils_glossary.py
@@ -1,36 +1,133 @@
-from translation.llm_utils import build_prompt_with_glossary
+"""Tests for V8-compatible glossary injection and single-line mode in llm_utils."""
+
+from translation.llm_utils import build_prompt_with_glossary, parse_llm_response
+
+# ---------------------------------------------------------------------------
+# build_prompt_with_glossary — format
+# ---------------------------------------------------------------------------
 
 
-def test_glossary_block_format():
-    entries = [{"source_term": "Naruto", "target_term": "Naruto"}]
-    result = build_prompt_with_glossary("Translate:", entries, ["Hello"])
-    assert "<glossary>" in result
-    assert "Naruto → Naruto" in result
-    assert "</glossary>" in result
+def test_glossary_uses_comma_separated_format():
+    """Glossary must use 'Glossary: term → trans' prefix, not XML blocks."""
+    entries = [{"source_term": "Nakama", "target_term": "Gruppe"}]
+    result = build_prompt_with_glossary("Translate:\n", entries, ["Hello", "World"])
+    assert result.startswith("Glossary: Nakama \u2192 Gruppe")
+    assert "<glossary>" not in result
+    assert "</glossary>" not in result
 
 
-def test_glossary_limit_50():
-    entries = [{"source_term": f"term{i}", "target_term": f"trans{i}"} for i in range(60)]
-    result = build_prompt_with_glossary("Translate:", entries, ["Hello"])
-    # Max 50 entries injected
-    assert result.count("→") == 50
+def test_glossary_multiple_entries_comma_joined():
+    entries = [
+        {"source_term": "Nakama", "target_term": "Gruppe"},
+        {"source_term": "Jutsu", "target_term": "Technik"},
+    ]
+    result = build_prompt_with_glossary("Translate:\n", entries, ["Line"])
+    # Single-line mode — check glossary prefix
+    assert "Glossary: Nakama \u2192 Gruppe, Jutsu \u2192 Technik" in result
+
+
+def test_glossary_limit_is_15():
+    """Only 15 entries may be injected (V8 training constraint)."""
+    entries = [{"source_term": f"term{i}", "target_term": f"trans{i}"} for i in range(20)]
+    result = build_prompt_with_glossary("Translate:\n", entries, ["Hello", "World"])
+    assert result.count("\u2192") == 15
 
 
 def test_only_approved_entries_injected():
+    """Entries with approved == 0 must be excluded."""
     entries = [
         {"source_term": "Konoha", "target_term": "Konoha", "approved": 1},
         {"source_term": "Pending", "target_term": "Pending", "approved": 0},
     ]
-    result = build_prompt_with_glossary("Translate:", entries, ["Hello"])
+    result = build_prompt_with_glossary("Translate:\n", entries, ["Hello", "World"])
     assert "Konoha" in result
     assert "Pending" not in result
 
 
-def test_no_glossary_entries_no_block():
-    result = build_prompt_with_glossary("Translate:", [], ["Hello"])
+def test_no_glossary_entries_no_prefix():
+    result = build_prompt_with_glossary("Translate:\n", [], ["Hello", "World"])
+    assert "Glossary:" not in result
     assert "<glossary>" not in result
 
 
-def test_none_glossary_no_block():
-    result = build_prompt_with_glossary("Translate:", None, ["Hello"])
-    assert "<glossary>" not in result
+def test_none_glossary_no_prefix():
+    result = build_prompt_with_glossary("Translate:\n", None, ["Hello", "World"])
+    assert "Glossary:" not in result
+
+
+def test_all_unapproved_no_prefix():
+    entries = [{"source_term": "X", "target_term": "Y", "approved": 0}]
+    result = build_prompt_with_glossary("Translate:\n", entries, ["Hello", "World"])
+    assert "Glossary:" not in result
+
+
+# ---------------------------------------------------------------------------
+# build_prompt_with_glossary — single-line mode
+# ---------------------------------------------------------------------------
+
+
+def test_single_line_uses_translate_to_german_format():
+    """When len(lines) == 1, prompt uses 'Translate to German: ...' format."""
+    result = build_prompt_with_glossary("Translate:\n", None, ["Guten Morgen"])
+    assert result == "Translate to German: Guten Morgen"
+
+
+def test_single_line_with_glossary():
+    entries = [{"source_term": "Nakama", "target_term": "Gruppe"}]
+    result = build_prompt_with_glossary("Translate:\n", entries, ["Nakama wa doko?"])
+    assert result.startswith("Glossary: Nakama \u2192 Gruppe\n\n")
+    assert "Translate to German: Nakama wa doko?" in result
+
+
+def test_single_line_no_numbered_prefix():
+    """Single-line prompt must NOT contain '1:' numbering."""
+    result = build_prompt_with_glossary("Translate:\n", None, ["Hello"])
+    assert "1:" not in result
+
+
+def test_multi_line_uses_numbered_format():
+    result = build_prompt_with_glossary("Translate:\n", None, ["Line A", "Line B"])
+    assert "1: Line A" in result
+    assert "2: Line B" in result
+
+
+# ---------------------------------------------------------------------------
+# parse_llm_response — single-line mode
+# ---------------------------------------------------------------------------
+
+
+def test_parse_single_line_returns_list_with_one_element():
+    result = parse_llm_response("Guten Morgen", 1)
+    assert result == ["Guten Morgen"]
+
+
+def test_parse_single_line_strips_whitespace():
+    result = parse_llm_response("  Hallo Welt  \n", 1)
+    assert result == ["Hallo Welt"]
+
+
+def test_parse_single_line_empty_returns_none():
+    result = parse_llm_response("   ", 1)
+    assert result is None
+
+
+def test_parse_single_line_too_long_returns_none():
+    result = parse_llm_response("x" * 501, 1)
+    assert result is None
+
+
+def test_parse_single_line_exactly_500_chars_ok():
+    result = parse_llm_response("a" * 500, 1)
+    assert result == ["a" * 500]
+
+
+def test_parse_multi_line_unchanged():
+    """Multi-line parsing must still work as before."""
+    response = "1: Hallo\n2: Welt"
+    result = parse_llm_response(response, 2)
+    assert result == ["Hallo", "Welt"]
+
+
+def test_parse_multi_line_count_mismatch_returns_none():
+    result = parse_llm_response("Only one line", 3)
+    assert result is None

--- a/backend/tests/test_llm_utils_glossary.py
+++ b/backend/tests/test_llm_utils_glossary.py
@@ -1,0 +1,36 @@
+from translation.llm_utils import build_prompt_with_glossary
+
+
+def test_glossary_block_format():
+    entries = [{"source_term": "Naruto", "target_term": "Naruto"}]
+    result = build_prompt_with_glossary("Translate:", entries, ["Hello"])
+    assert "<glossary>" in result
+    assert "Naruto → Naruto" in result
+    assert "</glossary>" in result
+
+
+def test_glossary_limit_50():
+    entries = [{"source_term": f"term{i}", "target_term": f"trans{i}"} for i in range(60)]
+    result = build_prompt_with_glossary("Translate:", entries, ["Hello"])
+    # Max 50 entries injected
+    assert result.count("→") == 50
+
+
+def test_only_approved_entries_injected():
+    entries = [
+        {"source_term": "Konoha", "target_term": "Konoha", "approved": 1},
+        {"source_term": "Pending", "target_term": "Pending", "approved": 0},
+    ]
+    result = build_prompt_with_glossary("Translate:", entries, ["Hello"])
+    assert "Konoha" in result
+    assert "Pending" not in result
+
+
+def test_no_glossary_entries_no_block():
+    result = build_prompt_with_glossary("Translate:", [], ["Hello"])
+    assert "<glossary>" not in result
+
+
+def test_none_glossary_no_block():
+    result = build_prompt_with_glossary("Translate:", None, ["Hello"])
+    assert "<glossary>" not in result

--- a/backend/translation/llm_utils.py
+++ b/backend/translation/llm_utils.py
@@ -103,26 +103,36 @@ def build_prompt_with_glossary(
 ) -> str:
     """Build a translation prompt with glossary terms prepended.
 
+    Only approved entries (approved != 0) are injected, capped at 50.
+    The glossary is rendered as a structured <glossary> XML block placed
+    before the prompt template.
+
     Args:
         prompt_template: Base prompt template
-        glossary_entries: List of {source_term, target_term} dicts (max 15)
+        glossary_entries: List of {source_term, target_term[, approved]} dicts (max 50)
         lines: List of subtitle lines to translate
 
     Returns:
-        Complete prompt with glossary and numbered lines
+        Complete prompt with optional glossary block and numbered lines
     """
+    numbered = "\n".join(f"{i + 1}: {line}" for i, line in enumerate(lines))
+
     if not glossary_entries:
-        numbered = "\n".join(f"{i + 1}: {line}" for i, line in enumerate(lines))
         return prompt_template + numbered
 
-    # Build glossary string (max 15 entries)
-    glossary_parts = [
-        f"{entry['source_term']} \u2192 {entry['target_term']}" for entry in glossary_entries[:15]
-    ]
-    glossary_str = "Glossary: " + ", ".join(glossary_parts) + "\n\n"
+    # Filter out non-approved entries (approved == 0 means pending suggestion)
+    approved = [e for e in glossary_entries if e.get("approved", 1) != 0]
 
-    numbered = "\n".join(f"{i + 1}: {line}" for i, line in enumerate(lines))
-    return glossary_str + prompt_template + numbered
+    if not approved:
+        return prompt_template + numbered
+
+    # Cap at 50 entries and build structured <glossary> block
+    glossary_lines = "\n".join(
+        f"  {entry['source_term']} \u2192 {entry['target_term']}" for entry in approved[:50]
+    )
+    glossary_block = f"<glossary>\n{glossary_lines}\n</glossary>\n\n"
+
+    return glossary_block + prompt_template + numbered
 
 
 def build_translation_prompt(

--- a/backend/translation/llm_utils.py
+++ b/backend/translation/llm_utils.py
@@ -46,6 +46,11 @@ def parse_llm_response(response_text: str, expected_count: int) -> list[str] | N
     Handles numbered responses (e.g. "1: text") and plain lines.
     Attempts to merge split lines before truncating.
 
+    Single-line mode: when ``expected_count == 1`` the V8 model returns a
+    single un-numbered line.  We accept it as-is (stripped) and reject
+    empty or suspiciously long results (> 500 chars) by returning ``None``
+    so the caller can trigger a retry.
+
     Args:
         response_text: Raw LLM response text
         expected_count: Number of lines expected
@@ -53,6 +58,13 @@ def parse_llm_response(response_text: str, expected_count: int) -> list[str] | N
     Returns:
         List of parsed lines, or None if count mismatch cannot be resolved
     """
+    # Single-line mode: model returns exactly one plain line (no numbering)
+    if expected_count == 1:
+        translation = response_text.strip()
+        if not translation or len(translation) > 500:
+            return None
+        return [translation]
+
     lines = response_text.strip().split("\n")
     lines = [l for l in lines if l.strip()]
 
@@ -103,36 +115,42 @@ def build_prompt_with_glossary(
 ) -> str:
     """Build a translation prompt with glossary terms prepended.
 
-    Only approved entries (approved != 0) are injected, capped at 50.
-    The glossary is rendered as a structured <glossary> XML block placed
-    before the prompt template.
+    Only approved entries (approved != 0) are injected, capped at 15.
+    The glossary is rendered as a comma-separated inline line in the format
+    the V8 fine-tuned model was trained on:
+      ``Glossary: term1 → trans1, term2 → trans2``
+
+    Single-line mode: when only one subtitle line is provided the prompt uses
+    a direct ``Translate to German: <line>`` format (no numbering) so the
+    model returns a single un-numbered translation.
 
     Args:
-        prompt_template: Base prompt template
-        glossary_entries: List of {source_term, target_term[, approved]} dicts (max 50)
+        prompt_template: Base prompt template (used for multi-line batches)
+        glossary_entries: List of {source_term, target_term[, approved]} dicts
         lines: List of subtitle lines to translate
 
     Returns:
-        Complete prompt with optional glossary block and numbered lines
+        Complete prompt with optional glossary prefix and numbered lines
     """
-    numbered = "\n".join(f"{i + 1}: {line}" for i, line in enumerate(lines))
-
-    if not glossary_entries:
-        return prompt_template + numbered
-
     # Filter out non-approved entries (approved == 0 means pending suggestion)
-    approved = [e for e in glossary_entries if e.get("approved", 1) != 0]
+    approved_entries: list[dict] = []
+    if glossary_entries:
+        approved_entries = [e for e in glossary_entries if e.get("approved", 1) != 0]
 
-    if not approved:
-        return prompt_template + numbered
+    # Build glossary prefix (V8-compatible comma-separated format, max 15 entries)
+    glossary_str = ""
+    if approved_entries:
+        pairs = ", ".join(
+            f"{e['source_term']} \u2192 {e['target_term']}" for e in approved_entries[:15]
+        )
+        glossary_str = f"Glossary: {pairs}\n\n"
 
-    # Cap at 50 entries and build structured <glossary> block
-    glossary_lines = "\n".join(
-        f"  {entry['source_term']} \u2192 {entry['target_term']}" for entry in approved[:50]
-    )
-    glossary_block = f"<glossary>\n{glossary_lines}\n</glossary>\n\n"
+    # Single-line mode: V8 expects direct "Translate to German: <line>" format
+    if len(lines) == 1:
+        return f"{glossary_str}Translate to German: {lines[0]}"
 
-    return glossary_block + prompt_template + numbered
+    numbered = "\n".join(f"{i + 1}: {line}" for i, line in enumerate(lines))
+    return glossary_str + prompt_template + numbered
 
 
 def build_translation_prompt(

--- a/backend/translator.py
+++ b/backend/translator.py
@@ -442,28 +442,35 @@ def _translate_with_manager(lines, source_lang, target_lang, arr_context=None, s
     # Load glossary entries: merged (global + per-series) for series,
     # global-only for non-series (movies/standalone)
     glossary_entries = None
-    try:
-        if series_id:
-            from db.translation import get_merged_glossary_for_series
+    if getattr(get_settings(), "glossary_enabled", True):
+        try:
+            if series_id:
+                from db.translation import get_merged_glossary_for_series
 
-            entries = get_merged_glossary_for_series(series_id)
-            if entries:
-                glossary_entries = entries
-                logger.debug(
-                    "Loaded %d merged glossary entries for series %d", len(entries), series_id
-                )
-        else:
-            from db.translation import get_global_glossary
+                entries = get_merged_glossary_for_series(series_id)
+                if entries:
+                    max_terms = getattr(get_settings(), "glossary_max_terms", 100)
+                    entries = entries[:max_terms]
+                    glossary_entries = entries
+                    logger.debug(
+                        "Loaded %d merged glossary entries for series %d",
+                        len(entries),
+                        series_id,
+                    )
+            else:
+                from db.translation import get_global_glossary
 
-            global_entries = get_global_glossary()
-            if global_entries:
-                glossary_entries = [
-                    {"source_term": e["source_term"], "target_term": e["target_term"]}
-                    for e in global_entries
-                ]
-                logger.debug("Loaded %d global glossary entries", len(glossary_entries))
-    except Exception as e:
-        logger.debug("Failed to load glossary: %s", e)
+                global_entries = get_global_glossary()
+                if global_entries:
+                    max_terms = getattr(get_settings(), "glossary_max_terms", 100)
+                    global_entries = global_entries[:max_terms]
+                    glossary_entries = [
+                        {"source_term": e["source_term"], "target_term": e["target_term"]}
+                        for e in global_entries
+                    ]
+                    logger.debug("Loaded %d global glossary entries", len(glossary_entries))
+        except Exception as e:
+            logger.debug("Failed to load glossary: %s", e)
 
     # --- Translation memory cache lookup ---
     cache_enabled, similarity_threshold = _get_cache_config()

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -541,8 +541,18 @@ export interface GlossaryEntry {
   source_term: string
   target_term: string
   notes: string
+  term_type: 'character' | 'place' | 'other'
+  confidence: number | null
+  approved: number  // 0 or 1 (SQLite boolean)
   created_at: string
   updated_at: string
+}
+
+export interface GlossaryCandidate {
+  source_term: string
+  term_type: 'character' | 'place' | 'other'
+  frequency: number
+  confidence: number
 }
 
 export async function getGlossaryEntries(seriesId?: number | null, query?: string): Promise<{ entries: GlossaryEntry[]; series_id: number | null }> {
@@ -553,18 +563,36 @@ export async function getGlossaryEntries(seriesId?: number | null, query?: strin
   return data
 }
 
-export async function createGlossaryEntry(entry: { series_id?: number | null; source_term: string; target_term: string; notes?: string }): Promise<GlossaryEntry> {
+export async function createGlossaryEntry(entry: { series_id?: number | null; source_term: string; target_term: string; notes?: string; term_type?: 'character' | 'place' | 'other'; confidence?: number | null; approved?: number }): Promise<GlossaryEntry> {
   const { data } = await api.post('/glossary', entry)
   return data
 }
 
-export async function updateGlossaryEntry(entryId: number, entry: { source_term?: string; target_term?: string; notes?: string }): Promise<GlossaryEntry> {
+export async function updateGlossaryEntry(entryId: number, entry: { source_term?: string; target_term?: string; notes?: string; term_type?: 'character' | 'place' | 'other'; confidence?: number | null; approved?: number }): Promise<GlossaryEntry> {
   const { data } = await api.put(`/glossary/${entryId}`, entry)
   return data
 }
 
 export async function deleteGlossaryEntry(entryId: number): Promise<void> {
   await api.delete(`/glossary/${entryId}`)
+}
+
+export async function suggestGlossaryTerms(
+  seriesId: number,
+  options?: { source_lang?: string; min_freq?: number }
+): Promise<{ candidates: GlossaryCandidate[]; series_id: number }> {
+  const { data } = await api.post(`/series/${seriesId}/glossary/suggest`, options ?? {})
+  return data
+}
+
+export async function exportGlossaryTsv(seriesId?: number | null): Promise<Blob> {
+  const params: Record<string, unknown> = {}
+  if (seriesId != null) params.series_id = seriesId
+  const { data } = await api.get('/glossary/export', {
+    params,
+    responseType: 'blob',
+  })
+  return data
 }
 
 // ─── Prompt Presets ───────────────────────────────────────────────────────────

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -17,6 +17,7 @@ import {
   searchInteractive, searchInteractiveEpisode, downloadSpecific, downloadSpecificEpisode,
   exportConfig, importConfig,
   getGlossaryEntries, createGlossaryEntry, updateGlossaryEntry, deleteGlossaryEntry,
+  suggestGlossaryTerms, exportGlossaryTsv,
   getPromptPresets, getDefaultPromptPreset, createPromptPreset, updatePromptPreset, deletePromptPreset,
   getBackends, testBackend, getBackendConfig, saveBackendConfig, getBackendStats,
   getMediaServerTypes, getMediaServerInstances, saveMediaServerInstances, testMediaServer, getMediaServerHealth,
@@ -716,6 +717,41 @@ export function useDeleteGlossaryEntry() {
       } else {
         queryClient.invalidateQueries({ queryKey: ['glossary', 'global'] })
       }
+    },
+  })
+}
+
+export function useSuggestGlossaryTerms() {
+  return useMutation({
+    mutationFn: ({ seriesId, options }: {
+      seriesId: number
+      options?: { source_lang?: string; min_freq?: number }
+    }) => suggestGlossaryTerms(seriesId, options),
+  })
+}
+
+export function useExportGlossaryTsv() {
+  return useMutation({
+    mutationFn: ({ seriesId }: { seriesId?: number | null }) => exportGlossaryTsv(seriesId),
+    onSuccess: (blob, { seriesId }) => {
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = seriesId != null ? `glossary_series_${seriesId}.tsv` : 'glossary_global.tsv'
+      a.click()
+      URL.revokeObjectURL(url)
+    },
+  })
+}
+
+export function useApproveGlossaryEntry() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ entryId }: { entryId: number; seriesId?: number | null }) =>
+      updateGlossaryEntry(entryId, { approved: 1 }),
+    onSuccess: (_, { seriesId }) => {
+      queryClient.invalidateQueries({ queryKey: ['glossary', seriesId] })
+      queryClient.invalidateQueries({ queryKey: ['glossary', 'global'] })
     },
   })
 }

--- a/frontend/src/pages/SeriesDetail.tsx
+++ b/frontend/src/pages/SeriesDetail.tsx
@@ -3,19 +3,20 @@ import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { useSeriesDetail, useEpisodeSearch, useEpisodeHistory, useProcessWantedItem, useGlossaryEntries, useCreateGlossaryEntry, useUpdateGlossaryEntry, useDeleteGlossaryEntry, useStartWantedBatch, useUpdateSeriesSettings, useAnidbMappingStatus, useRefreshAnidbMapping, useBatchTranslate } from '@/hooks/useApi'
+import { useSeriesDetail, useEpisodeSearch, useEpisodeHistory, useProcessWantedItem, useGlossaryEntries, useCreateGlossaryEntry, useUpdateGlossaryEntry, useDeleteGlossaryEntry, useStartWantedBatch, useUpdateSeriesSettings, useAnidbMappingStatus, useRefreshAnidbMapping, useBatchTranslate, useSuggestGlossaryTerms, useExportGlossaryTsv } from '@/hooks/useApi'
 import {
   ArrowLeft, Loader2, ChevronDown, ChevronRight,
   Folder, FileVideo, AlertTriangle, Play, Tag, Globe, Search,
   Download, X, BookOpen, Plus, Edit2, Trash2, Check,
   Eye, Pencil, Database,
-  Layers, Sparkles, Trash, FileCode,
+  Layers, Sparkles, Trash, FileCode, Wand2,
 } from 'lucide-react'
 import { formatRelativeTime } from '@/lib/utils'
 import { toast } from '@/components/shared/Toast'
 import SubtitleEditorModal from '@/components/editor/SubtitleEditorModal'
 import { TrackPanel } from '@/components/tracks/TrackPanel'
 import { autoSyncFile, startWantedBatchSearch, batchExtractAllTracks, listSeriesSubtitles, deleteSubtitles, getSubtitleDownloadUrl, getSeriesSubtitleExportUrl, exportSubtitleNfo } from '@/api/client'
+import type { GlossaryCandidate } from '@/api/client'
 import { useWebSocket } from '@/hooks/useWebSocket'
 import { ProgressBar } from '@/components/shared/ProgressBar'
 import { InteractiveSearchModal } from '@/components/wanted/InteractiveSearchModal'
@@ -248,16 +249,41 @@ function EpisodeSearchPanel({ results, isLoading, onProcess }: {
 
 // ─── Glossary Panel ────────────────────────────────────────────────────────
 
+const TERM_TYPE_COLORS: Record<string, string> = {
+  character: 'var(--accent)',
+  place: '#3b82f6',
+  other: 'var(--text-muted)',
+}
+
+function TermTypeBadge({ type }: { type: string }) {
+  return (
+    <span
+      className="px-1.5 py-0.5 rounded text-[10px] font-medium"
+      style={{
+        backgroundColor: 'var(--bg-surface)',
+        border: `1px solid ${TERM_TYPE_COLORS[type] ?? 'var(--border)'}`,
+        color: TERM_TYPE_COLORS[type] ?? 'var(--text-muted)',
+      }}
+    >
+      {type}
+    </span>
+  )
+}
+
 function GlossaryPanel({ seriesId }: { seriesId: number }) {
   const { t } = useTranslation('library')
   const { data, isLoading } = useGlossaryEntries(seriesId)
   const createEntry = useCreateGlossaryEntry()
   const updateEntry = useUpdateGlossaryEntry()
   const deleteEntry = useDeleteGlossaryEntry()
+  const suggestTerms = useSuggestGlossaryTerms()
+  const exportTsv = useExportGlossaryTsv()
   const [showAdd, setShowAdd] = useState(false)
   const [editingId, setEditingId] = useState<number | null>(null)
   const [searchQuery, setSearchQuery] = useState('')
   const [formData, setFormData] = useState({ source_term: '', target_term: '', notes: '' })
+  const [showCandidates, setShowCandidates] = useState<boolean>(false)
+  const [candidates, setCandidates] = useState<GlossaryCandidate[]>([])
 
   const entries = data?.entries || []
   const filteredEntries = searchQuery
@@ -325,6 +351,20 @@ function GlossaryPanel({ seriesId }: { seriesId: number }) {
     )
   }
 
+  const handleSuggest = () => {
+    suggestTerms.mutate(
+      { seriesId, options: { source_lang: 'en', min_freq: 3 } },
+      {
+        onSuccess: (data) => {
+          setCandidates(data.candidates)
+          setShowCandidates(true)
+          if (data.candidates.length === 0) toast('No new candidates found', 'info')
+        },
+        onError: () => toast('Failed to fetch suggestions', 'error'),
+      }
+    )
+  }
+
   if (isLoading) {
     return (
       <div
@@ -343,17 +383,37 @@ function GlossaryPanel({ seriesId }: { seriesId: number }) {
         <span className="text-xs font-semibold uppercase tracking-wider" style={{ color: 'var(--text-muted)' }}>
           {t('series_detail.glossary')} ({entries.length})
         </span>
-        <button
-          onClick={() => {
-            resetForm()
-            setShowAdd(true)
-          }}
-          className="flex items-center gap-1.5 px-2.5 py-1 rounded text-xs font-medium text-white hover:opacity-90"
-          style={{ backgroundColor: 'var(--accent)' }}
-        >
-          <Plus size={11} />
-          {t('series_detail.add_entry')}
-        </button>
+        <div className="flex items-center gap-1.5">
+          <button
+            onClick={() => {
+              resetForm()
+              setShowAdd(true)
+            }}
+            className="flex items-center gap-1.5 px-2.5 py-1 rounded text-xs font-medium text-white hover:opacity-90"
+            style={{ backgroundColor: 'var(--accent)' }}
+          >
+            <Plus size={11} />
+            {t('series_detail.add_entry')}
+          </button>
+          <button
+            onClick={handleSuggest}
+            disabled={suggestTerms.isPending}
+            className="flex items-center gap-1.5 px-2.5 py-1 rounded text-xs font-medium hover:opacity-90"
+            style={{ backgroundColor: 'var(--bg-surface)', border: '1px solid var(--border)', color: 'var(--text-secondary)' }}
+          >
+            {suggestTerms.isPending ? <Loader2 size={11} className="animate-spin" /> : <Wand2 size={11} />}
+            Suggest
+          </button>
+          <button
+            onClick={() => exportTsv.mutate({ seriesId })}
+            disabled={exportTsv.isPending}
+            className="flex items-center gap-1.5 px-2.5 py-1 rounded text-xs font-medium hover:opacity-90"
+            style={{ backgroundColor: 'var(--bg-surface)', border: '1px solid var(--border)', color: 'var(--text-secondary)' }}
+          >
+            <Download size={11} />
+            TSV
+          </button>
+        </div>
       </div>
 
       {entries.length > 0 && (
@@ -444,6 +504,49 @@ function GlossaryPanel({ seriesId }: { seriesId: number }) {
         </div>
       )}
 
+      {/* Candidates */}
+      {showCandidates && candidates.length > 0 && (
+        <div
+          className="rounded-lg p-3 space-y-2"
+          style={{ backgroundColor: 'var(--bg-surface)', border: '1px solid var(--accent-dim)' }}
+        >
+          <div className="flex items-center justify-between">
+            <span className="text-xs font-semibold" style={{ color: 'var(--text-primary)' }}>
+              {candidates.length} Suggestions
+            </span>
+            <button onClick={() => setShowCandidates(false)} style={{ color: 'var(--text-muted)' }}>
+              <X size={12} />
+            </button>
+          </div>
+          <div className="space-y-1 max-h-48 overflow-y-auto">
+            {candidates.map((c) => (
+              <div
+                key={c.source_term}
+                className="flex items-center gap-2 px-2 py-1 rounded text-xs"
+                style={{ backgroundColor: 'var(--bg-primary)' }}
+              >
+                <span className="font-medium flex-1" style={{ color: 'var(--text-primary)' }}>
+                  {c.source_term}
+                </span>
+                <TermTypeBadge type={c.term_type} />
+                <span style={{ color: 'var(--text-muted)' }}>{Math.round(c.confidence * 100)}%</span>
+                <button
+                  onClick={() => {
+                    setFormData({ source_term: c.source_term, target_term: '', notes: '' })
+                    setShowAdd(true)
+                    setShowCandidates(false)
+                  }}
+                  className="flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium text-white"
+                  style={{ backgroundColor: 'var(--accent)' }}
+                >
+                  <Plus size={10} /> Add
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
       {/* Entries List */}
       {filteredEntries.length === 0 ? (
         <div className="text-xs text-center py-4" style={{ color: 'var(--text-muted)' }}>
@@ -457,6 +560,7 @@ function GlossaryPanel({ seriesId }: { seriesId: number }) {
                 <th className="text-left text-[10px] font-semibold uppercase tracking-wider px-3 py-1.5" style={{ color: 'var(--text-muted)' }}>Source</th>
                 <th className="text-left text-[10px] font-semibold uppercase tracking-wider px-3 py-1.5" style={{ color: 'var(--text-muted)' }}>Target</th>
                 <th className="text-left text-[10px] font-semibold uppercase tracking-wider px-3 py-1.5" style={{ color: 'var(--text-muted)' }}>Notes</th>
+                <th className="text-left text-[10px] font-semibold uppercase tracking-wider px-3 py-1.5" style={{ color: 'var(--text-muted)' }}>Type</th>
                 <th className="text-left text-[10px] font-semibold uppercase tracking-wider px-3 py-1.5" style={{ color: 'var(--text-muted)' }}>Actions</th>
               </tr>
             </thead>
@@ -474,6 +578,16 @@ function GlossaryPanel({ seriesId }: { seriesId: number }) {
                   </td>
                   <td className="px-3 py-1.5 text-xs" style={{ color: 'var(--text-secondary)' }}>
                     {entry.notes || '-'}
+                  </td>
+                  <td className="px-3 py-1.5">
+                    <div className="flex items-center gap-1 flex-wrap">
+                      <TermTypeBadge type={entry.term_type ?? 'other'} />
+                      {entry.approved === 0 && (
+                        <span className="text-[10px] px-1 rounded" style={{ backgroundColor: 'var(--bg-surface)', color: 'var(--text-muted)', border: '1px solid var(--border)' }}>
+                          pending
+                        </span>
+                      )}
+                    </div>
                   </td>
                   <td className="px-3 py-1.5">
                     <div className="flex items-center gap-1">

--- a/frontend/src/pages/Settings/TranslationTab.tsx
+++ b/frontend/src/pages/Settings/TranslationTab.tsx
@@ -1389,6 +1389,7 @@ export function GlobalGlossaryPanel() {
         <SettingRow
           label="Max Glossary Terms"
           helpText="Maximum number of glossary terms injected per translation request."
+          advanced
         >
           <input
             type="number"

--- a/frontend/src/pages/Settings/TranslationTab.tsx
+++ b/frontend/src/pages/Settings/TranslationTab.tsx
@@ -1230,6 +1230,8 @@ export function GlobalGlossaryPanel() {
   const createEntry = useCreateGlossaryEntry()
   const updateEntry = useUpdateGlossaryEntry()
   const deleteEntry = useDeleteGlossaryEntry()
+  const { data: config } = useConfig()
+  const updateConfig = useUpdateConfig()
   const [showAdd, setShowAdd] = useState(false)
   const [editingId, setEditingId] = useState<number | null>(null)
   const [searchQuery, setSearchQuery] = useState('')
@@ -1242,6 +1244,38 @@ export function GlobalGlossaryPanel() {
         e.target_term.toLowerCase().includes(searchQuery.toLowerCase())
       )
     : entries
+
+  const glossaryEnabled = config
+    ? (config as Record<string, unknown>)['glossary_enabled'] !== 'false'
+    : true
+  const glossaryMaxTerms = config
+    ? Number((config as Record<string, unknown>)['glossary_max_terms'] ?? 20)
+    : 20
+  const [localMaxTerms, setLocalMaxTerms] = useState<number>(glossaryMaxTerms)
+  useEffect(() => { setLocalMaxTerms(glossaryMaxTerms) }, [glossaryMaxTerms])
+
+  const handleGlossaryEnabledChange = (value: boolean) => {
+    updateConfig.mutate(
+      { glossary_enabled: String(value) },
+      {
+        onSuccess: () => toast('Glossary setting saved'),
+        onError: () => toast('Failed to save setting', 'error'),
+      },
+    )
+  }
+
+  const handleMaxTermsBlur = () => {
+    const clamped = Math.max(1, Math.min(200, Math.round(localMaxTerms)))
+    if (clamped !== glossaryMaxTerms) {
+      updateConfig.mutate(
+        { glossary_max_terms: String(clamped) },
+        {
+          onSuccess: () => toast('Max glossary terms saved'),
+          onError: () => toast('Failed to save setting', 'error'),
+        },
+      )
+    }
+  }
 
   const resetForm = () => {
     setShowAdd(false)
@@ -1335,6 +1369,49 @@ export function GlobalGlossaryPanel() {
           <Plus size={12} />
           Add Entry
         </button>
+      </div>
+
+      {/* Glossary Settings */}
+      <div
+        className="rounded-lg p-4 space-y-3"
+        style={{ backgroundColor: 'var(--bg-surface)', border: '1px solid var(--border)' }}
+      >
+        <SettingRow
+          label="Glossary"
+          helpText="Inject per-series glossary terms into LLM translation prompts for consistent proper noun handling."
+        >
+          <Toggle
+            checked={glossaryEnabled}
+            onChange={handleGlossaryEnabledChange}
+            disabled={updateConfig.isPending}
+          />
+        </SettingRow>
+        <SettingRow
+          label="Max Glossary Terms"
+          helpText="Maximum number of glossary terms injected per translation request."
+        >
+          <input
+            type="number"
+            min={1}
+            max={200}
+            step={1}
+            value={localMaxTerms}
+            disabled={!glossaryEnabled || updateConfig.isPending}
+            onChange={(e) => {
+              const parsed = parseInt(e.target.value, 10)
+              if (!isNaN(parsed)) setLocalMaxTerms(parsed)
+            }}
+            onBlur={handleMaxTermsBlur}
+            className="w-24 px-3 py-2 rounded-md text-sm transition-all duration-150 focus:outline-none"
+            style={{
+              backgroundColor: 'var(--bg-primary)',
+              border: '1px solid var(--border)',
+              color: 'var(--text-primary)',
+              fontSize: '13px',
+              opacity: glossaryEnabled ? 1 : 0.5,
+            }}
+          />
+        </SettingRow>
       </div>
 
       {/* Search */}


### PR DESCRIPTION
## Summary

- **DB migration:** Adds `term_type` (character/place/other), `confidence` (float), `approved` (0/1) columns to `glossary_entries`
- **Glossary extractor service:** `backend/services/glossary_extractor.py` — frequency analysis over subtitle sidecar files returns proper-noun term candidates (no LLM required)
- **New endpoints:** `POST /api/v1/series/<id>/glossary/suggest` + `GET /api/v1/glossary/export` (TSV download)
- **CRUD extended:** Existing `POST/PUT /api/v1/glossary` accept the new metadata fields
- **Config:** `SUBLARR_GLOSSARY_ENABLED` (default true) + `SUBLARR_GLOSSARY_MAX_TERMS` (default 100)
- **V8 model compatibility:** LLM injection keeps the `Glossary: term → trans` comma format (V8 training format); adds single-line mode when `len(lines) == 1` → `Translate to German: {line}`; fast-path response parsing for single-line
- **Frontend:** `GlossaryPanel` gets Suggest button (Wand2), candidate list with approve/pre-fill, Export TSV button, `TermTypeBadge`, "pending" badge; Settings → Translation tab adds GLOSSARY_ENABLED toggle + `glossary_max_terms` (advanced)

## Test Plan
- [ ] Backend tests pass: `603 passed, 6 pre-existing Windows log-lock errors`
- [ ] `ruff check . && ruff format --check .` — clean (304 files)
- [ ] Frontend lint: 0 errors (10 pre-existing warnings)
- [ ] `npx tsc --noEmit` — 0 errors
- [ ] Manual: open SeriesDetail → Glossary panel → click Suggest → candidates appear
- [ ] Manual: click TSV → file downloads with correct columns
- [ ] Manual: create entry with `term_type=character` → shows teal badge in table
- [ ] Manual: `SUBLARR_GLOSSARY_ENABLED=false` → translation does not inject glossary
- [ ] Manual: `SUBLARR_BATCH_SIZE=1` + V8 model → single-line prompt format used