### PR TITLE
fix: standalone scanner — symlinks, app context, SQLAlchemy text()

### DIFF
--- a/backend/routes/standalone.py
+++ b/backend/routes/standalone.py
@@ -8,7 +8,8 @@ import logging
 import os
 import threading
 
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, current_app, jsonify, request
+from sqlalchemy import text
 
 bp = Blueprint("standalone", __name__, url_prefix="/api/v1/standalone")
 logger = logging.getLogger(__name__)
@@ -287,8 +288,10 @@ def list_series():
         with _db_lock:
             for series in series_list:
                 row = db.execute(
-                    "SELECT COUNT(*) FROM wanted_items WHERE standalone_series_id=? AND status='wanted'",
-                    (series["id"],),
+                    text(
+                        "SELECT COUNT(*) FROM wanted_items WHERE standalone_series_id=:sid AND status='wanted'"
+                    ),
+                    {"sid": series["id"]},
                 ).fetchone()
                 series["wanted_count"] = row[0] if row else 0
 
@@ -337,10 +340,12 @@ def get_series(series_id):
         db = get_db()
         with _db_lock:
             rows = db.execute(
-                "SELECT * FROM wanted_items WHERE standalone_series_id=? ORDER BY file_path",
-                (series_id,),
+                text(
+                    "SELECT * FROM wanted_items WHERE standalone_series_id=:sid ORDER BY file_path"
+                ),
+                {"sid": series_id},
             ).fetchall()
-        series["wanted_items"] = [dict(row) for row in rows]
+        series["wanted_items"] = [dict(row._mapping) for row in rows]
 
         return jsonify(series)
     except Exception as e:
@@ -390,8 +395,8 @@ def delete_series(series_id):
         db = get_db()
         with _db_lock:
             db.execute(
-                "DELETE FROM wanted_items WHERE standalone_series_id=?",
-                (series_id,),
+                text("DELETE FROM wanted_items WHERE standalone_series_id=:sid"),
+                {"sid": series_id},
             )
             db.commit()
 
@@ -439,8 +444,10 @@ def list_movies():
         with _db_lock:
             for movie in movies:
                 row = db.execute(
-                    "SELECT COUNT(*) FROM wanted_items WHERE standalone_movie_id=? AND status='wanted'",
-                    (movie["id"],),
+                    text(
+                        "SELECT COUNT(*) FROM wanted_items WHERE standalone_movie_id=:mid AND status='wanted'"
+                    ),
+                    {"mid": movie["id"]},
                 ).fetchone()
                 movie["wanted_count"] = row[0] if row else 0
 
@@ -492,8 +499,8 @@ def delete_movie(movie_id):
         db = get_db()
         with _db_lock:
             db.execute(
-                "DELETE FROM wanted_items WHERE standalone_movie_id=?",
-                (movie_id,),
+                text("DELETE FROM wanted_items WHERE standalone_movie_id=:mid"),
+                {"mid": movie_id},
             )
             db.commit()
 
@@ -532,14 +539,17 @@ def scan_all():
                     type: string
     """
 
-    def _run_scan():
-        try:
-            from standalone.scanner import StandaloneScanner
+    app = current_app._get_current_object()
 
-            scanner = StandaloneScanner()
-            scanner.scan_all_folders()
-        except Exception as e:
-            logger.error("Standalone scan failed: %s", e)
+    def _run_scan():
+        with app.app_context():
+            try:
+                from standalone.scanner import StandaloneScanner
+
+                scanner = StandaloneScanner()
+                scanner.scan_all_folders()
+            except Exception as e:
+                logger.error("Standalone scan failed: %s", e)
 
     threading.Thread(target=_run_scan, daemon=True).start()
     return jsonify({"message": "Scan started"}), 202
@@ -581,14 +591,17 @@ def scan_folder(folder_id):
     if not folder:
         return jsonify({"error": "Folder not found"}), 404
 
-    def _run_scan():
-        try:
-            from standalone.scanner import StandaloneScanner
+    app = current_app._get_current_object()
 
-            scanner = StandaloneScanner()
-            scanner.scan_folder(folder["path"])
-        except Exception as e:
-            logger.error("Standalone scan for folder %d failed: %s", folder_id, e)
+    def _run_scan():
+        with app.app_context():
+            try:
+                from standalone.scanner import StandaloneScanner
+
+                scanner = StandaloneScanner()
+                scanner.scan_folder(folder["path"])
+            except Exception as e:
+                logger.error("Standalone scan for folder %d failed: %s", folder_id, e)
 
     threading.Thread(target=_run_scan, daemon=True).start()
     return jsonify({"message": f"Scan started for folder {folder_id}"}), 202

--- a/backend/standalone/scanner.py
+++ b/backend/standalone/scanner.py
@@ -10,6 +10,8 @@ import os
 import threading
 import time
 
+from sqlalchemy import text
+
 logger = logging.getLogger(__name__)
 
 
@@ -159,7 +161,7 @@ class StandaloneScanner:
 
         # Collect all video files
         video_files = []
-        for root, _dirs, files in os.walk(folder_path):
+        for root, _dirs, files in os.walk(folder_path, followlinks=True):
             for filename in files:
                 full_path = os.path.join(root, filename)
                 if is_video_file(full_path):
@@ -544,7 +546,7 @@ class StandaloneScanner:
             db = get_db()
             with _db_lock:
                 rows = db.execute(
-                    "SELECT id, file_path FROM wanted_items WHERE instance_name='standalone'"
+                    text("SELECT id, file_path FROM wanted_items WHERE instance_name='standalone'")
                 ).fetchall()
 
             to_remove = []


### PR DESCRIPTION
## Summary

Three bugs in standalone mode, all discovered while setting up a dedicated test instance with symlinked series directories:

- **Symlinks not followed**: `os.walk()` called without `followlinks=True` — any library folder using symlinks yielded 0 video files
- **App context crash**: Background scan threads spawned via `threading.Thread` had no Flask app context, causing `get_db()` / SQLAlchemy session calls to raise `Working outside of application context`
- **SQLAlchemy 2.x incompatibility**: Raw SQL strings passed directly to `db.execute()` — SQLAlchemy 2.x requires `text()` wrapper; also replaces SQLite `?` placeholders with `:param` named params for PostgreSQL compatibility

## Files changed

| File | Change |
|------|--------|
| `backend/standalone/scanner.py` | `followlinks=True`, `text()` for cleanup query |
| `backend/routes/standalone.py` | `current_app` + app context for both scan threads; `text()` + `:param` for all 5 raw SQL calls; `row._mapping` for dict conversion |

## Test plan

- [x] ruff check + format — clean
- [x] Verified on live test instance (CT 125, PostgreSQL backend): 10 symlinked series discovered, 104 wanted items created, `/standalone/series` and `/standalone/movies` endpoints return correct data
- [ ] Backend pytest (CI)