### PR TITLE
fix: setup auth redirect and plugins nav label

### DIFF
--- a/frontend/src/i18n/locales/de/common.json
+++ b/frontend/src/i18n/locales/de/common.json
@@ -10,7 +10,8 @@
     "settings": "Einstellungen",
     "logs": "Protokolle",
     "statistics": "Statistiken",
-    "tasks": "Aufgaben"
+    "tasks": "Aufgaben",
+    "plugins": "Plugins"
   },
   "nav_groups": {
     "content": "Inhalte",

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -10,7 +10,8 @@
     "settings": "Settings",
     "logs": "Logs",
     "statistics": "Statistics",
-    "tasks": "Tasks"
+    "tasks": "Tasks",
+    "plugins": "Plugins"
   },
   "nav_groups": {
     "content": "Content",

--- a/frontend/src/pages/Setup.tsx
+++ b/frontend/src/pages/Setup.tsx
@@ -21,6 +21,12 @@ export function SetupPage() {
     },
     onError: (err: unknown) => {
       const msg = (err as { response?: { data?: { error?: string } } })?.response?.data?.error ?? 'Setup failed'
+      // "Already configured" means auth is already set up (e.g. AUTH_ENABLED=false in env) — just navigate
+      if (msg.includes('Already configured')) {
+        queryClient.invalidateQueries({ queryKey: ['auth-status'] })
+        navigate('/')
+        return
+      }
       toast(msg, 'error')
     },
   })


### PR DESCRIPTION
## Summary
- **SetupPage**: When `AUTH_ENABLED=false`, the backend returns `"Already configured"` on setup attempts. The `"Continue without password"` button now correctly navigates to home instead of showing an error toast.
- **i18n**: Added missing `nav.plugins` translation key to EN and DE locale files — sidebar was displaying the raw key `nav.plugins` instead of "Plugins".

## Test plan
- [ ] Start dev server with `SUBLARR_AUTH_ENABLED=false`
- [ ] Navigate to `/setup` → click "Continue without password" → should redirect to dashboard
- [ ] Verify sidebar shows "Plugins" in both English and German locale
- [ ] Backend tests green
- [ ] Frontend lint clean