### PR TITLE
fix: filter media extras from standalone scan + fix Wanted list layout

### DIFF
--- a/V9_INTEGRATION.md
+++ b/V9_INTEGRATION.md
@@ -1,0 +1,326 @@
+# V9 Sublarr Integration Plan
+
+> **Kontext:** anime-translator-en-de-v9 basiert auf TranslateGemma-12B (SFT + DPO).
+> Das Modell wurde mit einem fixen Chat-Format trainiert — Sublarr muss dieses Format
+> exakt replizieren, sonst degradiert die Qualität trotz besserem Modell.
+
+---
+
+## 1. Optimales Prompt-Format für V9
+
+### Warum `/api/chat` statt `/api/generate`
+
+V9 ist ein Chat-Fine-Tune (Gemma-3 Chat Template). Sublarr verwendet aktuell
+`/api/generate` mit einem rohen Prompt-String. Das funktioniert, weil Ollama die
+Chat-Template-Wrapping intern erledigt — aber dabei geht die System-Prompt-Trennung
+verloren und Serienkontexte können nicht sauber injiziert werden.
+
+**V9 muss `/api/chat` verwenden** mit expliziter System/User-Trennung.
+
+---
+
+### Prompt-Format: Single-Line (1 Zeile)
+
+**System-Turn (immer identisch, optional + Serienkontext):**
+```
+Du bist ein spezialisierter Anime-Untertitel-Übersetzer. Übersetze englische
+Anime-Untertitel präzise und natürlich ins Deutsche. Verwende informelle Sprache
+(du-Form). Behalte Charakternamen und Eigennamen unverändert. Keine Erklärungen
+oder Kommentare — nur die Übersetzung.
+```
+Mit Serienkontext (wenn verfügbar):
+```
+[System-Prompt]. Serie: Attack on Titan. Genre: Action, Drama.
+```
+
+**User-Turn (ohne Glossar):**
+```
+Translate to German: It's not over yet.
+```
+
+**User-Turn (mit Glossar):**
+```
+Glossary: Survey Corps → Aufklärungstrupp, Titan → Titan, ODM → ODM-Gerät
+
+Translate to German: The Survey Corps never gives up.
+```
+
+**Erwartete Modell-Antwort:**
+```
+Die Aufklärungstrupp gibt niemals auf.
+```
+
+---
+
+### Prompt-Format: Multi-Line Batch (2–25 Zeilen)
+
+**System-Turn:** identisch zu Single-Line (mit optionalem Serienkontext)
+
+**User-Turn (ohne Glossar):**
+```
+Translate these anime subtitle lines from English to German.
+Return ONLY the translated lines, one per line, same count.
+Preserve \N exactly as \N (hard line break).
+Do NOT add numbering or prefixes to the output lines.
+
+1: It's not over yet.
+2: We have to keep fighting.
+3: For everyone we've lost.
+```
+
+**User-Turn (mit Glossar):**
+```
+Glossary: Survey Corps → Aufklärungstrupp, ODM → ODM-Gerät
+
+Translate these anime subtitle lines from English to German.
+Return ONLY the translated lines, one per line, same count.
+Preserve \N exactly as \N (hard line break).
+Do NOT add numbering or prefixes to the output lines.
+
+1: The Survey Corps charges forward.
+2: Use your ODM gear!
+3: Don't give up now.
+```
+
+**Erwartete Modell-Antwort:**
+```
+Die Aufklärungstrupp stürmt vor.
+Benutze dein ODM-Gerät!
+Gib jetzt nicht auf.
+```
+
+---
+
+### Glossar-Regeln (unverändert gegenüber V8)
+
+- Format: `Glossary: term1 → trans1, term2 → trans2`
+- Nur `approved != 0` Einträge injizieren
+- Max 15 Einträge pro Request
+- Leerzeile nach dem Glossar-Block (vor dem Prompt-Text)
+- Globale Einträge (series_id IS NULL) + serienspezifische Einträge mergen (serienspezifisch überschreibt global)
+
+---
+
+## 2. Sublarr Code-Änderungen
+
+### 2.1 `translation/ollama.py` — Chat API + Serienkontext
+
+**Neue Config-Felder hinzufügen:**
+
+```python
+{
+    "key": "use_chat_api",
+    "label": "Chat API verwenden (V9+)",
+    "type": "checkbox",
+    "required": False,
+    "default": "false",
+    "help": "Für V9-Modelle: /api/chat statt /api/generate verwenden",
+},
+{
+    "key": "system_prompt",
+    "label": "System Prompt",
+    "type": "textarea",
+    "required": False,
+    "default": "Du bist ein spezialisierter Anime-Untertitel-Übersetzer. Übersetze englische Anime-Untertitel präzise und natürlich ins Deutsche. Verwende informelle Sprache (du-Form). Behalte Charakternamen und Eigennamen unverändert. Keine Erklärungen oder Kommentare — nur die Übersetzung.",
+    "help": "System-Prompt für Chat-API-Modus. {series_context} wird durch 'Serie: Name. Genre: ...' ersetzt.",
+},
+```
+
+**`translate_batch()` Signatur erweitern:**
+```python
+def translate_batch(
+    self,
+    lines: list[str],
+    source_lang: str,
+    target_lang: str,
+    glossary_entries: list[dict] | None = None,
+    series_context: str | None = None,   # NEU
+) -> TranslationResult:
+```
+
+**Neue `_call_ollama_chat()` Methode:**
+```python
+def _call_ollama_chat(self, system_prompt: str, user_prompt: str) -> str:
+    payload = {
+        "model": self._model,
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user",   "content": user_prompt},
+        ],
+        "stream": False,
+        "options": {
+            "temperature": self._temperature,
+            "num_predict": 4096,
+            "num_ctx": 4096,
+        },
+    }
+    resp = requests.post(
+        f"{self._url}/api/chat",
+        json=payload,
+        timeout=self._request_timeout,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    return data["message"]["content"].strip()
+```
+
+**Dispatch-Logik in `translate_batch()`:**
+```python
+if self._use_chat_api:
+    system = self._build_system_prompt(series_context)
+    user = build_translation_prompt(lines, source_lang, target_lang, glossary_entries)
+    response = self._call_ollama_chat(system, user)
+else:
+    # legacy: /api/generate (V6/V7/V8 Kompatibilität)
+    prompt = build_translation_prompt(lines, source_lang, target_lang, glossary_entries)
+    response = self._call_ollama(prompt)
+```
+
+---
+
+### 2.2 `translation/base.py` — Serienkontext im Interface
+
+```python
+@abstractmethod
+def translate_batch(
+    self,
+    lines: list[str],
+    source_lang: str,
+    target_lang: str,
+    glossary_entries: list[dict] | None = None,
+    series_context: str | None = None,   # NEU — optional, backward-kompatibel
+) -> TranslationResult:
+```
+
+Alle anderen Backends (DeepL, Google, etc.) ignorieren `series_context` einfach.
+
+---
+
+### 2.3 `translator.py` — Serienkontext weitergeben
+
+Bei jedem `translate_with_fallback()`-Aufruf den Serienkontext aus dem Job-Kontext
+extrahieren und weitergeben:
+
+```python
+# Serienkontext aus bazarr_context_json oder Sonarr-Metadaten bauen
+series_context = None
+if series_title:
+    series_context = f"Serie: {series_title}."
+    if series_genre:
+        series_context += f" Genre: {', '.join(series_genre[:2])}."
+
+result = backend.translate_batch(
+    lines=lines,
+    source_lang=source_lang,
+    target_lang=target_lang,
+    glossary_entries=glossary_entries,
+    series_context=series_context,   # NEU
+)
+```
+
+---
+
+### 2.4 `translation/llm_utils.py` — Quality Evaluator Fix
+
+Der aktuelle Evaluator gibt fast immer DEFAULT_QUALITY_SCORE (50) zurück, weil der
+LLM keinen reinen Integer ausgibt.
+
+**Neues Evaluierungs-Prompt (zuverlässigere Extraktion):**
+
+```python
+def build_evaluation_prompt(...) -> str:
+    return (
+        f"Bewerte diese Untertitel-Übersetzung. "
+        f"Antworte NUR mit einer einzigen Zahl von 0 bis 100.\n\n"
+        f"Original (EN): {source_text}\n"
+        f"Übersetzung (DE): {translated_text}\n\n"
+        f"Kriterien: Bedeutung korrekt (40%), natürliches Deutsch (40%), "
+        f"Länge passend (20%). Zahl:"
+    )
+```
+
+**Robusteres Score-Parsing:**
+```python
+def parse_quality_score(response_text: str) -> int:
+    # Zuerst: erste Zahl am Anfang der Antwort suchen (Modell soll nur Zahl ausgeben)
+    text = response_text.strip()
+    first_token = text.split()[0] if text else ""
+    try:
+        score = int(first_token)
+        return max(0, min(100, score))
+    except ValueError:
+        pass
+    # Fallback: alle Zahlen suchen, letzte nehmen
+    matches = re.findall(r'\b(100|[1-9]?\d)\b', text)
+    if matches:
+        return max(0, min(100, int(matches[-1])))
+    return DEFAULT_QUALITY_SCORE
+```
+
+---
+
+## 3. Ollama Modelfile für V9
+
+Beim Deployment auf dem Mac mini (`05_export_gguf.py`) folgendes Modelfile verwenden:
+
+```
+FROM /Users/denniswittke/models/anime-translator-en-de-v9-Q5_K_M.gguf
+
+PARAMETER temperature 0.3
+PARAMETER top_p 0.9
+PARAMETER top_k 40
+PARAMETER num_ctx 4096
+PARAMETER num_predict 1024
+
+# System-Prompt wird per Request von Sublarr injiziert (Chat API)
+# Kein SYSTEM-Block hier — Sublarr kontrolliert den Kontext vollständig
+```
+
+**Wichtig:** Kein `SYSTEM`-Block im Modelfile — Sublarr injiziert den System-Prompt
+dynamisch (inkl. Serienkontext) über `/api/chat`.
+
+---
+
+## 4. Sublarr Settings — V9 Konfiguration
+
+Nach dem Deployment folgende Werte in den Sublarr-Einstellungen setzen:
+
+| Setting | Wert |
+|---------|------|
+| Ollama URL | `http://192.168.178.155:11434` |
+| Model | `anime-translator-en-de-v9` |
+| Chat API | ✅ aktiviert |
+| Temperature | `0.3` |
+| Timeout | `120` |
+| Max Retries | `3` |
+| Batch Size | `25` |
+| System Prompt | *(Standard aus config_field default)* |
+
+---
+
+## 5. Reihenfolge der Änderungen
+
+```
+1. [ ] translation/base.py       — series_context Parameter hinzufügen
+2. [ ] translation/ollama.py     — use_chat_api, system_prompt, _call_ollama_chat()
+3. [ ] translation/llm_utils.py  — Quality Evaluator Prompt + Parser Fix
+4. [ ] translator.py             — series_context aus Job-Kontext extrahieren + weitergeben
+5. [ ] Tests anpassen            — test_ollama_backend.py, test_llm_utils.py
+6. [ ] V9 deployen               — nach 05_export_gguf.py
+7. [ ] Sublarr config setzen     — use_chat_api=True, model=v9
+```
+
+---
+
+## 6. Backward-Kompatibilität
+
+Alle Änderungen sind rückwärtskompatibel:
+- `use_chat_api=False` (default) → bestehende V6-Deployments laufen unverändert
+- `series_context=None` → alle anderen Backends ignorieren den Parameter
+- Neues Evaluator-Prompt ist modellunabhängig
+
+Beim V9-Rollout: nur `use_chat_api=True` und `model=anime-translator-en-de-v9` setzen.
+
+---
+
+*Erstellt: 2026-03-15 | Für: Sublarr v0.29+ | Modell: anime-translator-en-de-v9*

--- a/backend/app.py
+++ b/backend/app.py
@@ -520,7 +520,7 @@ def _start_schedulers(settings, app=None):
             from standalone import get_standalone_manager
 
             standalone_mgr = get_standalone_manager()
-            standalone_mgr.start(socketio=socketio)
+            standalone_mgr.start(socketio=socketio, app=app)
         except Exception as e:
             logging.getLogger(__name__).warning("Standalone watcher start failed: %s", e)
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -248,6 +248,7 @@ class Settings(BaseSettings):
     standalone_enabled: bool = False
     standalone_scan_interval_hours: int = 6  # 0 = disabled
     standalone_debounce_seconds: int = 10
+    standalone_skip_extras: bool = True  # Skip trailers/featurettes/samples during scan
     tmdb_api_key: str = ""  # TMDB API v3 Bearer token
     tvdb_api_key: str = ""  # TVDB API v4 key (optional)
     tvdb_pin: str = ""  # TVDB PIN (optional)

--- a/backend/routes/library.py
+++ b/backend/routes/library.py
@@ -109,6 +109,10 @@ def get_library():
                             ),
                             {"sid": s["id"]},
                         ).fetchone()
+                    # Use the API endpoint for local posters (browser can't load file:// URLs)
+                    poster = (
+                        f"/api/v1/standalone/series/{s['id']}/poster" if s.get("poster_url") else ""
+                    )
                     result["series"].append(
                         {
                             "id": s["id"],
@@ -118,7 +122,7 @@ def get_library():
                             "episodes": s.get("episode_count") or 0,
                             "episodes_with_files": s.get("episode_count") or 0,
                             "path": s.get("folder_path", ""),
-                            "poster": s.get("poster_url") or "",
+                            "poster": poster,
                             "status": "continuing",
                             "profile_id": profile_id,
                             "profile_name": profile_name,
@@ -145,6 +149,9 @@ def get_library():
                             ),
                             {"mid": m["id"]},
                         ).fetchone()
+                    movie_poster = (
+                        f"/api/v1/standalone/movies/{m['id']}/poster" if m.get("poster_url") else ""
+                    )
                     result["movies"].append(
                         {
                             "id": m["id"],
@@ -152,7 +159,7 @@ def get_library():
                             "year": m.get("year"),
                             "has_file": True,
                             "path": m.get("file_path", ""),
-                            "poster": m.get("poster_url") or "",
+                            "poster": movie_poster,
                             "status": "released",
                             "missing_count": row[0] if row else 0,
                             "source": "standalone",

--- a/backend/routes/library.py
+++ b/backend/routes/library.py
@@ -81,6 +81,70 @@ def get_library():
     except Exception as e:
         logger.warning("Failed to get Radarr library: %s", e)
 
+    # If no Sonarr/Radarr data, fall back to standalone series/movies
+    if not result["series"] and not result["movies"]:
+        try:
+            from sqlalchemy import text
+
+            from config import get_settings
+            from db import _db_lock, get_db
+            from db.profiles import get_default_profile
+            from db.standalone import get_standalone_movies, get_standalone_series
+
+            settings = get_settings()
+            if getattr(settings, "standalone_enabled", False):
+                default_profile = get_default_profile()
+                profile_id = default_profile.get("id", 0) if default_profile else 0
+                profile_name = default_profile.get("name", "Default") if default_profile else "Default"
+
+                db = get_db()
+
+                for s in get_standalone_series():
+                    with _db_lock:
+                        row = db.execute(
+                            text("SELECT COUNT(*) FROM wanted_items WHERE standalone_series_id=:sid AND status='wanted'"),
+                            {"sid": s["id"]},
+                        ).fetchone()
+                    result["series"].append({
+                        "id": s["id"],
+                        "title": s["title"],
+                        "year": s.get("year"),
+                        "seasons": s.get("season_count") or 0,
+                        "episodes": s.get("episode_count") or 0,
+                        "episodes_with_files": s.get("episode_count") or 0,
+                        "path": s.get("folder_path", ""),
+                        "poster": s.get("poster_url") or "",
+                        "status": "continuing",
+                        "profile_id": profile_id,
+                        "profile_name": profile_name,
+                        "missing_count": row[0] if row else 0,
+                        "source": "standalone",
+                    })
+
+                for m in get_standalone_movies():
+                    # Skip misidentified entries (files inside series folders)
+                    title = m.get("title", "")
+                    if not title or title.lower() in ("tvshow", "movie", "trailer", "featurette", "sample"):
+                        continue
+                    with _db_lock:
+                        row = db.execute(
+                            text("SELECT COUNT(*) FROM wanted_items WHERE standalone_movie_id=:mid AND status='wanted'"),
+                            {"mid": m["id"]},
+                        ).fetchone()
+                    result["movies"].append({
+                        "id": m["id"],
+                        "title": title,
+                        "year": m.get("year"),
+                        "has_file": True,
+                        "path": m.get("file_path", ""),
+                        "poster": m.get("poster_url") or "",
+                        "status": "released",
+                        "missing_count": row[0] if row else 0,
+                        "source": "standalone",
+                    })
+        except Exception as e:
+            logger.warning("Failed to get standalone library: %s", e)
+
     return jsonify(result)
 
 

--- a/backend/routes/library.py
+++ b/backend/routes/library.py
@@ -353,6 +353,101 @@ def test_radarr_instance():
         return jsonify({"healthy": False, "message": str(e)}), 500
 
 
+def _get_standalone_series_detail(series_id: int, settings) -> dict | None:
+    """Build a Sonarr-compatible series detail dict from standalone DB data."""
+    import re
+
+    from sqlalchemy import text
+
+    from db import _db_lock, get_db
+    from db.profiles import get_default_profile
+    from db.standalone import get_standalone_series
+    from translator import detect_existing_target_for_lang
+
+    series = get_standalone_series(series_id)
+    if not series:
+        return None
+
+    profile = get_default_profile()
+    target_languages = (
+        profile.get("target_languages", [settings.target_language])
+        if profile
+        else [settings.target_language]
+    )
+    target_language_names = (
+        profile.get("target_language_names", [settings.target_language_name])
+        if profile
+        else [settings.target_language_name]
+    )
+    profile_name = profile.get("name", "Default") if profile else "Default"
+
+    db = get_db()
+    with _db_lock:
+        rows = db.execute(
+            text("SELECT * FROM wanted_items WHERE standalone_series_id=:sid ORDER BY file_path"),
+            {"sid": series_id},
+        ).fetchall()
+    wanted_items = [dict(r._mapping) for r in rows]
+
+    episodes = []
+    seen: set = set()
+    for item in wanted_items:
+        fp = item.get("file_path", "")
+        if fp in seen:
+            continue
+        seen.add(fp)
+        se = item.get("season_episode", "")
+        season, episode = 0, 0
+        if se:
+            m = re.match(r"S(\d+)E(\d+)", se, re.IGNORECASE)
+            if m:
+                season, episode = int(m.group(1)), int(m.group(2))
+        subtitles: dict = {}
+        for lang in target_languages:
+            try:
+                result = detect_existing_target_for_lang(fp, lang)
+                subtitles[lang] = result or ""
+            except Exception:
+                subtitles[lang] = ""
+        episodes.append(
+            {
+                "id": item.get("id"),
+                "season": season,
+                "episode": episode,
+                "title": item.get("title", ""),
+                "has_file": True,
+                "file_path": fp,
+                "subtitles": subtitles,
+                "audio_languages": [],
+                "monitored": True,
+            }
+        )
+
+    poster = f"/api/v1/standalone/series/{series_id}/poster" if series.get("poster_url") else ""
+    return {
+        "id": series.get("id"),
+        "title": series.get("title", ""),
+        "year": series.get("year"),
+        "path": series.get("folder_path", ""),
+        "poster": poster,
+        "fanart": "",
+        "overview": "",
+        "status": series.get("status", "continuing"),
+        "season_count": series.get("season_count") or 0,
+        "episode_count": len(episodes),
+        "episode_file_count": len(episodes),
+        "tags": [],
+        "profile_name": profile_name,
+        "target_languages": target_languages,
+        "target_language_names": target_language_names,
+        "source_language": settings.source_language,
+        "source_language_name": settings.source_language_name,
+        "absolute_order": False,
+        "episodes": episodes,
+        "source": "standalone",
+    }
+
+
 @bp.route("/library/series/<int:series_id>", methods=["GET"])
 def get_series_detail(series_id):
     """Get detailed series info with episodes and subtitle status.
@@ -417,6 +512,10 @@ def get_series_detail(series_id):
 
     sonarr = get_sonarr_client()
     if not sonarr:
+        # Try standalone fallback before giving up
+        standalone_response = _get_standalone_series_detail(series_id, settings)
+        if standalone_response is not None:
+            return jsonify(standalone_response)
         return jsonify({"error": "Sonarr not configured"}), 503
 
     series = sonarr.get_series_by_id(series_id)

--- a/backend/routes/library.py
+++ b/backend/routes/library.py
@@ -95,53 +95,69 @@ def get_library():
             if getattr(settings, "standalone_enabled", False):
                 default_profile = get_default_profile()
                 profile_id = default_profile.get("id", 0) if default_profile else 0
-                profile_name = default_profile.get("name", "Default") if default_profile else "Default"
+                profile_name = (
+                    default_profile.get("name", "Default") if default_profile else "Default"
+                )
 
                 db = get_db()
 
                 for s in get_standalone_series():
                     with _db_lock:
                         row = db.execute(
-                            text("SELECT COUNT(*) FROM wanted_items WHERE standalone_series_id=:sid AND status='wanted'"),
+                            text(
+                                "SELECT COUNT(*) FROM wanted_items WHERE standalone_series_id=:sid AND status='wanted'"
+                            ),
                             {"sid": s["id"]},
                         ).fetchone()
-                    result["series"].append({
-                        "id": s["id"],
-                        "title": s["title"],
-                        "year": s.get("year"),
-                        "seasons": s.get("season_count") or 0,
-                        "episodes": s.get("episode_count") or 0,
-                        "episodes_with_files": s.get("episode_count") or 0,
-                        "path": s.get("folder_path", ""),
-                        "poster": s.get("poster_url") or "",
-                        "status": "continuing",
-                        "profile_id": profile_id,
-                        "profile_name": profile_name,
-                        "missing_count": row[0] if row else 0,
-                        "source": "standalone",
-                    })
+                    result["series"].append(
+                        {
+                            "id": s["id"],
+                            "title": s["title"],
+                            "year": s.get("year"),
+                            "seasons": s.get("season_count") or 0,
+                            "episodes": s.get("episode_count") or 0,
+                            "episodes_with_files": s.get("episode_count") or 0,
+                            "path": s.get("folder_path", ""),
+                            "poster": s.get("poster_url") or "",
+                            "status": "continuing",
+                            "profile_id": profile_id,
+                            "profile_name": profile_name,
+                            "missing_count": row[0] if row else 0,
+                            "source": "standalone",
+                        }
+                    )
 
                 for m in get_standalone_movies():
                     # Skip misidentified entries (files inside series folders)
                     title = m.get("title", "")
-                    if not title or title.lower() in ("tvshow", "movie", "trailer", "featurette", "sample"):
+                    if not title or title.lower() in (
+                        "tvshow",
+                        "movie",
+                        "trailer",
+                        "featurette",
+                        "sample",
+                    ):
                         continue
                     with _db_lock:
                         row = db.execute(
-                            text("SELECT COUNT(*) FROM wanted_items WHERE standalone_movie_id=:mid AND status='wanted'"),
+                            text(
+                                "SELECT COUNT(*) FROM wanted_items WHERE standalone_movie_id=:mid AND status='wanted'"
+                            ),
                             {"mid": m["id"]},
                         ).fetchone()
-                    result["movies"].append({
-                        "id": m["id"],
-                        "title": title,
-                        "year": m.get("year"),
-                        "has_file": True,
-                        "path": m.get("file_path", ""),
-                        "poster": m.get("poster_url") or "",
-                        "status": "released",
-                        "missing_count": row[0] if row else 0,
-                        "source": "standalone",
-                    })
+                    result["movies"].append(
+                        {
+                            "id": m["id"],
+                            "title": title,
+                            "year": m.get("year"),
+                            "has_file": True,
+                            "path": m.get("file_path", ""),
+                            "poster": m.get("poster_url") or "",
+                            "status": "released",
+                            "missing_count": row[0] if row else 0,
+                            "source": "standalone",
+                        }
+                    )
         except Exception as e:
             logger.warning("Failed to get standalone library: %s", e)
 

--- a/backend/routes/standalone.py
+++ b/backend/routes/standalone.py
@@ -371,10 +371,16 @@ def series_poster(series_id):
     if not poster_path or not os.path.isfile(poster_path):
         return jsonify({"error": "No local poster available"}), 404
 
-    # Security: poster must reside inside the series folder
+    # Security: poster must reside inside the series folder or its parent
+    # (poster.jpg often lives in the series root while folder_path may point
+    # to a Season subfolder)
     series_folder = series.get("folder_path", "")
-    if series_folder and not is_safe_path(poster_path, series_folder):
-        return jsonify({"error": "Forbidden"}), 403
+    if series_folder:
+        allowed = is_safe_path(poster_path, series_folder) or is_safe_path(
+            poster_path, os.path.dirname(series_folder)
+        )
+        if not allowed:
+            return jsonify({"error": "Forbidden"}), 403
 
     try:
         return send_file(poster_path)
@@ -501,10 +507,14 @@ def movie_poster(movie_id):
     if not poster_path or not os.path.isfile(poster_path):
         return jsonify({"error": "No local poster available"}), 404
 
-    # Security: poster must reside inside the movie folder
+    # Security: poster must reside inside the movie folder or its parent
     movie_folder = os.path.dirname(movie.get("file_path", ""))
-    if movie_folder and not is_safe_path(poster_path, movie_folder):
-        return jsonify({"error": "Forbidden"}), 403
+    if movie_folder:
+        allowed = is_safe_path(poster_path, movie_folder) or is_safe_path(
+            poster_path, os.path.dirname(movie_folder)
+        )
+        if not allowed:
+            return jsonify({"error": "Forbidden"}), 403
 
     try:
         return send_file(poster_path)

--- a/backend/routes/standalone.py
+++ b/backend/routes/standalone.py
@@ -8,7 +8,7 @@ import logging
 import os
 import threading
 
-from flask import Blueprint, current_app, jsonify, request
+from flask import Blueprint, current_app, jsonify, request, send_file
 from sqlalchemy import text
 
 bp = Blueprint("standalone", __name__, url_prefix="/api/v1/standalone")
@@ -353,6 +353,36 @@ def get_series(series_id):
         return jsonify({"error": "Failed to get standalone series"}), 500
 
 
+@bp.route("/series/<int:series_id>/poster", methods=["GET"])
+def series_poster(series_id):
+    """Serve the local poster image for a standalone series.
+
+    Returns the local poster.jpg/poster.png found in the series folder
+    during scanning. Falls back to 404 if no local poster is stored.
+    """
+    from db.standalone import get_standalone_series
+    from security_utils import is_safe_path
+
+    series = get_standalone_series(series_id)
+    if not series:
+        return jsonify({"error": "Series not found"}), 404
+
+    poster_path = series.get("poster_url", "")
+    if not poster_path or not os.path.isfile(poster_path):
+        return jsonify({"error": "No local poster available"}), 404
+
+    # Security: poster must reside inside the series folder
+    series_folder = series.get("folder_path", "")
+    if series_folder and not is_safe_path(poster_path, series_folder):
+        return jsonify({"error": "Forbidden"}), 403
+
+    try:
+        return send_file(poster_path)
+    except Exception as e:
+        logger.error("Failed to serve poster for series %d: %s", series_id, e)
+        return jsonify({"error": "Failed to serve poster"}), 500
+
+
 @bp.route("/series/<int:series_id>", methods=["DELETE"])
 def delete_series(series_id):
     """Delete a standalone series and its wanted items.
@@ -455,6 +485,32 @@ def list_movies():
     except Exception as e:
         logger.error("Failed to list standalone movies: %s", e)
         return jsonify({"error": "Failed to list standalone movies"}), 500
+
+
+@bp.route("/movies/<int:movie_id>/poster", methods=["GET"])
+def movie_poster(movie_id):
+    """Serve the local poster image for a standalone movie."""
+    from db.standalone import get_standalone_movies
+    from security_utils import is_safe_path
+
+    movie = get_standalone_movies(movie_id)
+    if not movie:
+        return jsonify({"error": "Movie not found"}), 404
+
+    poster_path = movie.get("poster_url", "")
+    if not poster_path or not os.path.isfile(poster_path):
+        return jsonify({"error": "No local poster available"}), 404
+
+    # Security: poster must reside inside the movie folder
+    movie_folder = os.path.dirname(movie.get("file_path", ""))
+    if movie_folder and not is_safe_path(poster_path, movie_folder):
+        return jsonify({"error": "Forbidden"}), 403
+
+    try:
+        return send_file(poster_path)
+    except Exception as e:
+        logger.error("Failed to serve poster for movie %d: %s", movie_id, e)
+        return jsonify({"error": "Failed to serve poster"}), 500
 
 
 @bp.route("/movies/<int:movie_id>", methods=["DELETE"])

--- a/backend/routes/subtitles.py
+++ b/backend/routes/subtitles.py
@@ -230,7 +230,27 @@ def list_series_subtitles(series_id: int):
 
     client = get_sonarr_client()
     if client is None:
-        return jsonify({"error": "Sonarr not configured"}), 503
+        # Standalone fallback: scan wanted_items for this series
+        from sqlalchemy import text
+
+        from db import _db_lock, get_db
+        from db.standalone import get_standalone_series
+
+        if get_standalone_series(series_id) is None:
+            return jsonify({"error": "Sonarr not configured"}), 503
+
+        db = get_db()
+        with _db_lock:
+            rows = db.execute(
+                text("SELECT id, file_path FROM wanted_items WHERE standalone_series_id=:sid"),
+                {"sid": series_id},
+            ).fetchall()
+        result: dict[str, list[dict]] = {}
+        for row in rows:
+            sidecars = scan_subtitle_sidecars(row.file_path)
+            if sidecars:
+                result[str(row.id)] = sidecars
+        return jsonify({"subtitles": result})
 
     episode_files = client.get_episode_files_by_series(series_id)
     if not episode_files:

--- a/backend/standalone/__init__.py
+++ b/backend/standalone/__init__.py
@@ -55,14 +55,16 @@ class StandaloneManager:
         self._scanner = StandaloneScanner()
         self._watcher_running = False
         self._socketio = None
+        self._app = None
 
-    def start(self, socketio=None) -> None:
+    def start(self, socketio=None, app=None) -> None:
         """Start standalone mode: watcher + initial scan.
 
         Args:
             socketio: Optional SocketIO instance for WebSocket events.
         """
         self._socketio = socketio
+        self._app = app
 
         try:
             from config import get_settings
@@ -150,7 +152,10 @@ class StandaloneManager:
 
     def _initial_scan(self) -> None:
         """Run an initial full scan of all watched folders (background thread)."""
+        ctx = self._app.app_context() if self._app is not None else None
         try:
+            if ctx is not None:
+                ctx.push()
             summary = self._scanner.scan_all_folders()
             try:
                 from events import emit_event
@@ -161,13 +166,19 @@ class StandaloneManager:
             logger.info("Initial standalone scan complete: %s", summary)
         except Exception as e:
             logger.error("Initial standalone scan failed: %s", e)
+        finally:
+            if ctx is not None:
+                ctx.pop()
 
     def _on_new_file(self, path: str) -> None:
         """Callback for the watcher when a new stable video file is detected.
 
         Processes the file through the scanner and emits an event.
         """
+        ctx = self._app.app_context() if self._app is not None else None
         try:
+            if ctx is not None:
+                ctx.push()
             result = self._scanner.process_single_file(path)
             try:
                 from events import emit_event
@@ -189,3 +200,6 @@ class StandaloneManager:
             )
         except Exception as e:
             logger.error("Error processing new file via watcher: %s", e)
+        finally:
+            if ctx is not None:
+                ctx.pop()

--- a/backend/standalone/nfo_parser.py
+++ b/backend/standalone/nfo_parser.py
@@ -1,0 +1,219 @@
+"""NFO metadata parser for standalone mode.
+
+Reads Kodi/Emby/Jellyfin-style NFO sidecar files (tvshow.nfo, movie.nfo)
+from media folders and extracts structured metadata.
+
+Priority chain in scanner:
+  1. NFO file (local, complete, offline)
+  2. MetadataResolver (online API) — only for fields missing from NFO
+  3. Filename parsing (fallback)
+"""
+
+import logging
+import os
+import xml.etree.ElementTree as ET
+
+logger = logging.getLogger(__name__)
+
+# Genres that indicate anime content
+_ANIME_GENRES = {"anime", "animation (japan)", "japanimation"}
+
+# NFO filenames checked in order
+_SERIES_NFO_NAMES = ("tvshow.nfo",)
+_MOVIE_NFO_NAMES = ("movie.nfo",)
+
+# Poster filenames checked in order (prefer poster.jpg)
+_POSTER_NAMES = ("poster.jpg", "poster.png", "folder.jpg", "folder.png", "thumb.jpg")
+
+
+def _find_file(folder: str, candidates: tuple) -> str | None:
+    """Return first existing file path from candidates, or None."""
+    for name in candidates:
+        path = os.path.join(folder, name)
+        if os.path.isfile(path):
+            return path
+    return None
+
+
+def _text(element, tag: str, default=None):
+    """Extract text from a child tag, stripping whitespace."""
+    child = element.find(tag)
+    if child is not None and child.text:
+        return child.text.strip()
+    return default
+
+
+def _int_or_none(value: str | None) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (ValueError, TypeError):
+        return None
+
+
+def _parse_genres(root) -> list[str]:
+    """Extract all genre strings from the NFO."""
+    return [g.text.strip() for g in root.findall("genre") if g.text]
+
+
+def _is_anime_from_genres(genres: list[str]) -> bool:
+    """Return True if any genre indicates anime."""
+    lower = {g.lower() for g in genres}
+    return bool(lower & _ANIME_GENRES)
+
+
+def _parse_unique_ids(root) -> dict:
+    """Extract <uniqueid type="x"> entries into a dict."""
+    ids: dict = {}
+    for uid in root.findall("uniqueid"):
+        id_type = uid.get("type", "").lower()
+        if uid.text and id_type:
+            ids[id_type] = uid.text.strip()
+    return ids
+
+
+def parse_series_nfo(folder_path: str) -> dict | None:
+    """Parse tvshow.nfo from a series folder.
+
+    Args:
+        folder_path: Path to the series root folder.
+
+    Returns:
+        Dict with metadata keys, or None if no NFO found / parse error.
+        Keys: title, year, tvdb_id, tmdb_id, imdb_id, anilist_id,
+              is_anime, status, metadata_source, local_poster
+    """
+    nfo_path = _find_file(folder_path, _SERIES_NFO_NAMES)
+    if nfo_path is None:
+        return None
+
+    try:
+        tree = ET.parse(nfo_path)
+        root = tree.getroot()
+
+        # Some NFOs use <tvshow> as root, others are bare
+        if root.tag != "tvshow":
+            root = root.find("tvshow") or root
+
+        genres = _parse_genres(root)
+        unique_ids = _parse_unique_ids(root)
+
+        # IDs — prefer <tvdbid>/<tmdbid> tags, fall back to <uniqueid type="...">
+        tvdb_id = _int_or_none(_text(root, "tvdbid") or unique_ids.get("tvdb"))
+        tmdb_id = _int_or_none(_text(root, "tmdbid") or unique_ids.get("tmdb"))
+        imdb_id = _text(root, "imdb_id") or unique_ids.get("imdb")
+
+        # AniDB ID (present in some anime NFOs)
+        anidb_raw = unique_ids.get("anidb") or _text(root, "anidbid")
+        anidb_id = _int_or_none(anidb_raw)
+
+        year_raw = _text(root, "year") or _text(root, "premiered", "")[:4] or None
+        year = _int_or_none(year_raw)
+
+        status_raw = _text(root, "status", "")
+        status = status_raw.lower() if status_raw else None
+
+        is_anime = _is_anime_from_genres(genres) or anidb_id is not None
+
+        local_poster = _find_file(folder_path, _POSTER_NAMES)
+
+        result = {
+            "title": _text(root, "title") or _text(root, "sorttitle"),
+            "year": year,
+            "tvdb_id": tvdb_id,
+            "tmdb_id": tmdb_id,
+            "imdb_id": imdb_id or "",
+            "anilist_id": None,  # NFO does not carry AniList ID
+            "is_anime": is_anime,
+            "status": status,
+            "metadata_source": "nfo",
+            "local_poster": local_poster,
+        }
+
+        logger.debug(
+            "NFO parsed for %s: title=%r year=%s tvdb=%s tmdb=%s anime=%s",
+            folder_path,
+            result["title"],
+            year,
+            tvdb_id,
+            tmdb_id,
+            is_anime,
+        )
+        return result
+
+    except ET.ParseError as e:
+        logger.warning("Failed to parse NFO at %s: %s", nfo_path, e)
+        return None
+    except Exception as e:
+        logger.warning("Unexpected error reading NFO at %s: %s", nfo_path, e)
+        return None
+
+
+def parse_movie_nfo(folder_path: str) -> dict | None:
+    """Parse movie.nfo from a movie folder.
+
+    Args:
+        folder_path: Path to the movie root folder.
+
+    Returns:
+        Dict with metadata keys, or None if no NFO found / parse error.
+        Keys: title, year, tmdb_id, imdb_id, metadata_source, local_poster
+    """
+    nfo_path = _find_file(folder_path, _MOVIE_NFO_NAMES)
+    if nfo_path is None:
+        return None
+
+    try:
+        tree = ET.parse(nfo_path)
+        root = tree.getroot()
+
+        if root.tag != "movie":
+            root = root.find("movie") or root
+
+        unique_ids = _parse_unique_ids(root)
+
+        tmdb_id = _int_or_none(_text(root, "tmdbid") or unique_ids.get("tmdb"))
+        imdb_id = _text(root, "imdb_id") or _text(root, "imdbid") or unique_ids.get("imdb")
+
+        year_raw = _text(root, "year") or _text(root, "premiered", "")[:4] or None
+        year = _int_or_none(year_raw)
+
+        local_poster = _find_file(folder_path, _POSTER_NAMES)
+
+        result = {
+            "title": _text(root, "title") or _text(root, "sorttitle"),
+            "year": year,
+            "tmdb_id": tmdb_id,
+            "imdb_id": imdb_id or "",
+            "metadata_source": "nfo",
+            "local_poster": local_poster,
+        }
+
+        logger.debug(
+            "NFO parsed for movie %s: title=%r year=%s tmdb=%s",
+            folder_path,
+            result["title"],
+            year,
+            tmdb_id,
+        )
+        return result
+
+    except ET.ParseError as e:
+        logger.warning("Failed to parse movie NFO at %s: %s", nfo_path, e)
+        return None
+    except Exception as e:
+        logger.warning("Unexpected error reading movie NFO at %s: %s", nfo_path, e)
+        return None
+
+
+def find_local_poster(folder_path: str) -> str | None:
+    """Find a poster image in a media folder without parsing NFO.
+
+    Args:
+        folder_path: Path to the media folder.
+
+    Returns:
+        Absolute path to poster file, or None.
+    """
+    return _find_file(folder_path, _POSTER_NAMES)

--- a/backend/standalone/nfo_parser.py
+++ b/backend/standalone/nfo_parser.py
@@ -76,15 +76,26 @@ def _parse_unique_ids(root) -> dict:
 def parse_series_nfo(folder_path: str) -> dict | None:
     """Parse tvshow.nfo from a series folder.
 
+    Searches folder_path first, then its parent (handles the common case
+    where episodes live in Season subfolders but NFO is in the series root).
+
     Args:
-        folder_path: Path to the series root folder.
+        folder_path: Path to the common parent of episode files (may be a
+            Season subfolder).
 
     Returns:
         Dict with metadata keys, or None if no NFO found / parse error.
         Keys: title, year, tvdb_id, tmdb_id, imdb_id, anilist_id,
               is_anime, status, metadata_source, local_poster
     """
+    # Try current folder, then parent (Season subfolder → series root)
     nfo_path = _find_file(folder_path, _SERIES_NFO_NAMES)
+    nfo_folder = folder_path
+    if nfo_path is None:
+        parent = os.path.dirname(folder_path)
+        if parent != folder_path:
+            nfo_path = _find_file(parent, _SERIES_NFO_NAMES)
+            nfo_folder = parent
     if nfo_path is None:
         return None
 
@@ -116,7 +127,8 @@ def parse_series_nfo(folder_path: str) -> dict | None:
 
         is_anime = _is_anime_from_genres(genres) or anidb_id is not None
 
-        local_poster = _find_file(folder_path, _POSTER_NAMES)
+        # Poster lives in the same folder as the NFO (series root, not Season subfolder)
+        local_poster = _find_file(nfo_folder, _POSTER_NAMES)
 
         result = {
             "title": _text(root, "title") or _text(root, "sorttitle"),
@@ -210,10 +222,17 @@ def parse_movie_nfo(folder_path: str) -> dict | None:
 def find_local_poster(folder_path: str) -> str | None:
     """Find a poster image in a media folder without parsing NFO.
 
+    Checks folder_path first, then parent (handles Season subfolder layout).
+
     Args:
-        folder_path: Path to the media folder.
+        folder_path: Path to the media folder (may be a Season subfolder).
 
     Returns:
         Absolute path to poster file, or None.
     """
-    return _find_file(folder_path, _POSTER_NAMES)
+    poster = _find_file(folder_path, _POSTER_NAMES)
+    if poster is None:
+        parent = os.path.dirname(folder_path)
+        if parent != folder_path:
+            poster = _find_file(parent, _POSTER_NAMES)
+    return poster

--- a/backend/standalone/scanner.py
+++ b/backend/standalone/scanner.py
@@ -222,6 +222,8 @@ class StandaloneScanner:
         Resolves metadata once for the series, upserts standalone_series,
         then checks each episode for missing target language subtitles.
 
+        Metadata priority: NFO file → MetadataResolver (online) → filename.
+
         Args:
             title: Normalized series title (lowercase).
             files: List of parsed file dicts (each with file_path key).
@@ -232,6 +234,7 @@ class StandaloneScanner:
         """
         from db.standalone import upsert_standalone_series
         from db.wanted import upsert_wanted_item
+        from standalone.nfo_parser import find_local_poster, parse_series_nfo
 
         # Use the first file's original title for display
         display_title = files[0].get("title", title)
@@ -242,28 +245,64 @@ class StandaloneScanner:
                 year = f["year"]
                 break
 
-        # Resolve metadata (one lookup per unique series)
-        resolver = self._get_resolver()
-        meta = resolver.resolve_series(display_title, year=year, is_anime=is_anime)
-
         # Determine series folder path (common parent)
         series_folder = self._find_common_parent([f["file_path"] for f in files])
 
-        # Upsert standalone series
-        series_id = upsert_standalone_series(
-            title=meta.get("title", display_title),
-            folder_path=series_folder,
-            year=meta.get("year"),
-            tmdb_id=meta.get("tmdb_id"),
-            tvdb_id=meta.get("tvdb_id"),
-            anilist_id=meta.get("anilist_id"),
-            imdb_id=meta.get("imdb_id", ""),
-            poster_url=meta.get("poster_url", ""),
-            is_anime=meta.get("is_anime", is_anime),
-            episode_count=len(files),
-            season_count=meta.get("season_count") or 0,
-            metadata_source=meta.get("metadata_source", "filename"),
-        )
+        # --- NFO-first metadata resolution ---
+        nfo = parse_series_nfo(series_folder)
+
+        if nfo and (nfo.get("title") or nfo.get("tvdb_id") or nfo.get("tmdb_id")):
+            nfo_title = nfo.get("title") or display_title
+            nfo_year = nfo.get("year") or year
+            nfo_is_anime = nfo.get("is_anime", is_anime)
+
+            if nfo.get("tvdb_id") or nfo.get("tmdb_id"):
+                # NFO has IDs — no online lookup needed
+                poster_url = nfo.get("local_poster") or ""
+                meta: dict = {}
+            else:
+                # NFO has title but no IDs — enrich via resolver
+                resolver = self._get_resolver()
+                meta = resolver.resolve_series(nfo_title, year=nfo_year, is_anime=nfo_is_anime)
+                poster_url = nfo.get("local_poster") or meta.get("poster_url", "")
+
+            series_id = upsert_standalone_series(
+                title=nfo_title,
+                folder_path=series_folder,
+                year=nfo_year,
+                tmdb_id=nfo.get("tmdb_id") or meta.get("tmdb_id"),
+                tvdb_id=nfo.get("tvdb_id") or meta.get("tvdb_id"),
+                anilist_id=nfo.get("anilist_id") or meta.get("anilist_id"),
+                imdb_id=nfo.get("imdb_id") or meta.get("imdb_id", ""),
+                poster_url=poster_url,
+                is_anime=nfo_is_anime,
+                episode_count=len(files),
+                season_count=meta.get("season_count") or 0,
+                metadata_source="nfo",
+            )
+            resolved_title = nfo_title
+        else:
+            # No usable NFO — fall back to MetadataResolver
+            resolver = self._get_resolver()
+            meta = resolver.resolve_series(display_title, year=year, is_anime=is_anime)
+            local_poster = find_local_poster(series_folder)
+            poster_url = local_poster or meta.get("poster_url", "")
+
+            series_id = upsert_standalone_series(
+                title=meta.get("title", display_title),
+                folder_path=series_folder,
+                year=meta.get("year"),
+                tmdb_id=meta.get("tmdb_id"),
+                tvdb_id=meta.get("tvdb_id"),
+                anilist_id=meta.get("anilist_id"),
+                imdb_id=meta.get("imdb_id", ""),
+                poster_url=poster_url,
+                is_anime=meta.get("is_anime", is_anime),
+                episode_count=len(files),
+                season_count=meta.get("season_count") or 0,
+                metadata_source=meta.get("metadata_source", "filename"),
+            )
+            resolved_title = meta.get("title", display_title)
 
         # Check each episode for missing target subtitles
         wanted_added = 0
@@ -285,18 +324,16 @@ class StandaloneScanner:
                 if existing == "ass":
                     continue  # Goal achieved
 
-                ep_title = f"{meta.get('title', display_title)}"
+                ep_title = resolved_title
                 if season_episode:
                     ep_title = f"{ep_title} -- {season_episode}"
-
-                existing_sub = existing or ""
 
                 upsert_wanted_item(
                     item_type="episode",
                     file_path=file_path,
                     title=ep_title,
                     season_episode=season_episode,
-                    existing_sub=existing_sub,
+                    existing_sub=existing or "",
                     missing_languages=[target_lang],
                     target_language=target_lang,
                     instance_name="standalone",
@@ -312,6 +349,8 @@ class StandaloneScanner:
         Resolves metadata, upserts standalone_movie, checks for missing
         target language subtitles.
 
+        Metadata priority: NFO file → MetadataResolver (online) → filename.
+
         Args:
             parsed: Parsed file metadata dict.
             file_path: Absolute path to the movie file.
@@ -322,24 +361,59 @@ class StandaloneScanner:
         """
         from db.standalone import upsert_standalone_movie
         from db.wanted import upsert_wanted_item
+        from standalone.nfo_parser import find_local_poster, parse_movie_nfo
 
         title = parsed.get("title", "Unknown")
         year = parsed.get("year")
+        movie_folder = os.path.dirname(file_path)
 
-        # Resolve metadata
-        resolver = self._get_resolver()
-        meta = resolver.resolve_movie(title, year=year)
+        # --- NFO-first metadata resolution ---
+        nfo = parse_movie_nfo(movie_folder)
 
-        # Upsert standalone movie
-        movie_id = upsert_standalone_movie(
-            title=meta.get("title", title),
-            file_path=file_path,
-            year=meta.get("year"),
-            tmdb_id=meta.get("tmdb_id"),
-            imdb_id=meta.get("imdb_id", ""),
-            poster_url=meta.get("poster_url", ""),
-            metadata_source=meta.get("metadata_source", "filename"),
-        )
+        if nfo and (nfo.get("title") or nfo.get("tmdb_id")):
+            nfo_title = nfo.get("title") or title
+            nfo_year = nfo.get("year") or year
+
+            if nfo.get("tmdb_id"):
+                # NFO has IDs — no online lookup needed
+                poster_url = nfo.get("local_poster") or ""
+                tmdb_id = nfo["tmdb_id"]
+                imdb_id = nfo.get("imdb_id", "")
+            else:
+                # NFO has title but no IDs — enrich via resolver
+                resolver = self._get_resolver()
+                meta = resolver.resolve_movie(nfo_title, year=nfo_year)
+                poster_url = nfo.get("local_poster") or meta.get("poster_url", "")
+                tmdb_id = meta.get("tmdb_id")
+                imdb_id = nfo.get("imdb_id") or meta.get("imdb_id", "")
+
+            movie_id = upsert_standalone_movie(
+                title=nfo_title,
+                file_path=file_path,
+                year=nfo_year,
+                tmdb_id=tmdb_id,
+                imdb_id=imdb_id,
+                poster_url=poster_url,
+                metadata_source="nfo",
+            )
+            resolved_title = nfo_title
+        else:
+            # No usable NFO — fall back to MetadataResolver
+            resolver = self._get_resolver()
+            meta = resolver.resolve_movie(title, year=year)
+            local_poster = find_local_poster(movie_folder)
+            poster_url = local_poster or meta.get("poster_url", "")
+
+            movie_id = upsert_standalone_movie(
+                title=meta.get("title", title),
+                file_path=file_path,
+                year=meta.get("year"),
+                tmdb_id=meta.get("tmdb_id"),
+                imdb_id=meta.get("imdb_id", ""),
+                poster_url=poster_url,
+                metadata_source=meta.get("metadata_source", "filename"),
+            )
+            resolved_title = meta.get("title", title)
 
         # Check for missing target subtitles
         wanted_added = 0
@@ -350,13 +424,11 @@ class StandaloneScanner:
             if existing == "ass":
                 continue
 
-            existing_sub = existing or ""
-
             upsert_wanted_item(
                 item_type="movie",
                 file_path=file_path,
-                title=meta.get("title", title),
-                existing_sub=existing_sub,
+                title=resolved_title,
+                existing_sub=existing or "",
                 missing_languages=[target_lang],
                 target_language=target_lang,
                 instance_name="standalone",

--- a/backend/standalone/scanner.py
+++ b/backend/standalone/scanner.py
@@ -14,6 +14,28 @@ from sqlalchemy import text
 
 logger = logging.getLogger(__name__)
 
+# Filename stems and suffixes that mark non-episode extras (Jellyfin/Kodi convention).
+# Files matching these are excluded from subtitle discovery.
+_EXTRA_STEMS = frozenset({"tvshow", "movie", "trailer", "sample"})
+_EXTRA_SUFFIXES = (
+    "-trailer",
+    "-featurette",
+    "-behindthescenes",
+    "-deleted",
+    "-interview",
+    "-scene",
+    "-short",
+    "-sample",
+    "-theme",
+)
+
+
+def _is_extra_file(path: str) -> bool:
+    """Return True if *path* is a media extra (trailer, featurette, …) that should
+    be excluded from subtitle discovery."""
+    stem = os.path.splitext(os.path.basename(path))[0].lower()
+    return stem in _EXTRA_STEMS or any(stem.endswith(s) for s in _EXTRA_SUFFIXES)
+
 
 class StandaloneScanner:
     """Scans watched folders for video files, resolves metadata, and populates wanted_items.
@@ -152,6 +174,7 @@ class StandaloneScanner:
         Returns:
             Tuple of (series_count, movie_count, wanted_count).
         """
+        from config import get_settings
         from standalone.parser import group_files_by_series, is_video_file, parse_media_file
 
         folder_path = folder["path"]
@@ -159,12 +182,14 @@ class StandaloneScanner:
             logger.warning("Watched folder does not exist: %s", folder_path)
             return (0, 0, 0)
 
+        skip_extras = getattr(get_settings(), "standalone_skip_extras", True)
+
         # Collect all video files
         video_files = []
         for root, _dirs, files in os.walk(folder_path, followlinks=True):
             for filename in files:
                 full_path = os.path.join(root, filename)
-                if is_video_file(full_path):
+                if is_video_file(full_path) and (not skip_extras or not _is_extra_file(full_path)):
                     video_files.append(full_path)
 
         if not video_files:
@@ -613,8 +638,10 @@ class StandaloneScanner:
             Number of items removed.
         """
         try:
+            from config import get_settings
             from db import _db_lock, get_db
 
+            skip_extras = getattr(get_settings(), "standalone_skip_extras", True)
             db = get_db()
             with _db_lock:
                 rows = db.execute(
@@ -623,7 +650,7 @@ class StandaloneScanner:
 
             to_remove = []
             for row in rows:
-                if not os.path.exists(row[1]):
+                if not os.path.exists(row[1]) or (skip_extras and _is_extra_file(row[1])):
                     to_remove.append(row[0])
 
             if to_remove:

--- a/docs/superpowers/specs/2026-03-15-fansub-scoring-integration-design.md
+++ b/docs/superpowers/specs/2026-03-15-fansub-scoring-integration-design.md
@@ -5,56 +5,57 @@
 
 ## Overview
 
-Redesign Fansub Preferences to integrate properly into the scoring pipeline with a global default and an optional per-series override. Fix the standalone series bug. Reduce the per-series UI from a prominent panel to a small toolbar button with modal.
+Extend Fansub Preferences to support standalone series, wire per-series fansub rules into the automatic processing pipeline, fix the Settings tab placement, and reduce the per-series UI from a prominent panel to a small toolbar button with modal.
 
 ---
 
 ## Problem Statement
 
-1. **Global fields exist but are not wired.** `release_group_prefer`, `release_group_exclude`, and `release_group_prefer_bonus` exist in `config.py` and the Settings UI (Wanted tab), but `_apply_fansub_rules()` in `wanted_search.py` never reads them — they are dead config.
-2. **Standalone series are excluded.** `wanted_search.py` line ~543 only applies fansub prefs when `sonarr_series_id` is set. Standalone series (`standalone_series_id` only) never get fansub rules applied.
-3. **Per-series panel is too prominent.** `SeriesFansubPrefsPanel` renders as a full card section on every series detail page regardless of whether the user has configured anything.
-4. **Wrong Settings tab.** Release group fields live in the Wanted tab, but conceptually they are score modifiers like HI Preference and Forced Preference, which live in the Scoring tab.
+1. **Standalone series excluded from per-series fansub rules.** `wanted_search.py` only checks `sonarr_series_id` when looking up per-series prefs.
+2. **`fansub_preferences` table only supports Sonarr.** The PK is `sonarr_series_id` — no column for standalone series IDs.
+3. **`process_wanted_item` (scheduler/automatic path) never applies Layer 2 per-series fansub rules.** Only the interactive `search_wanted_item` function applies them. Scheduled and batch downloads use `search_and_download_best` directly, which skips Layer 2 entirely. This affects all series (Sonarr and standalone).
+4. **Per-series panel is too prominent.** `SeriesFansubPrefsPanel` renders as a full card section on every series detail page.
+5. **Release group fields in wrong Settings tab.** They are hardcoded into the Wanted tab render path; they belong in the Scoring tab alongside HI/Forced Preference.
+
+---
+
+## Architecture — Two Independent Layers
+
+```
+ProviderManager.search()                    ← Layer 1: Global
+  → release_group_prefer/exclude/bonus from config
+  → Applied to ALL searches, already functional
+
+wanted_search.py: _apply_fansub_rules()     ← Layer 2: Per-Series
+  → Looked up from fansub_preferences table
+  → Applied additively on top of Layer 1
+  → Currently: search_wanted_item() only
+  → After this spec: process_wanted_item() also
+```
+
+Both layers run additively. A per-series rule does not suppress global rules.
 
 ---
 
 ## Design Decisions
 
-| Decision | Choice | Rationale |
-|----------|--------|-----------|
-| Global vs per-series | Global default + per-series override (replaces) | 80% of users want one rule set; power users can override per series |
-| Per-series merge strategy | Override **replaces** global entirely for that series | Simple, no surprising interactions |
-| Settings placement | Move to Scoring tab | Consistent with HI/Forced Preference which also adjust scores |
-| Per-series UI | Small toolbar button + modal | Not prominent, but accessible when needed |
-
----
-
-## Architecture
-
-### Scoring Pipeline — New Flow
-
-```
-search_wanted_item(item)
-  → collect all provider results
-  → resolve fansub rules:
-      if series has per-series override → use override
-      else → use global config (release_group_prefer/exclude/bonus)
-  → _apply_fansub_rules(results, rules)   ← same function, no change
-  → sort by priority key
-  → return results
-```
-
-The `_apply_fansub_rules()` function itself is unchanged — it already does case-insensitive substring matching, +bonus for preferred groups, −999 for excluded groups.
+| Decision | Choice |
+|----------|--------|
+| Layer interaction | Additive — both layers always run |
+| Standalone support | Add `standalone_series_id` column to `fansub_preferences` |
+| `process_wanted_item` gap | Fix it — add Layer 2 lookup to automatic pipeline |
+| Settings placement | Move 3 fields from hardcoded Wanted block → `ScoringTab` component |
+| Per-series UI | Small toolbar button + modal, replaces current panel |
+| Movie fansub overrides | Out of scope — table remains series-only |
 
 ---
 
 ## Backend Changes
 
-### 1. `backend/wanted_search.py`
+### 1. `backend/wanted_search.py` — extend fansub lookup in both search paths
 
-Replace the current block (lines ~542–554):
+**In `search_wanted_item()`** (interactive UI path, lines ~542–554), replace:
 ```python
-# CURRENT (broken)
 series_id = item.get("sonarr_series_id")
 if series_id:
     fansub = FansubPreferenceRepository().get_fansub_prefs(series_id)
@@ -62,21 +63,38 @@ if series_id:
         _apply_fansub_rules(...)
 ```
 
-With a new helper `_resolve_fansub_rules(item, settings)` that:
-1. Checks `sonarr_series_id` → `FansubPreferenceRepository().get_fansub_prefs(sonarr_id)`
-2. Falls back to `standalone_series_id` → `FansubPreferenceRepository().get_fansub_prefs_standalone(standalone_id)`
-3. Falls back to global config:
-   ```python
-   preferred = [g.strip() for g in settings.release_group_prefer.split(",") if g.strip()]
-   excluded  = [g.strip() for g in settings.release_group_exclude.split(",") if g.strip()]
-   bonus     = settings.release_group_prefer_bonus
-   ```
-4. Always calls `_apply_fansub_rules()` (even if lists are empty — no-op).
+With a helper call `_apply_series_fansub_rules(all_results, item)` (see below).
+
+**In `process_wanted_item()`** (automatic pipeline), add `_apply_series_fansub_rules()` between obtaining results and selecting the best. Since `process_wanted_item` currently calls `search_and_download_best()` (which returns a single downloaded result), refactor that step to:
+1. Call `search_with_fallback()` to get the ranked result list
+2. Call `_apply_series_fansub_rules(results, item)` to apply Layer 2
+3. Re-sort results: `results.sort(key=lambda r: (0 if r.format == ASS else 1, -r.score))`
+4. Iterate and download the best
+
+**New helper:**
+```python
+def _apply_series_fansub_rules(results: list, item: dict) -> None:
+    """Apply per-series fansub rules (Layer 2) in-place if configured."""
+    repo = FansubPreferenceRepository()
+    fansub = None
+    if sonarr_id := item.get("sonarr_series_id"):
+        fansub = repo.get_fansub_prefs_by_sonarr(sonarr_id)
+    elif standalone_id := item.get("standalone_series_id"):
+        fansub = repo.get_fansub_prefs_by_standalone(standalone_id)
+    if fansub:
+        _apply_fansub_rules(
+            results,
+            preferred=fansub["preferred_groups"],
+            excluded=fansub["excluded_groups"],
+            bonus=fansub["bonus"],
+        )
+```
 
 ### 2. `backend/db/models/core.py` — `FansubPreference` table
 
-Add a nullable `standalone_series_id` column. The table currently has `sonarr_series_id` as the primary key; change to a surrogate auto-increment PK and add a unique constraint per source:
+Current: `sonarr_series_id` is the primary key. SQLite does not support in-place PK changes, so the migration must recreate the table.
 
+New schema:
 ```python
 class FansubPreference(Base):
     __tablename__ = "fansub_preferences"
@@ -86,48 +104,135 @@ class FansubPreference(Base):
     preferred_groups_json: Mapped[str] = mapped_column(Text, nullable=False, default="[]")
     excluded_groups_json: Mapped[str] = mapped_column(Text, nullable=False, default="[]")
     bonus: Mapped[int] = mapped_column(Integer, nullable=False, default=20)
-    updated_at: Mapped[str] = mapped_column(Text, nullable=False, default=...)
+    updated_at: Mapped[str] = mapped_column(Text, nullable=False)
 ```
 
-Constraint: exactly one of `sonarr_series_id` / `standalone_series_id` must be non-null (enforced at repository level).
+Invariant (enforced at repository level): exactly one of `sonarr_series_id` / `standalone_series_id` must be non-null per row.
 
 ### 3. `backend/db/repositories/fansub_prefs.py`
 
-Add:
-- `get_fansub_prefs_standalone(standalone_series_id: int) -> dict | None`
-- `set_fansub_prefs_standalone(standalone_series_id, preferred, excluded, bonus)`
-- `delete_fansub_prefs_standalone(standalone_series_id)`
+Rename existing method and add standalone equivalents. All methods query by column value, not PK:
+
+```python
+def get_fansub_prefs_by_sonarr(self, sonarr_series_id: int) -> dict | None:
+    row = self.session.query(FansubPreference).filter_by(sonarr_series_id=sonarr_series_id).first()
+    ...
+
+def set_fansub_prefs_by_sonarr(self, sonarr_series_id: int, preferred, excluded, bonus) -> None:
+    now = datetime.utcnow().isoformat()
+    existing = self.session.query(FansubPreference).filter_by(sonarr_series_id=sonarr_series_id).first()
+    if existing:
+        existing.preferred_groups_json = json.dumps(preferred)
+        existing.excluded_groups_json = json.dumps(excluded)
+        existing.bonus = bonus
+        existing.updated_at = now
+    else:
+        self.session.add(FansubPreference(
+            sonarr_series_id=sonarr_series_id,
+            preferred_groups_json=json.dumps(preferred),
+            excluded_groups_json=json.dumps(excluded),
+            bonus=bonus,
+            updated_at=now,
+        ))
+
+def delete_fansub_prefs_by_sonarr(self, sonarr_series_id: int) -> None: ...
+
+# Mirror of the above three for standalone_series_id
+def get_fansub_prefs_by_standalone(self, standalone_series_id: int) -> dict | None: ...
+def set_fansub_prefs_by_standalone(self, standalone_series_id: int, preferred, excluded, bonus) -> None: ...
+def delete_fansub_prefs_by_standalone(self, standalone_series_id: int) -> None: ...
+```
+
+Keep `get_fansub_prefs(series_id)` as a deprecated alias for `get_fansub_prefs_by_sonarr(series_id)` to avoid breaking any callers outside `wanted_search.py`.
 
 ### 4. `backend/routes/fansub_prefs.py`
 
-Current endpoints are keyed to Sonarr series ID:
+Update existing routes to use renamed repository methods. Add standalone routes:
+
 ```
-GET/PUT/DELETE /api/v1/series/<id>/fansub-prefs
+GET    /api/v1/series/<id>/fansub-prefs              (Sonarr, existing)
+PUT    /api/v1/series/<id>/fansub-prefs              (Sonarr, existing)
+DELETE /api/v1/series/<id>/fansub-prefs              (Sonarr, existing)
+GET    /api/v1/standalone/series/<id>/fansub-prefs   (new)
+PUT    /api/v1/standalone/series/<id>/fansub-prefs   (new)
+DELETE /api/v1/standalone/series/<id>/fansub-prefs   (new)
 ```
 
-Add standalone equivalents:
+Standalone routes register under the existing `/api/v1/standalone` blueprint.
+
+### 5. Database migration (Alembic)
+
+SQLite requires table-rename pattern for PK changes:
+
+```python
+def upgrade():
+    op.execute("""
+        CREATE TABLE fansub_preferences_new (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            sonarr_series_id INTEGER UNIQUE,
+            standalone_series_id INTEGER UNIQUE,
+            preferred_groups_json TEXT NOT NULL DEFAULT '[]',
+            excluded_groups_json TEXT NOT NULL DEFAULT '[]',
+            bonus INTEGER NOT NULL DEFAULT 20,
+            updated_at TEXT NOT NULL DEFAULT ''
+        )
+    """)
+    op.execute("""
+        INSERT INTO fansub_preferences_new
+            (sonarr_series_id, preferred_groups_json, excluded_groups_json, bonus, updated_at)
+        SELECT
+            sonarr_series_id,
+            preferred_groups_json,
+            excluded_groups_json,
+            bonus,
+            COALESCE(updated_at, datetime('now'))
+        FROM fansub_preferences
+    """)
+    op.execute("DROP TABLE fansub_preferences")
+    op.execute("ALTER TABLE fansub_preferences_new RENAME TO fansub_preferences")
+
+def downgrade():
+    # Standalone rows are dropped on downgrade; only Sonarr rows preserved
+    op.execute("""
+        CREATE TABLE fansub_preferences_old (
+            sonarr_series_id INTEGER PRIMARY KEY,
+            preferred_groups_json TEXT NOT NULL DEFAULT '[]',
+            excluded_groups_json TEXT NOT NULL DEFAULT '[]',
+            bonus INTEGER NOT NULL DEFAULT 20,
+            updated_at TEXT
+        )
+    """)
+    op.execute("""
+        INSERT INTO fansub_preferences_old
+        SELECT sonarr_series_id, preferred_groups_json, excluded_groups_json, bonus, updated_at
+        FROM fansub_preferences
+        WHERE sonarr_series_id IS NOT NULL
+    """)
+    op.execute("DROP TABLE fansub_preferences")
+    op.execute("ALTER TABLE fansub_preferences_old RENAME TO fansub_preferences")
 ```
-GET/PUT/DELETE /api/v1/standalone/series/<id>/fansub-prefs
+
+### 6. Settings — move fields from Wanted block to ScoringTab component
+
+**`frontend/src/pages/Settings/index.tsx`:** Remove the hardcoded key array in the Wanted tab render block:
+```tsx
+// REMOVE this SettingsCard from the isWantedTab branch:
+<SettingsCard title="Release Group Filter" ...>
+  {['release_group_prefer','release_group_exclude','release_group_prefer_bonus']
+    .map(k => FIELDS.find(f => f.key === k)!).filter(Boolean).map(renderField)}
+</SettingsCard>
 ```
 
-The existing Sonarr-keyed routes remain unchanged.
+**`frontend/src/pages/Settings/EventsTab.tsx` — `ScoringTab` component:** Add a new `SettingsCard` section at the bottom of `ScoringTab`:
+```tsx
+<SettingsCard title="Release Group Filter"
+  description="Boost preferred groups and block unwanted ones during provider search">
+  {['release_group_prefer','release_group_exclude','release_group_prefer_bonus']
+    .map(k => FIELDS.find(f => f.key === k)!).filter(Boolean).map(renderField)}
+</SettingsCard>
+```
 
-### 5. Database migration
-
-New Alembic migration:
-- Add `standalone_series_id` column (nullable int)
-- Add unique index on `standalone_series_id`
-- Change PK from `sonarr_series_id` to auto-increment `id`
-- Make `sonarr_series_id` nullable (was non-nullable PK)
-
-### 6. Settings — move fields from Wanted to Scoring tab
-
-In `frontend/src/pages/Settings/index.tsx`, change `tab` from `'Wanted'` to `'Scoring'` for:
-- `release_group_prefer`
-- `release_group_exclude`
-- `release_group_prefer_bonus`
-
-Also update the Scoring tab section grouping to include a "Release Group Filtering" section header.
+`ScoringTab` must import `FIELDS`, `renderField`, and `SettingsCard` (or accept them as props — match the existing pattern used by other special-case tabs in the file).
 
 ---
 
@@ -135,52 +240,62 @@ Also update the Scoring tab section grouping to include a "Release Group Filteri
 
 ### 1. `SeriesDetail.tsx` — remove Fansub Preferences panel
 
-Remove the `{/* Fansub Preferences Panel */}` block (currently renders `SeriesFansubPrefsPanel` as a full card section). Replace with nothing — the panel is gone.
+Remove the `{/* Fansub Preferences Panel */}` block entirely (the `SeriesFansubPrefsPanel` card section).
 
 ### 2. `SeriesDetail.tsx` — add Fansub toolbar button
 
-In the actions toolbar row (next to "Tracks extrahieren", "Bereinigen", "Export ZIP"), add:
-
+In the actions toolbar row (next to "Tracks extrahieren", "Bereinigen", "Export ZIP"):
 ```tsx
-<FansubOverrideButton seriesId={seriesId} source={seriesData.source} />
+<FansubOverrideButton seriesId={seriesId} source={seriesData?.source ?? 'sonarr'} />
 ```
-
-Button states:
-- **No override set** → grey icon + label "Fansub", tooltip "Using global defaults"
-- **Override active** → teal/accent color + label "Fansub", tooltip shows configured groups
 
 ### 3. New component: `FansubOverrideButton`
 
 Location: `frontend/src/components/series/FansubOverrideButton.tsx`
 
-Responsibilities:
-- Renders the toolbar button
-- On click, opens `FansubOverrideModal`
-- Uses `useSeriesFansubPrefs(seriesId)` / `useStandaloneFansubPrefs(seriesId)` based on `source`
-- Visual state: teal when override active, grey when using global
+- Renders a small button labelled "Fansub"
+- Selects hook based on `source` prop:
+  - `'standalone'` → `useStandaloneFansubPrefs(seriesId)` / `useSetStandaloneFansubPrefs` / `useDeleteStandaloneFansubPrefs`
+  - anything else → `useSeriesFansubPrefs(seriesId)` / `useSetSeriesFansubPrefs` / `useDeleteSeriesFansubPrefs`
+- Active state (teal/accent): `prefs?.preferred_groups.length > 0 || prefs?.excluded_groups.length > 0`
+- Inactive state (grey): empty lists or no override row in DB
+- On click: opens `FansubOverrideModal`
 
 ### 4. New component: `FansubOverrideModal`
 
 Location: `frontend/src/components/series/FansubOverrideModal.tsx`
 
 Content:
-- "Override for this series" heading
-- Read-only info row: "Global: SubsPlease, Erai-raws" (from settings)
-- Preferred Groups input (comma-separated)
-- Blocked Groups input (comma-separated)
-- Bonus Points number input
-- Save button + "Reset to Global" button (deletes the override)
-- Follows existing Modal pattern: `role="dialog"`, `aria-modal`, backdrop click to close, Escape to close
+- Heading: "Fansub Override — this series only"
+- Read-only global defaults row: displays `settings.release_group_prefer` and `settings.release_group_exclude` (split by comma, joined as comma list). Data source: `useConfig()` or passed in as props.
+- Preferred Groups input (comma-separated, placeholder from global value)
+- Blocked Groups input (comma-separated, placeholder from global value)
+- Bonus Points number input (default: `settings.release_group_prefer_bonus`)
+- Save button (calls set mutation)
+- "Reset to Global" button (calls delete mutation, resets local state to empty)
+- Modal pattern: `role="dialog"`, `aria-modal="true"`, `aria-labelledby` on heading, `autoFocus` on first input, backdrop click and Escape close
 
 ### 5. `api/client.ts` + `hooks/useApi.ts`
 
-Add:
-- `getStandaloneFansubPrefs(seriesId)`
-- `setStandaloneFansubPrefs(seriesId, prefs)`
-- `deleteStandaloneFansubPrefs(seriesId)`
-- `useStandaloneFansubPrefs(seriesId)` hook
-- `useSetStandaloneFansubPrefs(seriesId)` hook
-- `useDeleteStandaloneFansubPrefs(seriesId)` hook
+Add standalone fansub API functions and TanStack Query hooks mirroring the existing Sonarr ones:
+- `getStandaloneFansubPrefs(seriesId)` → `GET /api/v1/standalone/series/<id>/fansub-prefs`
+- `setStandaloneFansubPrefs(seriesId, prefs)` → `PUT /api/v1/standalone/series/<id>/fansub-prefs`
+- `deleteStandaloneFansubPrefs(seriesId)` → `DELETE /api/v1/standalone/series/<id>/fansub-prefs`
+- `useStandaloneFansubPrefs(seriesId)` — query hook, `queryKey: ['standalone-fansub-prefs', seriesId]`
+- `useSetStandaloneFansubPrefs(seriesId)` — mutation hook, invalidates above query key on success
+- `useDeleteStandaloneFansubPrefs(seriesId)` — mutation hook, invalidates above query key on success
+
+---
+
+## Test Coverage
+
+New or extended tests in `tests/test_fansub_prefs.py`:
+
+1. **`_apply_series_fansub_rules()` — Sonarr branch**: item with `sonarr_series_id`, repo returns prefs → rules applied
+2. **`_apply_series_fansub_rules()` — standalone branch**: item with `standalone_series_id`, repo returns prefs → rules applied
+3. **`_apply_series_fansub_rules()` — no override**: item with no series ID → function is no-op, no exception
+4. **`process_wanted_item` integration**: verify Layer 2 rules are applied in the automatic pipeline path
+5. **Migration**: verify existing Sonarr rows survive upgrade; `sonarr_series_id` values intact; `standalone_series_id` is NULL for migrated rows; downgrade restores original schema and drops standalone rows cleanly
 
 ---
 
@@ -188,12 +303,13 @@ Add:
 
 | File | Change |
 |------|--------|
-| `backend/wanted_search.py` | Replace series-only fansub block with `_resolve_fansub_rules()` helper |
-| `backend/db/models/core.py` | Add `standalone_series_id` column, change PK |
-| `backend/db/repositories/fansub_prefs.py` | Add standalone CRUD methods |
-| `backend/routes/fansub_prefs.py` | Add `/standalone/series/<id>/fansub-prefs` routes |
-| `backend/db/migrations/versions/...` | Migration: schema change on `fansub_preferences` |
-| `frontend/src/pages/Settings/index.tsx` | Move 3 fields from Wanted → Scoring tab |
+| `backend/wanted_search.py` | Extract `_apply_series_fansub_rules()` helper; use in both `search_wanted_item` and `process_wanted_item` |
+| `backend/db/models/core.py` | Add `standalone_series_id`, change PK to auto-increment |
+| `backend/db/repositories/fansub_prefs.py` | Rename to `by_sonarr`/`by_standalone`; keep alias for old name |
+| `backend/routes/fansub_prefs.py` | Update + add standalone routes under `/api/v1/standalone` blueprint |
+| `backend/db/migrations/versions/<hash>_fansub_standalone.py` | Table-rename migration with explicit downgrade |
+| `frontend/src/pages/Settings/index.tsx` | Remove 3-field hardcoded block from Wanted tab render |
+| `frontend/src/pages/Settings/EventsTab.tsx` | Add Release Group Filter card to `ScoringTab` |
 | `frontend/src/pages/SeriesDetail.tsx` | Remove panel, add `FansubOverrideButton` to toolbar |
 | `frontend/src/components/series/FansubOverrideButton.tsx` | New component |
 | `frontend/src/components/series/FansubOverrideModal.tsx` | New component |
@@ -204,7 +320,8 @@ Add:
 
 ## Out of Scope
 
-- Movie-level fansub overrides (only series for now)
+- Movie-level fansub overrides (table remains series-only — intentional)
 - Per-episode fansub rules
 - Regex matching for group names (keep substring match)
-- UI to show which rule was applied to a past search result
+- UI showing which rule was applied to a past search result
+- Changing the additive two-layer model to exclusive override at the provider layer

--- a/docs/superpowers/specs/2026-03-15-fansub-scoring-integration-design.md
+++ b/docs/superpowers/specs/2026-03-15-fansub-scoring-integration-design.md
@@ -1,0 +1,210 @@
+# Fansub Scoring Integration — Design Spec
+
+**Date:** 2026-03-15
+**Status:** Approved
+
+## Overview
+
+Redesign Fansub Preferences to integrate properly into the scoring pipeline with a global default and an optional per-series override. Fix the standalone series bug. Reduce the per-series UI from a prominent panel to a small toolbar button with modal.
+
+---
+
+## Problem Statement
+
+1. **Global fields exist but are not wired.** `release_group_prefer`, `release_group_exclude`, and `release_group_prefer_bonus` exist in `config.py` and the Settings UI (Wanted tab), but `_apply_fansub_rules()` in `wanted_search.py` never reads them — they are dead config.
+2. **Standalone series are excluded.** `wanted_search.py` line ~543 only applies fansub prefs when `sonarr_series_id` is set. Standalone series (`standalone_series_id` only) never get fansub rules applied.
+3. **Per-series panel is too prominent.** `SeriesFansubPrefsPanel` renders as a full card section on every series detail page regardless of whether the user has configured anything.
+4. **Wrong Settings tab.** Release group fields live in the Wanted tab, but conceptually they are score modifiers like HI Preference and Forced Preference, which live in the Scoring tab.
+
+---
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Global vs per-series | Global default + per-series override (replaces) | 80% of users want one rule set; power users can override per series |
+| Per-series merge strategy | Override **replaces** global entirely for that series | Simple, no surprising interactions |
+| Settings placement | Move to Scoring tab | Consistent with HI/Forced Preference which also adjust scores |
+| Per-series UI | Small toolbar button + modal | Not prominent, but accessible when needed |
+
+---
+
+## Architecture
+
+### Scoring Pipeline — New Flow
+
+```
+search_wanted_item(item)
+  → collect all provider results
+  → resolve fansub rules:
+      if series has per-series override → use override
+      else → use global config (release_group_prefer/exclude/bonus)
+  → _apply_fansub_rules(results, rules)   ← same function, no change
+  → sort by priority key
+  → return results
+```
+
+The `_apply_fansub_rules()` function itself is unchanged — it already does case-insensitive substring matching, +bonus for preferred groups, −999 for excluded groups.
+
+---
+
+## Backend Changes
+
+### 1. `backend/wanted_search.py`
+
+Replace the current block (lines ~542–554):
+```python
+# CURRENT (broken)
+series_id = item.get("sonarr_series_id")
+if series_id:
+    fansub = FansubPreferenceRepository().get_fansub_prefs(series_id)
+    if fansub:
+        _apply_fansub_rules(...)
+```
+
+With a new helper `_resolve_fansub_rules(item, settings)` that:
+1. Checks `sonarr_series_id` → `FansubPreferenceRepository().get_fansub_prefs(sonarr_id)`
+2. Falls back to `standalone_series_id` → `FansubPreferenceRepository().get_fansub_prefs_standalone(standalone_id)`
+3. Falls back to global config:
+   ```python
+   preferred = [g.strip() for g in settings.release_group_prefer.split(",") if g.strip()]
+   excluded  = [g.strip() for g in settings.release_group_exclude.split(",") if g.strip()]
+   bonus     = settings.release_group_prefer_bonus
+   ```
+4. Always calls `_apply_fansub_rules()` (even if lists are empty — no-op).
+
+### 2. `backend/db/models/core.py` — `FansubPreference` table
+
+Add a nullable `standalone_series_id` column. The table currently has `sonarr_series_id` as the primary key; change to a surrogate auto-increment PK and add a unique constraint per source:
+
+```python
+class FansubPreference(Base):
+    __tablename__ = "fansub_preferences"
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    sonarr_series_id: Mapped[int | None] = mapped_column(Integer, nullable=True, unique=True)
+    standalone_series_id: Mapped[int | None] = mapped_column(Integer, nullable=True, unique=True)
+    preferred_groups_json: Mapped[str] = mapped_column(Text, nullable=False, default="[]")
+    excluded_groups_json: Mapped[str] = mapped_column(Text, nullable=False, default="[]")
+    bonus: Mapped[int] = mapped_column(Integer, nullable=False, default=20)
+    updated_at: Mapped[str] = mapped_column(Text, nullable=False, default=...)
+```
+
+Constraint: exactly one of `sonarr_series_id` / `standalone_series_id` must be non-null (enforced at repository level).
+
+### 3. `backend/db/repositories/fansub_prefs.py`
+
+Add:
+- `get_fansub_prefs_standalone(standalone_series_id: int) -> dict | None`
+- `set_fansub_prefs_standalone(standalone_series_id, preferred, excluded, bonus)`
+- `delete_fansub_prefs_standalone(standalone_series_id)`
+
+### 4. `backend/routes/fansub_prefs.py`
+
+Current endpoints are keyed to Sonarr series ID:
+```
+GET/PUT/DELETE /api/v1/series/<id>/fansub-prefs
+```
+
+Add standalone equivalents:
+```
+GET/PUT/DELETE /api/v1/standalone/series/<id>/fansub-prefs
+```
+
+The existing Sonarr-keyed routes remain unchanged.
+
+### 5. Database migration
+
+New Alembic migration:
+- Add `standalone_series_id` column (nullable int)
+- Add unique index on `standalone_series_id`
+- Change PK from `sonarr_series_id` to auto-increment `id`
+- Make `sonarr_series_id` nullable (was non-nullable PK)
+
+### 6. Settings — move fields from Wanted to Scoring tab
+
+In `frontend/src/pages/Settings/index.tsx`, change `tab` from `'Wanted'` to `'Scoring'` for:
+- `release_group_prefer`
+- `release_group_exclude`
+- `release_group_prefer_bonus`
+
+Also update the Scoring tab section grouping to include a "Release Group Filtering" section header.
+
+---
+
+## Frontend Changes
+
+### 1. `SeriesDetail.tsx` — remove Fansub Preferences panel
+
+Remove the `{/* Fansub Preferences Panel */}` block (currently renders `SeriesFansubPrefsPanel` as a full card section). Replace with nothing — the panel is gone.
+
+### 2. `SeriesDetail.tsx` — add Fansub toolbar button
+
+In the actions toolbar row (next to "Tracks extrahieren", "Bereinigen", "Export ZIP"), add:
+
+```tsx
+<FansubOverrideButton seriesId={seriesId} source={seriesData.source} />
+```
+
+Button states:
+- **No override set** → grey icon + label "Fansub", tooltip "Using global defaults"
+- **Override active** → teal/accent color + label "Fansub", tooltip shows configured groups
+
+### 3. New component: `FansubOverrideButton`
+
+Location: `frontend/src/components/series/FansubOverrideButton.tsx`
+
+Responsibilities:
+- Renders the toolbar button
+- On click, opens `FansubOverrideModal`
+- Uses `useSeriesFansubPrefs(seriesId)` / `useStandaloneFansubPrefs(seriesId)` based on `source`
+- Visual state: teal when override active, grey when using global
+
+### 4. New component: `FansubOverrideModal`
+
+Location: `frontend/src/components/series/FansubOverrideModal.tsx`
+
+Content:
+- "Override for this series" heading
+- Read-only info row: "Global: SubsPlease, Erai-raws" (from settings)
+- Preferred Groups input (comma-separated)
+- Blocked Groups input (comma-separated)
+- Bonus Points number input
+- Save button + "Reset to Global" button (deletes the override)
+- Follows existing Modal pattern: `role="dialog"`, `aria-modal`, backdrop click to close, Escape to close
+
+### 5. `api/client.ts` + `hooks/useApi.ts`
+
+Add:
+- `getStandaloneFansubPrefs(seriesId)`
+- `setStandaloneFansubPrefs(seriesId, prefs)`
+- `deleteStandaloneFansubPrefs(seriesId)`
+- `useStandaloneFansubPrefs(seriesId)` hook
+- `useSetStandaloneFansubPrefs(seriesId)` hook
+- `useDeleteStandaloneFansubPrefs(seriesId)` hook
+
+---
+
+## File Summary
+
+| File | Change |
+|------|--------|
+| `backend/wanted_search.py` | Replace series-only fansub block with `_resolve_fansub_rules()` helper |
+| `backend/db/models/core.py` | Add `standalone_series_id` column, change PK |
+| `backend/db/repositories/fansub_prefs.py` | Add standalone CRUD methods |
+| `backend/routes/fansub_prefs.py` | Add `/standalone/series/<id>/fansub-prefs` routes |
+| `backend/db/migrations/versions/...` | Migration: schema change on `fansub_preferences` |
+| `frontend/src/pages/Settings/index.tsx` | Move 3 fields from Wanted → Scoring tab |
+| `frontend/src/pages/SeriesDetail.tsx` | Remove panel, add `FansubOverrideButton` to toolbar |
+| `frontend/src/components/series/FansubOverrideButton.tsx` | New component |
+| `frontend/src/components/series/FansubOverrideModal.tsx` | New component |
+| `frontend/src/api/client.ts` | Add standalone fansub API functions |
+| `frontend/src/hooks/useApi.ts` | Add standalone fansub hooks |
+
+---
+
+## Out of Scope
+
+- Movie-level fansub overrides (only series for now)
+- Per-episode fansub rules
+- Regex matching for group names (keep substring match)
+- UI to show which rule was applied to a past search result

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -991,7 +991,11 @@ export function useTriggerStandaloneScan() {
 }
 
 export function useStandaloneStatus() {
-  return useQuery({ queryKey: ['standaloneStatus'], queryFn: getStandaloneStatus })
+  return useQuery({
+    queryKey: ['standaloneStatus'],
+    queryFn: getStandaloneStatus,
+    refetchInterval: (query) => (query.state.data?.scanner_scanning ? 2000 : 15000),
+  })
 }
 
 export function useRefreshSeriesMetadata() {

--- a/frontend/src/i18n/locales/de/common.json
+++ b/frontend/src/i18n/locales/de/common.json
@@ -10,7 +10,8 @@
     "settings": "Einstellungen",
     "logs": "Protokolle",
     "statistics": "Statistiken",
-    "tasks": "Aufgaben"
+    "tasks": "Aufgaben",
+    "plugins": "Plugins"
   },
   "nav_groups": {
     "content": "Inhalte",

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -10,7 +10,8 @@
     "settings": "Settings",
     "logs": "Logs",
     "statistics": "Statistics",
-    "tasks": "Tasks"
+    "tasks": "Tasks",
+    "plugins": "Plugins"
   },
   "nav_groups": {
     "content": "Content",

--- a/frontend/src/pages/Settings/AdvancedTab.tsx
+++ b/frontend/src/pages/Settings/AdvancedTab.tsx
@@ -578,8 +578,8 @@ export function LibrarySourcesTab({
           <div className="flex items-center gap-2">
             <button
               onClick={handleScanAll}
-              disabled={scanAll.isPending}
-              className="flex items-center gap-1.5 px-2.5 py-1.5 rounded text-xs font-medium transition-all duration-150"
+              disabled={scanAll.isPending || standaloneStatus?.scanner_scanning}
+              className="flex items-center gap-1.5 px-2.5 py-1.5 rounded text-xs font-medium transition-all duration-150 disabled:opacity-60"
               style={{
                 border: '1px solid var(--border)',
                 color: 'var(--text-secondary)',
@@ -587,12 +587,12 @@ export function LibrarySourcesTab({
               }}
               title="Scan all folders"
             >
-              {scanAll.isPending ? (
+              {(scanAll.isPending || standaloneStatus?.scanner_scanning) ? (
                 <Loader2 size={12} className="animate-spin" />
               ) : (
                 <RefreshCw size={12} />
               )}
-              Scan All
+              {standaloneStatus?.scanner_scanning ? 'Scanning…' : 'Scan All'}
             </button>
             <button
               onClick={() => setShowAdd(true)}

--- a/frontend/src/pages/Settings/index.tsx
+++ b/frontend/src/pages/Settings/index.tsx
@@ -234,6 +234,9 @@ const FIELDS: FieldConfig[] = [
   { key: 'standalone_debounce_seconds', label: 'File Detection Debounce (seconds)', type: 'number', placeholder: '10', tab: 'Library Sources',
     description: 'Wartezeit nach letzter Dateiänderung bevor Scan ausgelöst wird.',
     advanced: true },
+  { key: 'standalone_skip_extras', label: 'Skip Extra Files (Trailer, Featurettes …)', type: 'toggle', tab: 'Library Sources',
+    description: 'Trailer, Featurettes, Samples und ähnliche Dateien beim Scan ignorieren.',
+    advanced: true },
   // Automation — Sidecar Cleanup
   { key: 'auto_cleanup_after_extract', label: 'Nach Extraktion bereinigen', type: 'toggle', tab: 'Automation',
     description: 'Nach batch-extract automatisch nicht-benötigte Sprachen löschen. Benötigt keep_languages.' },

--- a/frontend/src/pages/Settings/settingsHelpText.ts
+++ b/frontend/src/pages/Settings/settingsHelpText.ts
@@ -58,6 +58,7 @@ export const HELP_TEXT: Record<string, string> = {
   tvdb_pin: 'Optional TVDB subscriber PIN.',
   standalone_scan_interval_hours: 'How often to scan watched folders for new files. 0 = disabled.',
   standalone_debounce_seconds: 'Wait this many seconds after file detection before processing.',
+  standalone_skip_extras: 'When enabled, files matching common extras naming conventions are ignored (e.g. movie-trailer.mp4, tvshow.mp4, movie-featurette.mkv). Follows the Jellyfin/Kodi extras standard.',
 
   // Translation Backends
   ollama_url: 'Full URL to your Ollama instance (e.g. http://localhost:11434).',

--- a/frontend/src/pages/Setup.tsx
+++ b/frontend/src/pages/Setup.tsx
@@ -21,6 +21,12 @@ export function SetupPage() {
     },
     onError: (err: unknown) => {
       const msg = (err as { response?: { data?: { error?: string } } })?.response?.data?.error ?? 'Setup failed'
+      // "Already configured" means auth is already set up (e.g. AUTH_ENABLED=false in env) — just navigate
+      if (msg.includes('Already configured')) {
+        queryClient.invalidateQueries({ queryKey: ['auth-status'] })
+        navigate('/')
+        return
+      }
       toast(msg, 'error')
     },
   })

--- a/frontend/src/pages/Wanted.tsx
+++ b/frontend/src/pages/Wanted.tsx
@@ -454,7 +454,7 @@ export function WantedPage() {
   }
 
   return (
-    <div className="space-y-5">
+    <div className="flex flex-col gap-5" style={{ height: 'calc(100vh - 40px)' }}>
       {/* Batch Probe Progress Banner */}
       {probeStatus?.running && (
         <div
@@ -834,10 +834,10 @@ export function WantedPage() {
       {/* Table */}
       <div
         data-testid="wanted-list"
-        className="rounded-lg overflow-hidden"
+        className="rounded-lg overflow-hidden flex-1 min-h-0 flex flex-col"
         style={{ backgroundColor: 'var(--bg-surface)', border: '1px solid var(--border)' }}
       >
-        <div ref={wantedParentRef} style={{ height: 'calc(100vh - 300px)', overflowY: 'auto' }}>
+        <div ref={wantedParentRef} className="flex-1 min-h-0" style={{ overflowY: 'auto' }}>
           <table className="w-full min-w-[800px]">
             <thead style={{ position: 'sticky', top: 0, zIndex: 1, backgroundColor: 'var(--bg-elevated)' }}>
               <tr style={{ borderBottom: '1px solid var(--border)' }}>


### PR DESCRIPTION
## Summary

- **Standalone extras filter** — Trailers, featurettes, samples and other non-episode extras are now skipped during standalone filesystem scan. Follows Jellyfin/Kodi naming convention (`-trailer`, `-featurette`, `-behindthescenes`, `-deleted`, `-interview`, `-scene`, `-short`, `-sample`, `-theme` suffixes; plus bare stems `tvshow`, `movie`, `trailer`, `sample`). Existing wanted entries for matched extras are cleaned up on next scan.
- **Configurable** — New `standalone_skip_extras` setting (default: `true`) exposed as toggle in Settings → Library Sources (advanced section).
- **Wanted page layout** — Replaced hardcoded `calc(100vh - 300px)` virtualizer height with a proper `flex-1 / min-h-0` chain, so the list always fills the remaining viewport and doesn't leave dead space or clip items when scrolling.

## Test plan

- [ ] Backend tests green
- [ ] Frontend lint + tsc clean
- [ ] Standalone scan no longer adds `tvshow-trailer.mp4`, `movie-featurette.mkv` etc. to Wanted
- [ ] Existing trailer entries removed after "Aktualisieren"
- [ ] `standalone_skip_extras` toggle visible in Settings → Library Sources (advanced)
- [ ] Wanted list fills full viewport height at different window sizes
- [ ] Virtual scroll renders correct items while scrolling