### PR TITLE
security: pentest fixes — auth middleware, password policy, security headers

### DIFF
--- a/PENTEST_FINDINGS.md
+++ b/PENTEST_FINDINGS.md
@@ -1,0 +1,256 @@
+# Sublarr Penetration Test Findings
+
+**Date:** 2026-03-16
+**Scope:** Internal authorized pentest — `192.168.178.194:5765` (LXC 101, pve-node1)
+**Tester:** Kali Linux VM201 (`192.168.178.177`)
+**App version:** `0.30.0-beta`
+**Tools used:** nmap, nikto, gobuster, hydra, curl, Python3
+
+---
+
+## Executive Summary
+
+Sublarr is overall well-structured from a security perspective. The API-key auth middleware, `is_safe_path()` path traversal protection, `hmac.compare_digest()` for timing-safe comparisons, and parameterized SQLite queries all demonstrate good baseline hygiene. No critical or exploitable Remote Code Execution, SQL Injection, or path traversal vulnerabilities were found unauthenticated.
+
+**Main gaps:** No rate limiting on any auth endpoint (brute-force viable), the API-key middleware conflicts with the UI login flow when both auth systems are active simultaneously, and several HTTP security headers are missing.
+
+---
+
+## Findings
+
+### F-01 — No Rate Limiting on API Key Auth
+**Severity:** HIGH
+**Affected file:** `backend/auth.py` — `check_api_key()`
+
+20 consecutive requests with wrong API keys returned 401 instantly with no throttle, delay, or lockout. The warning is logged but requests are never blocked.
+
+**Impact:** An attacker with LAN access can brute-force the API key at network speed. A typical 32-char alphanumeric key is computationally infeasible to brute-force, but short or dictionary-style keys are at risk.
+
+**Fix:** Add `flask-limiter` with `5/minute` per IP on all auth-checked endpoints. Example:
+```python
+from flask_limiter import Limiter
+limiter = Limiter(key_func=get_remote_address, default_limits=["200/day", "50/hour"])
+# On the auth check:
+@limiter.limit("5/minute", error_message="Too many requests")
+def check_api_key(): ...
+```
+
+---
+
+### F-02 — No Rate Limiting on UI Login Endpoint
+**Severity:** HIGH
+**Affected file:** `backend/routes/auth_ui.py` — `login()`
+
+15 consecutive wrong-password attempts returned 401 instantly with no delay, throttle, or lockout. Only a warning log is written.
+
+**Impact:** The UI password (minimum 4 chars per F-06) can be brute-forced from the LAN in seconds.
+
+**Fix:** Same `flask-limiter` integration as F-01. Apply to `POST /api/v1/auth/login` specifically:
+```python
+@auth_ui_bp.post("/login")
+@limiter.limit("5/minute")
+def login(): ...
+```
+Also consider a 1-second `time.sleep()` delay on failed attempts (defense-in-depth).
+
+---
+
+### F-03 — Auth Middleware Ordering Breaks UI Login
+**Severity:** MEDIUM-HIGH
+**Affected file:** `backend/auth.py` — `check_api_key()`
+
+The API-key middleware (`auth.py`) fires **before** the UI session middleware (`ui_auth.py`) and does not exempt `/api/v1/auth/` paths. When `SUBLARR_API_KEY` is set, all auth endpoints (`/login`, `/setup`, `/status`, `/logout`, `/change-password`) return `{"error": "API key required"}` before the UI auth handler runs.
+
+**Confirmed by test:**
+```
+POST /api/v1/auth/login → 401 {"error":"API key required"}
+GET  /api/v1/auth/status → 401 {"error":"API key required"}
+```
+
+**Impact:** If both UI auth and API key are configured simultaneously, the web UI is completely inaccessible — users cannot log in. This functionally breaks UI authentication and may cause admins to disable auth entirely.
+
+**Fix** (one line in `auth.py`, analogous to the health and webhook exemptions):
+```python
+# Skip auth for UI auth endpoints (they handle their own auth)
+if path.startswith("/api/v1/auth/"):
+    return None
+```
+
+---
+
+### F-04 — Version and Service Topology Disclosed Unauthenticated
+**Severity:** MEDIUM
+**Affected endpoint:** `GET /api/v1/health` (exempt from auth by design)
+
+Response (no auth required):
+```json
+{
+  "status": "healthy",
+  "version": "0.30.0-beta",
+  "services": {
+    "sonarr": "OK",
+    "radarr": "OK",
+    "ollama": "OK",
+    "providers": "error",
+    "media_servers": "none configured"
+  }
+}
+```
+
+**Impact:** Exact software version enables targeted CVE lookups once vulnerabilities are published. Integration topology (Sonarr/Radarr connected, no media server) leaks architectural details.
+
+**Fix options:**
+- Strip `version` from the health response, or make it auth-gated.
+- Alternatively strip service detail from the health response, returning only `{"status": "healthy"}` for unauthenticated callers.
+
+---
+
+### F-05 — Webhook Middleware Exemption — Security-by-Convention Risk
+**Severity:** MEDIUM
+**Affected file:** `backend/auth.py` line 73
+
+`check_api_key()` globally skips auth for all `/api/v1/webhook/` paths:
+```python
+if path.startswith("/api/v1/webhook/"):
+    return None
+```
+Each webhook handler is expected to perform its own HMAC auth. Current handlers (`webhooks.py`) do this correctly.
+
+**Impact:** If a future webhook handler is added and the developer forgets the per-handler auth check, it will be globally unprotected with no safety net. There is no fallback enforcement.
+
+**Fix:** Remove the global webhook exemption from `auth.py` and instead validate at the webhook handler level only — or add documentation and a code comment flagging this as a footgun. Alternatively, validate in `auth.py` that webhook routes always have an `Authorization` or `X-Webhook-Secret` header present.
+
+---
+
+### F-06 — Minimum Password Length Too Short
+**Severity:** LOW
+**Affected file:** `backend/routes/auth_ui.py` line 20
+
+```python
+_MIN_PASSWORD_LENGTH = 4
+```
+
+4 characters allow trivially brute-forceable passwords. Combined with no rate limiting (F-02), this is exploitable from the LAN.
+
+**Fix:** Increase to `_MIN_PASSWORD_LENGTH = 12`. Add a reminder in the UI that passwords should be strong.
+
+---
+
+### F-07 — Missing HTTP Security Headers
+**Severity:** MEDIUM
+**Observed:** All HTTP responses lack:
+
+| Header | Missing Value | Risk |
+|--------|--------------|------|
+| `X-Frame-Options` | `DENY` | Clickjacking of the SPA |
+| `X-Content-Type-Options` | `nosniff` | MIME sniffing |
+| `Content-Security-Policy` | (none) | XSS amplification |
+| `Referrer-Policy` | `same-origin` | Referrer leakage |
+| `Permissions-Policy` | (none) | Feature policy |
+
+**Fix:** Add `Flask-Talisman` or set headers manually in `app.py`:
+```python
+@app.after_request
+def add_security_headers(response):
+    response.headers["X-Frame-Options"] = "DENY"
+    response.headers["X-Content-Type-Options"] = "nosniff"
+    response.headers["Referrer-Policy"] = "same-origin"
+    return response
+```
+
+---
+
+### F-08 — Socket.IO Handshake Unauthenticated (Config Leak)
+**Severity:** LOW
+**Affected endpoint:** `GET /socket.io/?EIO=4&transport=polling`
+
+The EIO4 open frame succeeds without authentication, returning:
+```json
+{"sid":"...","upgrades":["websocket"],"pingTimeout":20000,"pingInterval":25000,"maxPayload":1000000}
+```
+Namespace connect is correctly rejected. Only server timing config is leaked.
+
+**Impact:** Low. Reveals internal Socket.IO config. Namespace auth fires correctly on connection attempt.
+
+**Fix:** No immediate action required. Consider adding an origin check or early auth on the Socket.IO namespace connection.
+
+---
+
+### F-09 — rpcbind (Port 111) Exposed on LXC
+**Severity:** LOW
+**Affected system:** LXC CT 101 (infrastructure level, not Sublarr app)
+
+`nmap` reveals port 111 (rpcbind) open. Not needed for Sublarr.
+
+**Fix:**
+```bash
+# On pve-node1:
+pct exec 101 -- systemctl disable rpcbind --now
+```
+
+---
+
+### F-10 — ETag Leaks Inode and Mtime (INFO)
+**Severity:** INFO
+**Observed:** `ETag: "1773685672.0-1722-1563297874"` on static file responses.
+
+Gunicorn's ETag format encodes inode number and mtime. Historically used in inode fingerprinting (CVE-2003-1418 / Apache), low practical impact with Gunicorn.
+
+**No fix required.**
+
+---
+
+### F-11 — Server Header Discloses WSGI Server (INFO)
+**Severity:** INFO
+**Observed:** `Server: gunicorn`
+
+No version number disclosed. Standard fingerprinting risk, minimal impact.
+
+**Fix (optional):** Set `SERVER_NAME` or use a custom `server_header` in Gunicorn config.
+
+---
+
+## Summary Table
+
+| ID | Finding | Severity | Status |
+|----|---------|----------|--------|
+| F-01 | No rate limiting — API key auth | **HIGH** | Open |
+| F-02 | No rate limiting — UI login | **HIGH** | Open |
+| F-03 | Auth middleware ordering breaks UI login | **MEDIUM-HIGH** | Open |
+| F-04 | Version/topology in unauthenticated health endpoint | **MEDIUM** | Open |
+| F-05 | Webhook exemption — security-by-convention risk | **MEDIUM** | Open |
+| F-06 | Minimum password length too short (4 chars) | **LOW** | Open |
+| F-07 | Missing HTTP security headers | **MEDIUM** | Open |
+| F-08 | Socket.IO handshake unauthenticated (config leak) | **LOW** | Open |
+| F-09 | rpcbind exposed on LXC (infrastructure) | **LOW** | Open |
+| F-10 | ETag leaks inode + mtime | **INFO** | No fix needed |
+| F-11 | Server header discloses Gunicorn | **INFO** | Optional |
+
+---
+
+## Confirmed Safe
+
+The following attack vectors were tested and found **not exploitable**:
+
+- **SQL Injection:** All DB queries use parameterized statements. No raw string interpolation found.
+- **Path Traversal:** `is_safe_path()` correctly applied on file endpoints. Symlink resolution in place.
+- **Command Injection:** No user-supplied data passed to shell. Plugin git URLs validated against `_ALLOWED_GIT_DOMAINS`.
+- **ZIP Slip:** `safe_zip_extract()` validates all archive members before extraction.
+- **CORS Misconfiguration:** No wildcard or reflected origin on API responses.
+- **CSRF:** All state-changing operations are JSON POST — not submittable via standard HTML forms.
+- **Timing attacks on API key comparison:** `hmac.compare_digest()` used correctly in both `auth.py` middleware instances.
+- **Sensitive data in API responses:** Config, providers, API keys all require auth. No plaintext secrets in any unauthenticated response.
+- **SSRF:** Provider and media-server config endpoints require auth. No SSRF surface reachable unauthenticated.
+- **HTTP TRACE:** Disabled (405).
+
+---
+
+## Recommended Fix Priority
+
+1. **F-03** (1 line — `auth.py`) — fixes broken UI login, do immediately
+2. **F-06** (1 line — `auth_ui.py`) — increase minimum password to 12 chars
+3. **F-07** (5 lines — `app.py`) — add security headers
+4. **F-01 + F-02** (requires `flask-limiter` dependency) — rate limiting
+5. **F-04** — strip version from health response or gate behind auth
+6. **F-05** — document/comment the webhook exemption risk
+7. **F-09** — disable rpcbind on LXC 101 (infra)

--- a/backend/app.py
+++ b/backend/app.py
@@ -180,6 +180,13 @@ def create_app(testing=False):
 
     register_error_handlers(app)
 
+    @app.after_request
+    def add_security_headers(response):
+        response.headers.setdefault("X-Frame-Options", "DENY")
+        response.headers.setdefault("X-Content-Type-Options", "nosniff")
+        response.headers.setdefault("Referrer-Policy", "same-origin")
+        return response
+
     # Initialize authentication
     from auth import init_auth
     from routes.auth_ui import auth_ui_bp

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -74,6 +74,11 @@ def init_auth(app):
         if path.startswith("/api/v1/webhook/"):
             return None
 
+        # Skip auth for UI auth endpoints (login, setup, status, logout)
+        # These handle their own authentication logic
+        if path.startswith("/api/v1/auth/"):
+            return None
+
         provided_key = request.headers.get("X-Api-Key") or request.args.get("apikey")
 
         if not provided_key:

--- a/backend/routes/auth_ui.py
+++ b/backend/routes/auth_ui.py
@@ -17,7 +17,7 @@ import ui_auth
 logger = logging.getLogger(__name__)
 
 auth_ui_bp = Blueprint("auth_ui", __name__, url_prefix="/api/v1/auth")
-_MIN_PASSWORD_LENGTH = 4
+_MIN_PASSWORD_LENGTH = 12
 
 
 def _is_session_authenticated() -> bool:

--- a/backend/routes/system.py
+++ b/backend/routes/system.py
@@ -175,13 +175,28 @@ def health():
             healthy = False
 
     status_code = 200 if healthy else 503
-    return jsonify(
-        {
-            "status": "healthy" if healthy else "unhealthy",
-            "version": __version__,
-            "services": service_status,
-        }
-    ), status_code
+
+    # Include version and service detail only for authenticated callers.
+    # Unauthenticated probes (uptime monitors, scanners) receive only the status.
+    import hmac as _hmac
+
+    from flask import session as _session
+
+    from config import get_settings as _get_settings
+
+    _settings = _get_settings()
+    _api_key = getattr(_settings, "api_key", None)
+    _provided = request.headers.get("X-Api-Key") or request.args.get("apikey", "")
+    _key_ok = bool(_api_key and _hmac.compare_digest(_provided, _api_key))
+    _session_ok = bool(_session.get("ui_authenticated"))
+    _authenticated = _key_ok or _session_ok or not _api_key
+
+    body: dict = {"status": "healthy" if healthy else "unhealthy"}
+    if _authenticated:
+        body["version"] = __version__
+        body["services"] = service_status
+
+    return jsonify(body), status_code
 
 
 @bp.route("/update", methods=["GET"])

--- a/backend/tests/test_routes_auth_ui.py
+++ b/backend/tests/test_routes_auth_ui.py
@@ -39,7 +39,7 @@ def test_setup_set_password(app, monkeypatch):
     monkeypatch.setattr(ui_auth, "_save_config_entry", lambda k, v: saved.update({k: v}))
     with app.test_client() as client:
         r = client.post(
-            "/api/v1/auth/setup", json={"action": "set_password", "password": "hunter2"}
+            "/api/v1/auth/setup", json={"action": "set_password", "password": "hunter2-correct"}
         )
         assert r.status_code == 200
         assert "ui_password_hash" in saved
@@ -124,7 +124,7 @@ def test_change_password_correct(app, monkeypatch):
             sess["ui_authenticated"] = True
         r = client.post(
             "/api/v1/auth/change-password",
-            json={"current_password": "old", "new_password": "newpass1"},
+            json={"current_password": "old", "new_password": "newpass1-secure"},
         )
         assert r.status_code == 200
         assert "ui_password_hash" in saved


### PR DESCRIPTION
## Summary

Internal Kali Linux pentest (2026-03-16, VM201 → LXC 101) identified 11 findings. This PR fixes the 4 highest-priority code-level issues. Full findings documented in `PENTEST_FINDINGS.md`.

- **F-03 (MEDIUM-HIGH)** — `auth.py`: Add `/api/v1/auth/` exemption to API-key middleware. Without this, UI login/setup/status were blocked by the API-key check when `SUBLARR_API_KEY` was set, making the web UI completely inaccessible.
- **F-06 (LOW)** — `auth_ui.py`: Raise minimum password length 4 → 12 characters.
- **F-07 (MEDIUM)** — `app.py`: Add `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy: same-origin` via `after_request` hook.
- **F-04 (MEDIUM)** — `routes/system.py`: Gate `version` and `services` in `/api/v1/health` behind auth. Unauthenticated callers receive only `{"status": "healthy"}`.

## Remaining open findings (follow-up)

- **F-01/F-02 (HIGH)** — No rate limiting on API key auth + login endpoint → requires `flask-limiter` dependency
- **F-05 (MEDIUM)** — Webhook middleware exemption footgun → documentation/comment
- **F-08 (LOW)** — Socket.IO handshake leaks config → low priority
- **F-09 (LOW)** — rpcbind on LXC 101 → infra-level fix (`pct exec 101 -- systemctl disable rpcbind --now`)

## Test plan

- [x] `ruff check . && ruff format --check .` — clean
- [x] `pytest tests/test_auth.py tests/test_security.py` — 35/35 passed
- [ ] Verify UI login still works when `SUBLARR_API_KEY` is set (F-03 regression check)
- [ ] Verify `GET /api/v1/health` without auth returns only `{"status": "healthy"}` (no version)
- [ ] Verify security headers present on all responses