### PR TITLE
security: rate limiting on auth endpoints (F-01/F-02)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -11,7 +11,7 @@ import os
 
 from flask import Flask
 
-from extensions import socketio
+from extensions import limiter, socketio
 
 LOG_FORMAT = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
 
@@ -186,6 +186,9 @@ def create_app(testing=False):
         response.headers.setdefault("X-Content-Type-Options", "nosniff")
         response.headers.setdefault("Referrer-Policy", "same-origin")
         return response
+
+    # Initialize rate limiter (in-memory; swap storage_uri for Redis in multi-worker setups)
+    limiter.init_app(app)
 
     # Initialize authentication
     from auth import init_auth

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -8,12 +8,37 @@ Health endpoint is exempt.
 import functools
 import hmac
 import logging
+import threading
+import time
+from collections import defaultdict
 
 from flask import jsonify, request
 
 from config import get_settings
 
 logger = logging.getLogger(__name__)
+
+# Per-IP rate limiting for failed API key attempts.
+# Tracks timestamps of failures; entries older than _WINDOW are discarded.
+_failed_lock = threading.Lock()
+_failed_attempts: dict[str, list[float]] = defaultdict(list)
+_FAIL_LIMIT = 20  # max failed attempts per window
+_FAIL_WINDOW = 60  # seconds
+
+
+def _is_rate_limited(ip: str) -> bool:
+    """Return True if ip has exceeded the failed-auth rate limit."""
+    now = time.monotonic()
+    with _failed_lock:
+        cutoff = now - _FAIL_WINDOW
+        _failed_attempts[ip] = [t for t in _failed_attempts[ip] if t > cutoff]
+        return len(_failed_attempts[ip]) >= _FAIL_LIMIT
+
+
+def _record_failure(ip: str) -> None:
+    """Record a failed auth attempt for ip."""
+    with _failed_lock:
+        _failed_attempts[ip].append(time.monotonic())
 
 
 def require_api_key(f):
@@ -70,7 +95,10 @@ def init_auth(app):
         if path == "/api/v1/health":
             return None
 
-        # Skip auth for webhook endpoints (they use their own auth)
+        # Skip auth for webhook endpoints — each handler performs its own
+        # HMAC-based auth (see routes/webhooks.py). IMPORTANT: any new webhook
+        # route added under /api/v1/webhook/ MUST implement auth manually;
+        # there is no fallback enforcement here.
         if path.startswith("/api/v1/webhook/"):
             return None
 
@@ -79,12 +107,24 @@ def init_auth(app):
         if path.startswith("/api/v1/auth/"):
             return None
 
+        ip = request.remote_addr or "unknown"
+
+        # Reject IPs that have exceeded the failed-auth rate limit
+        if _is_rate_limited(ip):
+            logger.warning("Rate limit exceeded for API key auth from %s", ip)
+            resp = jsonify({"error": "Too many failed attempts. Try again later."})
+            resp.headers["Retry-After"] = str(_FAIL_WINDOW)
+            return resp, 429
+
         provided_key = request.headers.get("X-Api-Key") or request.args.get("apikey")
 
         if not provided_key:
+            _record_failure(ip)
             return jsonify({"error": "API key required"}), 401
 
         if not hmac.compare_digest(provided_key, current_settings.api_key):
+            _record_failure(ip)
+            logger.warning("Invalid API key from %s", ip)
             return jsonify({"error": "Invalid API key"}), 401
 
         return None

--- a/backend/extensions.py
+++ b/backend/extensions.py
@@ -7,9 +7,15 @@ Flask-SQLAlchemy and Flask-Migrate are guarded with try/except ImportError
 for graceful degradation during the transition period.
 """
 
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
 from flask_socketio import SocketIO
 
 socketio = SocketIO()
+
+# Rate limiter — unbound, init_app() called in create_app()
+# Default storage: in-memory (sufficient for single-process Gunicorn)
+limiter = Limiter(key_func=get_remote_address, default_limits=[])
 
 try:
     from flask_migrate import Migrate

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,6 @@
 flask==3.1.3
 flask-socketio==5.6.1
+flask-limiter==4.1.1
 Flask-SQLAlchemy==3.1.1
 Flask-Migrate==4.1.0
 SQLAlchemy==2.0.46

--- a/backend/routes/auth_ui.py
+++ b/backend/routes/auth_ui.py
@@ -13,6 +13,7 @@ import logging
 from flask import Blueprint, jsonify, request, session
 
 import ui_auth
+from extensions import limiter
 
 logger = logging.getLogger(__name__)
 
@@ -65,6 +66,7 @@ def setup():
 
 
 @auth_ui_bp.post("/login")
+@limiter.limit("10/minute; 30/hour")
 def login():
     if not ui_auth.is_ui_auth_enabled():
         session["ui_authenticated"] = True


### PR DESCRIPTION
## Summary

Follow-up to #92. Fixes the two HIGH-severity findings from the 2026-03-16 internal Kali pentest.

- **F-01 (HIGH)** — API key brute-force: per-IP sliding-window failure counter in \`auth.py\`. After 20 failed attempts within 60 s the IP receives \`429 Too Many Requests\` with \`Retry-After: 60\`. Uses \`threading.Lock\` + \`defaultdict\` — no external dependency, works correctly in single-worker Gunicorn.
- **F-02 (HIGH)** — Login brute-force: \`@limiter.limit("10/minute; 30/hour")\` on \`POST /api/v1/auth/login\` via **flask-limiter 4.1.1** (added to \`requirements.txt\`). Limiter instance lives in \`extensions.py\`, \`init_app()\` called in \`create_app()\`.
- **F-05 (MEDIUM)** — Webhook exemption footgun documented with an explicit \`IMPORTANT\` comment in \`auth.py\` warning future developers.
- **F-09 (LOW)** — rpcbind service + socket unit disabled on LXC CT101 (infra fix, already applied; port 111 confirmed closed via nmap).

## Test plan

- [x] \`ruff check . && ruff format --check .\` — clean
- [x] \`pytest tests/test_auth.py tests/test_security.py tests/test_routes_auth_ui.py\` — 48/48 passed
- [ ] Manual: 21 wrong API key requests → 21st returns 429 with Retry-After header
- [ ] Manual: 11 login attempts in < 1 min → 11th returns 429
- [ ] \`nmap -p 111 192.168.178.194\` → port closed (already confirmed)