### PR TITLE
feat: subtitle presence pills on Wanted page

### DIFF
--- a/backend/ass_utils.py
+++ b/backend/ass_utils.py
@@ -86,6 +86,7 @@ def get_all_subtitle_streams(ffprobe_data: dict, exclude_language: str | None = 
     exclude_tags: set[str] = set()
     if exclude_language:
         from config import _get_language_tags
+
         exclude_tags = _get_language_tags(exclude_language)
 
     seen: set[tuple] = set()

--- a/backend/ass_utils.py
+++ b/backend/ass_utils.py
@@ -71,6 +71,49 @@ def has_target_language_stream(ffprobe_data, target_language=None):
     return None
 
 
+def get_all_subtitle_streams(ffprobe_data: dict, exclude_language: str | None = None) -> list[dict]:
+    """Return all embedded subtitle streams as a list of {lang, format} dicts.
+
+    Args:
+        ffprobe_data: dict from get_media_streams / ffprobe JSON output.
+        exclude_language: ISO-639-1 code to exclude (typically the target language,
+            already tracked separately in existing_sub). None = return all.
+
+    Returns:
+        Deduplicated list of dicts with 'lang' (raw language tag) and 'format'
+        ('ass' or 'srt'). Unknown codecs (dvd_subtitle, etc.) are skipped.
+    """
+    exclude_tags: set[str] = set()
+    if exclude_language:
+        from config import _get_language_tags
+        exclude_tags = _get_language_tags(exclude_language)
+
+    seen: set[tuple] = set()
+    result: list[dict] = []
+
+    for stream in ffprobe_data.get("streams", []):
+        if stream.get("codec_type") != "subtitle":
+            continue
+        lang = stream.get("tags", {}).get("language", "").lower()
+        if not lang:
+            continue
+        if lang in exclude_tags:
+            continue
+        codec = stream.get("codec_name", "").lower()
+        if codec in ("ass", "ssa"):
+            fmt = "ass"
+        elif codec in ("subrip", "srt"):
+            fmt = "srt"
+        else:
+            continue
+        key = (lang, fmt)
+        if key not in seen:
+            seen.add(key)
+            result.append({"lang": lang, "format": fmt})
+
+    return result
+
+
 def has_target_language_audio(ffprobe_data, target_language=None):
     """Check if the file has an audio track in the target language.
 

--- a/backend/db/migrations/versions/c6d7e8f9a0b1_add_embedded_languages.py
+++ b/backend/db/migrations/versions/c6d7e8f9a0b1_add_embedded_languages.py
@@ -1,0 +1,27 @@
+"""Add embedded_languages column to wanted_items.
+
+Revision ID: c6d7e8f9a0b1
+Revises: b5c6d7e8f9a0
+Create Date: 2026-04-04
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "c6d7e8f9a0b1"
+down_revision = "b5c6d7e8f9a0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("wanted_items") as batch_op:
+        batch_op.add_column(
+            sa.Column("embedded_languages", sa.Text(), nullable=True, server_default="[]")
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("wanted_items") as batch_op:
+        batch_op.drop_column("embedded_languages")

--- a/backend/db/models/core.py
+++ b/backend/db/models/core.py
@@ -73,6 +73,7 @@ class WantedItem(db.Model):
     season_episode: Mapped[str | None] = mapped_column(Text, default="")
     file_path: Mapped[str] = mapped_column(Text, nullable=False)
     existing_sub: Mapped[str | None] = mapped_column(Text, default="")
+    embedded_languages: Mapped[str | None] = mapped_column(Text, default="[]")
     missing_languages: Mapped[str | None] = mapped_column(Text, default="[]")
     status: Mapped[str] = mapped_column(String(20), nullable=False, default="wanted")
     last_search_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/backend/db/repositories/wanted.py
+++ b/backend/db/repositories/wanted.py
@@ -53,7 +53,7 @@ class WantedRepository(BaseRepository):
         """
         now = self._now()
         langs_json = json.dumps(missing_languages or [])
-        embedded_json = json.dumps(embedded_languages or [])
+        embedded_json = json.dumps(embedded_languages) if embedded_languages is not None else None
         upgrade_int = 1 if upgrade_candidate else 0
 
         # Match on file_path + target_language + subtitle_type for multi-language + multi-type support
@@ -84,7 +84,8 @@ class WantedRepository(BaseRepository):
                 existing.season_episode = season_episode
                 existing.existing_sub = existing_sub
                 existing.missing_languages = langs_json
-                existing.embedded_languages = embedded_json
+                if embedded_json is not None:
+                    existing.embedded_languages = embedded_json
                 existing.sonarr_series_id = sonarr_series_id
                 existing.sonarr_episode_id = sonarr_episode_id
                 existing.radarr_movie_id = radarr_movie_id
@@ -102,7 +103,8 @@ class WantedRepository(BaseRepository):
                 existing.season_episode = season_episode
                 existing.existing_sub = existing_sub
                 existing.missing_languages = langs_json
-                existing.embedded_languages = embedded_json
+                if embedded_json is not None:
+                    existing.embedded_languages = embedded_json
                 existing.status = "wanted"
                 existing.sonarr_series_id = sonarr_series_id
                 existing.sonarr_episode_id = sonarr_episode_id
@@ -125,7 +127,7 @@ class WantedRepository(BaseRepository):
             season_episode=season_episode,
             existing_sub=existing_sub,
             missing_languages=langs_json,
-            embedded_languages=embedded_json,
+            embedded_languages=embedded_json if embedded_json is not None else "[]",
             sonarr_series_id=sonarr_series_id,
             sonarr_episode_id=sonarr_episode_id,
             radarr_movie_id=radarr_movie_id,

--- a/backend/db/repositories/wanted.py
+++ b/backend/db/repositories/wanted.py
@@ -40,6 +40,7 @@ class WantedRepository(BaseRepository):
         target_language: str = "",
         instance_name: str = "",
         subtitle_type: str = "full",
+        embedded_languages: list = None,
     ) -> tuple:
         """Insert or update a wanted item (matched on file_path + target_language + subtitle_type).
 
@@ -52,6 +53,7 @@ class WantedRepository(BaseRepository):
         """
         now = self._now()
         langs_json = json.dumps(missing_languages or [])
+        embedded_json = json.dumps(embedded_languages or [])
         upgrade_int = 1 if upgrade_candidate else 0
 
         # Match on file_path + target_language + subtitle_type for multi-language + multi-type support
@@ -82,6 +84,7 @@ class WantedRepository(BaseRepository):
                 existing.season_episode = season_episode
                 existing.existing_sub = existing_sub
                 existing.missing_languages = langs_json
+                existing.embedded_languages = embedded_json
                 existing.sonarr_series_id = sonarr_series_id
                 existing.sonarr_episode_id = sonarr_episode_id
                 existing.radarr_movie_id = radarr_movie_id
@@ -99,6 +102,7 @@ class WantedRepository(BaseRepository):
                 existing.season_episode = season_episode
                 existing.existing_sub = existing_sub
                 existing.missing_languages = langs_json
+                existing.embedded_languages = embedded_json
                 existing.status = "wanted"
                 existing.sonarr_series_id = sonarr_series_id
                 existing.sonarr_episode_id = sonarr_episode_id
@@ -121,6 +125,7 @@ class WantedRepository(BaseRepository):
             season_episode=season_episode,
             existing_sub=existing_sub,
             missing_languages=langs_json,
+            embedded_languages=embedded_json,
             sonarr_series_id=sonarr_series_id,
             sonarr_episode_id=sonarr_episode_id,
             radarr_movie_id=radarr_movie_id,
@@ -495,4 +500,11 @@ class WantedRepository(BaseRepository):
                 d["missing_languages"] = []
         else:
             d["missing_languages"] = []
+        if d.get("embedded_languages"):
+            try:
+                d["embedded_languages"] = json.loads(d["embedded_languages"])
+            except json.JSONDecodeError:
+                d["embedded_languages"] = []
+        else:
+            d["embedded_languages"] = []
         return d

--- a/backend/db/repositories/wanted.py
+++ b/backend/db/repositories/wanted.py
@@ -491,7 +491,7 @@ class WantedRepository(BaseRepository):
     # ---- Helpers ----
 
     def _row_to_wanted(self, item: WantedItem) -> dict:
-        """Convert a WantedItem model to a dict. Parse missing_languages JSON."""
+        """Convert a WantedItem model to a dict. Parse missing_languages and embedded_languages JSON."""
         d = self._to_dict(item)
         if d.get("missing_languages"):
             try:

--- a/backend/db/wanted.py
+++ b/backend/db/wanted.py
@@ -46,6 +46,7 @@ def upsert_wanted_item(
     target_language: str = "",
     instance_name: str = "",
     subtitle_type: str = "full",
+    embedded_languages: list = None,
 ) -> tuple:
     """Insert or update a wanted item. Returns (row_id, was_updated)."""
     return _get_repo().upsert_wanted_item(
@@ -65,6 +66,7 @@ def upsert_wanted_item(
         target_language,
         instance_name,
         subtitle_type,
+        embedded_languages,
     )
 
 

--- a/backend/providers/search_coordinator.py
+++ b/backend/providers/search_coordinator.py
@@ -247,9 +247,7 @@ class SearchCoordinatorMixin:
                         logger.info("Returning %d results from fast cache", len(cached_results))
                         try:
                             if _METRICS_AVAILABLE:
-                                _metrics_module.PROVIDER_CACHE_HITS_TOTAL.labels(
-                                    layer="fast"
-                                ).inc()
+                                _metrics_module.PROVIDER_CACHE_HITS_TOTAL.labels(layer="fast").inc()
                         except Exception:
                             pass
                         return cached_results

--- a/backend/routes/system/tasks.py
+++ b/backend/routes/system/tasks.py
@@ -144,9 +144,14 @@ def list_tasks():
             try:
                 from datetime import timedelta
 
-                base_dt = datetime.fromisoformat(str(scan_last)) if scan_last else (
-                    datetime.fromisoformat(scanner.scheduler_started_at)
-                    if scanner.scheduler_started_at else None
+                base_dt = (
+                    datetime.fromisoformat(str(scan_last))
+                    if scan_last
+                    else (
+                        datetime.fromisoformat(scanner.scheduler_started_at)
+                        if scanner.scheduler_started_at
+                        else None
+                    )
                 )
                 if base_dt:
                     scan_next = (base_dt + timedelta(hours=scan_interval)).isoformat()
@@ -172,9 +177,14 @@ def list_tasks():
             try:
                 from datetime import timedelta
 
-                base_dt = datetime.fromisoformat(str(search_last)) if search_last else (
-                    datetime.fromisoformat(scanner.scheduler_started_at)
-                    if scanner.scheduler_started_at else None
+                base_dt = (
+                    datetime.fromisoformat(str(search_last))
+                    if search_last
+                    else (
+                        datetime.fromisoformat(scanner.scheduler_started_at)
+                        if scanner.scheduler_started_at
+                        else None
+                    )
                 )
                 if base_dt:
                     search_next = (base_dt + timedelta(hours=search_interval)).isoformat()

--- a/backend/routes/wanted/extract.py
+++ b/backend/routes/wanted/extract.py
@@ -134,6 +134,18 @@ def _run_batch_extract(item_ids, auto_translate, app):
                     )
                     with _batch_extract_lock:
                         _batch_extract_state["succeeded"] += 1
+                except (LookupError, FileNotFoundError, ValueError) as exc:
+                    # Permanent failure: no subtitle stream found or file missing.
+                    # Clear the embedded_sub flag so the item falls through to provider search.
+                    logger.warning("[batch-extract] item %d failed (clearing embedded flag): %s", item_id, exc)
+                    try:
+                        from db.wanted import update_existing_sub, update_wanted_status
+                        update_existing_sub(item_id, "")
+                        update_wanted_status(item_id, "wanted")
+                    except Exception as db_exc:
+                        logger.debug("[batch-extract] DB update failed for item %d: %s", item_id, db_exc)
+                    with _batch_extract_lock:
+                        _batch_extract_state["failed"] += 1
                 except Exception as exc:
                     logger.warning("[batch-extract] item %d failed: %s", item_id, exc)
                     with _batch_extract_lock:

--- a/backend/routes/wanted/extract.py
+++ b/backend/routes/wanted/extract.py
@@ -137,13 +137,18 @@ def _run_batch_extract(item_ids, auto_translate, app):
                 except (LookupError, FileNotFoundError, ValueError) as exc:
                     # Permanent failure: no subtitle stream found or file missing.
                     # Clear the embedded_sub flag so the item falls through to provider search.
-                    logger.warning("[batch-extract] item %d failed (clearing embedded flag): %s", item_id, exc)
+                    logger.warning(
+                        "[batch-extract] item %d failed (clearing embedded flag): %s", item_id, exc
+                    )
                     try:
                         from db.wanted import update_existing_sub, update_wanted_status
+
                         update_existing_sub(item_id, "")
                         update_wanted_status(item_id, "wanted")
                     except Exception as db_exc:
-                        logger.debug("[batch-extract] DB update failed for item %d: %s", item_id, db_exc)
+                        logger.debug(
+                            "[batch-extract] DB update failed for item %d: %s", item_id, db_exc
+                        )
                     with _batch_extract_lock:
                         _batch_extract_state["failed"] += 1
                 except Exception as exc:

--- a/backend/routes/wanted/search.py
+++ b/backend/routes/wanted/search.py
@@ -359,6 +359,40 @@ def wanted_search_all():
     return jsonify({"status": "search_started"}), 202
 
 
+@bp.route("/wanted/search-upgrades", methods=["POST"])
+def wanted_search_upgrades():
+    """Trigger a one-time search for upgrade candidates (regardless of upgrade schedule setting).
+    ---
+    post:
+      tags:
+        - Wanted
+      summary: One-time upgrade search
+      description: >
+        Searches all upgrade candidates once, even when upgrade_scan_interval_hours is 0.
+        Useful for a manual upgrade run without permanently enabling the upgrade scheduler.
+      security:
+        - apiKeyAuth: []
+      responses:
+        202:
+          description: Search started
+        409:
+          description: Search already running
+    """
+    from services.wanted_scanner import get_scanner
+
+    scanner = get_scanner()
+    if scanner.is_searching:
+        return jsonify({"error": "Search already running"}), 409
+
+    def _run_search():
+        scanner._run_search_with_context(socketio=socketio, include_upgrades=True)
+
+    thread = threading.Thread(target=_run_search, daemon=True)
+    thread.start()
+
+    return jsonify({"status": "search_started"}), 202
+
+
 @bp.route("/wanted/batch-action", methods=["POST"])
 def wanted_batch_action():
     """Perform a batch action on multiple wanted items.

--- a/backend/services/wanted_scanner_core.py
+++ b/backend/services/wanted_scanner_core.py
@@ -839,8 +839,13 @@ class WantedScanner:
 
     # ─── Search All ────────────────────────────────────────────────────────
 
-    def search_all(self, socketio=None) -> dict:
+    def search_all(self, socketio=None, include_upgrades: bool | None = None) -> dict:
         """Search providers for all wanted items (respects max_items_per_run).
+
+        Args:
+            include_upgrades: Whether to include upgrade candidates. Defaults to
+                True when upgrade_scan_interval_hours > 0, False otherwise.
+                Pass True explicitly to force a one-time upgrade search run.
 
         Uses ThreadPoolExecutor for parallel item processing instead of
         sequential processing with sleep delays. Provider-level rate limiting
@@ -860,10 +865,19 @@ class WantedScanner:
             settings = get_settings()
             max_items = settings.wanted_search_max_items_per_run
 
+            # Determine whether upgrade candidates are included in this run
+            upgrade_enabled = getattr(settings, "upgrade_scan_interval_hours", 0) > 0
+            if include_upgrades is None:
+                include_upgrades = upgrade_enabled
+
             from db.wanted import get_wanted_items
 
             result = get_wanted_items(page=1, per_page=max_items, status="wanted")
             items = result.get("data", [])
+
+            # Skip upgrade candidates when upgrade scan is disabled (unless forced)
+            if not include_upgrades:
+                items = [i for i in items if not i.get("upgrade_candidate")]
 
             # Filter: adaptive backoff (or fixed 1h fallback when disabled)
             eligible = []
@@ -1098,13 +1112,13 @@ class WantedScanner:
         else:
             self.scan_all()
 
-    def _run_search_with_context(self, socketio=None):
+    def _run_search_with_context(self, socketio=None, include_upgrades: bool | None = None):
         """Run search_all inside Flask app context (for background threads)."""
         if self._app is not None:
             with self._app.app_context():
-                self.search_all(socketio)
+                self.search_all(socketio, include_upgrades=include_upgrades)
         else:
-            self.search_all(socketio)
+            self.search_all(socketio, include_upgrades=include_upgrades)
 
     def _scheduled_scan(self, interval_hours):
         """Execute a scheduled scan and reschedule."""

--- a/backend/services/wanted_scanner_core.py
+++ b/backend/services/wanted_scanner_core.py
@@ -20,7 +20,12 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import UTC, datetime
 
-from ass_utils import get_all_subtitle_streams, get_media_streams, has_target_language_audio, has_target_language_stream
+from ass_utils import (
+    get_all_subtitle_streams,
+    get_media_streams,
+    has_target_language_audio,
+    has_target_language_stream,
+)
 from config import get_settings, map_path
 from db.profiles import get_movie_profile, get_series_profile
 from db.wanted import batch_upsert_context, upsert_wanted_item
@@ -634,7 +639,9 @@ class WantedScanner:
 
                 embedded_langs = []
                 if probe_data:
-                    embedded_langs = get_all_subtitle_streams(probe_data, exclude_language=target_lang)
+                    embedded_langs = get_all_subtitle_streams(
+                        probe_data, exclude_language=target_lang
+                    )
 
                 title = f"{series_title} — {season_episode}"
                 if len(target_languages) > 1:

--- a/backend/services/wanted_scanner_core.py
+++ b/backend/services/wanted_scanner_core.py
@@ -348,6 +348,9 @@ class WantedScanner:
             existing = detect_existing_target_for_lang(mapped_path, target_lang, probe_data)
             if existing == "ass":
                 continue
+            # SRT is sufficient when upgrade scanning is disabled
+            if existing == "srt" and not settings.upgrade_enabled:
+                continue
 
             embedded_sub = None
             if probe_data:
@@ -608,6 +611,9 @@ class WantedScanner:
                 existing = detect_existing_target_for_lang(mapped_path, target_lang, probe_data)
                 if existing == "ass":
                     continue  # Goal achieved for this language
+                # SRT is sufficient when upgrade scanning is disabled
+                if existing == "srt" and not settings.upgrade_enabled:
+                    continue
 
                 # Check embedded streams and audio tracks if probe_data available
                 embedded_sub = None
@@ -811,7 +817,8 @@ class WantedScanner:
                 to_remove_ids.append(item["id"])
                 continue
 
-            # Target ASS appeared since last scan (language-aware)
+            # Target subtitle appeared since last scan (language-aware)
+            settings = get_settings()
             if target_lang:
                 existing = detect_existing_target_for_lang(path, target_lang)
             else:
@@ -819,6 +826,10 @@ class WantedScanner:
 
                 existing = detect_existing_target(path)
             if existing == "ass":
+                to_remove_ids.append(item["id"])
+                continue
+            # SRT counts as goal achieved when upgrade scanning is disabled
+            if existing == "srt" and not settings.upgrade_enabled:
                 to_remove_ids.append(item["id"])
                 continue
 

--- a/backend/services/wanted_scanner_core.py
+++ b/backend/services/wanted_scanner_core.py
@@ -20,7 +20,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import UTC, datetime
 
-from ass_utils import get_media_streams, has_target_language_audio, has_target_language_stream
+from ass_utils import get_all_subtitle_streams, get_media_streams, has_target_language_audio, has_target_language_stream
 from config import get_settings, map_path
 from db.profiles import get_movie_profile, get_series_profile
 from db.wanted import batch_upsert_context, upsert_wanted_item
@@ -363,6 +363,10 @@ class WantedScanner:
                 elif embedded_sub == "srt":
                     existing = "embedded_srt"
 
+            embedded_langs = []
+            if probe_data:
+                embedded_langs = get_all_subtitle_streams(probe_data, exclude_language=target_lang)
+
             title = movie_title
             if len(target_languages) > 1:
                 title = f"{title} [{target_lang.upper()}]"
@@ -388,6 +392,7 @@ class WantedScanner:
                 target_language=target_lang,
                 instance_name=instance_name or "",
                 subtitle_type="full",
+                embedded_languages=embedded_langs,
             )
             if was_updated:
                 updated += 1
@@ -627,6 +632,10 @@ class WantedScanner:
                     elif embedded_sub == "srt":
                         existing = "embedded_srt"
 
+                embedded_langs = []
+                if probe_data:
+                    embedded_langs = get_all_subtitle_streams(probe_data, exclude_language=target_lang)
+
                 title = f"{series_title} — {season_episode}"
                 if len(target_languages) > 1:
                     title = f"{title} [{target_lang.upper()}]"
@@ -655,6 +664,7 @@ class WantedScanner:
                     target_language=target_lang,
                     instance_name=instance_name or "",
                     subtitle_type="full",
+                    embedded_languages=embedded_langs,
                 )
                 if was_updated:
                     updated += 1

--- a/backend/tests/test_embedded_streams.py
+++ b/backend/tests/test_embedded_streams.py
@@ -1,4 +1,5 @@
 """Tests for get_all_subtitle_streams in ass_utils."""
+
 from unittest.mock import patch
 
 import pytest
@@ -40,6 +41,7 @@ PROBE_DUPLICATE = {
 @pytest.fixture(autouse=True)
 def mock_lang_tags():
     """Mock _get_language_tags to avoid real config loading."""
+
     def fake_tags(lang):
         mapping = {
             "de": {"deu", "ger", "de"},
@@ -54,6 +56,7 @@ def mock_lang_tags():
 
 def test_returns_all_non_target_streams():
     from ass_utils import get_all_subtitle_streams
+
     result = get_all_subtitle_streams(PROBE_EN_ASS_JA_SRT, exclude_language="de")
     langs = {r["lang"] for r in result}
     assert "eng" in langs
@@ -63,6 +66,7 @@ def test_returns_all_non_target_streams():
 
 def test_excludes_target_language():
     from ass_utils import get_all_subtitle_streams
+
     result = get_all_subtitle_streams(PROBE_EN_ASS_JA_SRT, exclude_language="en")
     langs = {r["lang"] for r in result}
     assert "eng" not in langs
@@ -71,6 +75,7 @@ def test_excludes_target_language():
 
 def test_formats_correctly():
     from ass_utils import get_all_subtitle_streams
+
     result = get_all_subtitle_streams(PROBE_EN_ASS_JA_SRT, exclude_language="de")
     by_lang = {r["lang"]: r["format"] for r in result}
     assert by_lang["eng"] == "ass"
@@ -79,16 +84,19 @@ def test_formats_correctly():
 
 def test_empty_probe_returns_empty():
     from ass_utils import get_all_subtitle_streams
+
     assert get_all_subtitle_streams(PROBE_EMPTY) == []
 
 
 def test_no_subtitle_streams_returns_empty():
     from ass_utils import get_all_subtitle_streams
+
     assert get_all_subtitle_streams(PROBE_NO_SUBS) == []
 
 
 def test_skips_unknown_codecs():
     from ass_utils import get_all_subtitle_streams
+
     result = get_all_subtitle_streams(PROBE_UNKNOWN_CODEC)
     assert len(result) == 1
     assert result[0]["format"] == "ass"
@@ -96,11 +104,13 @@ def test_skips_unknown_codecs():
 
 def test_deduplicates_same_lang_format():
     from ass_utils import get_all_subtitle_streams
+
     result = get_all_subtitle_streams(PROBE_DUPLICATE)
     assert len(result) == 1
 
 
 def test_no_exclude_returns_all():
     from ass_utils import get_all_subtitle_streams
+
     result = get_all_subtitle_streams(PROBE_EN_ASS_JA_SRT, exclude_language=None)
     assert len(result) == 3  # eng, jpn, deu

--- a/backend/tests/test_embedded_streams.py
+++ b/backend/tests/test_embedded_streams.py
@@ -1,0 +1,106 @@
+"""Tests for get_all_subtitle_streams in ass_utils."""
+import pytest
+from unittest.mock import patch
+
+
+PROBE_EN_ASS_JA_SRT = {
+    "streams": [
+        {"codec_type": "video", "codec_name": "h264"},
+        {"codec_type": "audio", "codec_name": "aac", "tags": {"language": "jpn"}},
+        {"codec_type": "subtitle", "codec_name": "ass", "tags": {"language": "eng"}},
+        {"codec_type": "subtitle", "codec_name": "subrip", "tags": {"language": "jpn"}},
+        {"codec_type": "subtitle", "codec_name": "ass", "tags": {"language": "deu"}},
+    ]
+}
+
+PROBE_EMPTY = {"streams": []}
+
+PROBE_NO_SUBS = {
+    "streams": [
+        {"codec_type": "video", "codec_name": "h264"},
+        {"codec_type": "audio", "codec_name": "aac"},
+    ]
+}
+
+PROBE_UNKNOWN_CODEC = {
+    "streams": [
+        {"codec_type": "subtitle", "codec_name": "dvd_subtitle", "tags": {"language": "eng"}},
+        {"codec_type": "subtitle", "codec_name": "ass", "tags": {"language": "eng"}},
+    ]
+}
+
+PROBE_DUPLICATE = {
+    "streams": [
+        {"codec_type": "subtitle", "codec_name": "ass", "tags": {"language": "eng"}},
+        {"codec_type": "subtitle", "codec_name": "ass", "tags": {"language": "eng"}},
+    ]
+}
+
+
+@pytest.fixture(autouse=True)
+def mock_lang_tags():
+    """Mock _get_language_tags to avoid real config loading."""
+    def fake_tags(lang):
+        mapping = {
+            "de": {"deu", "ger", "de"},
+            "en": {"eng", "en"},
+            "ja": {"jpn", "ja"},
+        }
+        return mapping.get(lang, {lang})
+
+    with patch("config._get_language_tags", side_effect=fake_tags):
+        yield
+
+
+def test_returns_all_non_target_streams():
+    from ass_utils import get_all_subtitle_streams
+    result = get_all_subtitle_streams(PROBE_EN_ASS_JA_SRT, exclude_language="de")
+    langs = {r["lang"] for r in result}
+    assert "eng" in langs
+    assert "jpn" in langs
+    assert "deu" not in langs
+
+
+def test_excludes_target_language():
+    from ass_utils import get_all_subtitle_streams
+    result = get_all_subtitle_streams(PROBE_EN_ASS_JA_SRT, exclude_language="en")
+    langs = {r["lang"] for r in result}
+    assert "eng" not in langs
+    assert "deu" in langs
+
+
+def test_formats_correctly():
+    from ass_utils import get_all_subtitle_streams
+    result = get_all_subtitle_streams(PROBE_EN_ASS_JA_SRT, exclude_language="de")
+    by_lang = {r["lang"]: r["format"] for r in result}
+    assert by_lang["eng"] == "ass"
+    assert by_lang["jpn"] == "srt"
+
+
+def test_empty_probe_returns_empty():
+    from ass_utils import get_all_subtitle_streams
+    assert get_all_subtitle_streams(PROBE_EMPTY) == []
+
+
+def test_no_subtitle_streams_returns_empty():
+    from ass_utils import get_all_subtitle_streams
+    assert get_all_subtitle_streams(PROBE_NO_SUBS) == []
+
+
+def test_skips_unknown_codecs():
+    from ass_utils import get_all_subtitle_streams
+    result = get_all_subtitle_streams(PROBE_UNKNOWN_CODEC)
+    assert len(result) == 1
+    assert result[0]["format"] == "ass"
+
+
+def test_deduplicates_same_lang_format():
+    from ass_utils import get_all_subtitle_streams
+    result = get_all_subtitle_streams(PROBE_DUPLICATE)
+    assert len(result) == 1
+
+
+def test_no_exclude_returns_all():
+    from ass_utils import get_all_subtitle_streams
+    result = get_all_subtitle_streams(PROBE_EN_ASS_JA_SRT, exclude_language=None)
+    assert len(result) == 3  # eng, jpn, deu

--- a/backend/tests/test_embedded_streams.py
+++ b/backend/tests/test_embedded_streams.py
@@ -1,7 +1,7 @@
 """Tests for get_all_subtitle_streams in ass_utils."""
-import pytest
 from unittest.mock import patch
 
+import pytest
 
 PROBE_EN_ASS_JA_SRT = {
     "streams": [

--- a/backend/wanted_search/process.py
+++ b/backend/wanted_search/process.py
@@ -16,6 +16,7 @@ from upgrade_scorer import should_upgrade
 from wanted_search.metadata import _set_adaptive_retry_after, build_query_from_wanted
 from wanted_search.post_processor import (
     _process_forced_wanted_item,
+    _try_auto_sync,
     download_specific_for_item,  # noqa: F401 — re-exported for callers
 )
 
@@ -235,6 +236,7 @@ def process_wanted_item(item_id: int) -> dict:
                         "score": result.score,
                     },
                 )
+                _try_auto_sync(output_path, file_path, settings)
                 update_wanted_status(item_id, "found")
                 return {
                     "wanted_id": item_id,
@@ -379,6 +381,7 @@ def process_wanted_item(item_id: int) -> dict:
                         item_id,
                         result.provider_name,
                     )
+                    _try_auto_sync(translate_result.get("output_path"), file_path, settings)
                     update_wanted_status(item_id, "found")
                     return {
                         "wanted_id": item_id,
@@ -449,6 +452,7 @@ def process_wanted_item(item_id: int) -> dict:
                             "score": result.score,
                         },
                     )
+                    _try_auto_sync(output_path, file_path, settings)
                     update_wanted_status(item_id, "found")
                     return {
                         "wanted_id": item_id,
@@ -588,6 +592,7 @@ def process_wanted_item(item_id: int) -> dict:
                         item_id,
                         result.provider_name,
                     )
+                    _try_auto_sync(translate_result.get("output_path"), file_path, settings)
                     update_wanted_status(item_id, "found")
                     return {
                         "wanted_id": item_id,

--- a/docs/superpowers/plans/2026-04-04-wanted-subtitle-presence-pills.md
+++ b/docs/superpowers/plans/2026-04-04-wanted-subtitle-presence-pills.md
@@ -1,0 +1,1060 @@
+# Wanted Subtitle Presence Pills — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the plain-text "Vorhanden" column in the Wanted table with pill-based subtitle presence indicators that show target-language status and all embedded subtitle streams.
+
+**Architecture:** New `get_all_subtitle_streams()` in `ass_utils.py` scans all embedded streams, stored in a new `embedded_languages` JSON column on `wanted_items`. Frontend renders a `SubtitlePresencePills` component using this data plus the existing `existing_sub` field and `source_language` config setting for sort priority.
+
+**Tech Stack:** Python/SQLAlchemy (backend), Alembic (migration), React 19 + TypeScript (frontend), Vitest (frontend tests), pytest (backend tests)
+
+**Spec:** `docs/superpowers/specs/2026-04-04-wanted-subtitle-presence-pills-design.md`
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|---------------|
+| Modify | `backend/ass_utils.py` | Add `get_all_subtitle_streams()` |
+| Modify | `backend/db/models/core.py` | Add `embedded_languages` column to `WantedItem` |
+| Create | `backend/db/migrations/versions/e1f2a3b4c5d6_add_embedded_languages.py` | Alembic migration |
+| Modify | `backend/db/repositories/wanted.py` | Pass + parse `embedded_languages` |
+| Modify | `backend/db/wanted.py` | Add param to public wrapper |
+| Modify | `backend/services/wanted_scanner_core.py` | Detect all streams, pass to upsert (2 call sites) |
+| Create | `backend/tests/test_embedded_streams.py` | Unit tests for `get_all_subtitle_streams` |
+| Modify | `frontend/src/types/wanted.ts` | Add `embedded_languages` to `WantedItem` |
+| Create | `frontend/src/pages/wanted/SubtitlePresencePills.tsx` | Pill display component |
+| Create | `frontend/src/test/SubtitlePresencePills.test.tsx` | Component tests |
+| Modify | `frontend/src/pages/wanted/WantedTableRow.tsx` | Use pills, add `sourceLanguage` prop |
+| Modify | `frontend/src/pages/Wanted.tsx` | Fetch config, pass `sourceLanguage` |
+| Modify | `frontend/src/i18n/locales/de/library.json` | Rename `existing_col` |
+| Modify | `frontend/src/i18n/locales/en/library.json` | Rename `existing_col` |
+
+---
+
+## Task 1: Add `get_all_subtitle_streams()` to `ass_utils.py`
+
+**Files:**
+- Modify: `backend/ass_utils.py` (after line 71, after `has_target_language_stream`)
+- Create: `backend/tests/test_embedded_streams.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/test_embedded_streams.py`:
+
+```python
+"""Tests for get_all_subtitle_streams in ass_utils."""
+import pytest
+from unittest.mock import patch
+
+
+PROBE_EN_ASS_JA_SRT = {
+    "streams": [
+        {"codec_type": "video", "codec_name": "h264"},
+        {"codec_type": "audio", "codec_name": "aac", "tags": {"language": "jpn"}},
+        {"codec_type": "subtitle", "codec_name": "ass", "tags": {"language": "eng"}},
+        {"codec_type": "subtitle", "codec_name": "subrip", "tags": {"language": "jpn"}},
+        {"codec_type": "subtitle", "codec_name": "ass", "tags": {"language": "deu"}},
+    ]
+}
+
+PROBE_EMPTY = {"streams": []}
+
+PROBE_NO_SUBS = {
+    "streams": [
+        {"codec_type": "video", "codec_name": "h264"},
+        {"codec_type": "audio", "codec_name": "aac"},
+    ]
+}
+
+PROBE_UNKNOWN_CODEC = {
+    "streams": [
+        {"codec_type": "subtitle", "codec_name": "dvd_subtitle", "tags": {"language": "eng"}},
+        {"codec_type": "subtitle", "codec_name": "ass", "tags": {"language": "eng"}},
+    ]
+}
+
+PROBE_DUPLICATE = {
+    "streams": [
+        {"codec_type": "subtitle", "codec_name": "ass", "tags": {"language": "eng"}},
+        {"codec_type": "subtitle", "codec_name": "ass", "tags": {"language": "eng"}},
+    ]
+}
+
+
+@pytest.fixture(autouse=True)
+def mock_lang_tags():
+    """Mock _get_language_tags to avoid real config loading."""
+    def fake_tags(lang):
+        mapping = {
+            "de": {"deu", "ger", "de"},
+            "en": {"eng", "en"},
+            "ja": {"jpn", "ja"},
+        }
+        return mapping.get(lang, {lang})
+
+    with patch("ass_utils._get_language_tags", side_effect=fake_tags):
+        yield
+
+
+def test_returns_all_non_target_streams():
+    from ass_utils import get_all_subtitle_streams
+    result = get_all_subtitle_streams(PROBE_EN_ASS_JA_SRT, exclude_language="de")
+    langs = {r["lang"] for r in result}
+    assert "eng" in langs
+    assert "jpn" in langs
+    # DE excluded
+    assert "deu" not in langs
+
+
+def test_excludes_target_language():
+    from ass_utils import get_all_subtitle_streams
+    result = get_all_subtitle_streams(PROBE_EN_ASS_JA_SRT, exclude_language="en")
+    langs = {r["lang"] for r in result}
+    assert "eng" not in langs
+    assert "deu" in langs
+
+
+def test_formats_correctly():
+    from ass_utils import get_all_subtitle_streams
+    result = get_all_subtitle_streams(PROBE_EN_ASS_JA_SRT, exclude_language="de")
+    by_lang = {r["lang"]: r["format"] for r in result}
+    assert by_lang["eng"] == "ass"
+    assert by_lang["jpn"] == "srt"
+
+
+def test_empty_probe_returns_empty():
+    from ass_utils import get_all_subtitle_streams
+    assert get_all_subtitle_streams(PROBE_EMPTY) == []
+
+
+def test_no_subtitle_streams_returns_empty():
+    from ass_utils import get_all_subtitle_streams
+    assert get_all_subtitle_streams(PROBE_NO_SUBS) == []
+
+
+def test_skips_unknown_codecs():
+    from ass_utils import get_all_subtitle_streams
+    result = get_all_subtitle_streams(PROBE_UNKNOWN_CODEC)
+    # dvd_subtitle is unknown, only ass counts
+    assert len(result) == 1
+    assert result[0]["format"] == "ass"
+
+
+def test_deduplicates_same_lang_format():
+    from ass_utils import get_all_subtitle_streams
+    result = get_all_subtitle_streams(PROBE_DUPLICATE)
+    assert len(result) == 1
+
+
+def test_no_exclude_returns_all():
+    from ass_utils import get_all_subtitle_streams
+    result = get_all_subtitle_streams(PROBE_EN_ASS_JA_SRT, exclude_language=None)
+    assert len(result) == 3  # eng, jpn, deu
+```
+
+- [ ] **Step 2: Run test — verify it fails**
+
+```bash
+cd backend && python -m pytest tests/test_embedded_streams.py -v
+```
+Expected: `ImportError` or `AttributeError: module 'ass_utils' has no attribute 'get_all_subtitle_streams'`
+
+- [ ] **Step 3: Add `get_all_subtitle_streams` to `backend/ass_utils.py`**
+
+Insert after line 71 (after `has_target_language_stream` function ends):
+
+```python
+def get_all_subtitle_streams(ffprobe_data: dict, exclude_language: str | None = None) -> list[dict]:
+    """Return all embedded subtitle streams as a list of {lang, format} dicts.
+
+    Args:
+        ffprobe_data: dict from get_media_streams / ffprobe JSON output.
+        exclude_language: ISO-639-1 code to exclude (typically the target language,
+            already tracked separately in existing_sub). None = return all.
+
+    Returns:
+        Deduplicated list of dicts with 'lang' (raw language tag) and 'format'
+        ('ass' or 'srt'). Unknown codecs (dvd_subtitle, etc.) are skipped.
+    """
+    exclude_tags: set[str] = set()
+    if exclude_language:
+        from config import _get_language_tags
+        exclude_tags = _get_language_tags(exclude_language)
+
+    seen: set[tuple] = set()
+    result: list[dict] = []
+
+    for stream in ffprobe_data.get("streams", []):
+        if stream.get("codec_type") != "subtitle":
+            continue
+        lang = stream.get("tags", {}).get("language", "").lower()
+        if not lang:
+            continue
+        if lang in exclude_tags:
+            continue
+        codec = stream.get("codec_name", "").lower()
+        if codec in ("ass", "ssa"):
+            fmt = "ass"
+        elif codec in ("subrip", "srt"):
+            fmt = "srt"
+        else:
+            continue
+        key = (lang, fmt)
+        if key not in seen:
+            seen.add(key)
+            result.append({"lang": lang, "format": fmt})
+
+    return result
+```
+
+- [ ] **Step 4: Run tests — verify they pass**
+
+```bash
+cd backend && python -m pytest tests/test_embedded_streams.py -v
+```
+Expected: all 8 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/ass_utils.py backend/tests/test_embedded_streams.py
+git commit -m "feat: add get_all_subtitle_streams to ass_utils"
+```
+
+---
+
+## Task 2: DB Migration — add `embedded_languages` column
+
+**Files:**
+- Create: `backend/db/migrations/versions/e1f2a3b4c5d6_add_embedded_languages.py`
+- Modify: `backend/db/models/core.py`
+
+- [ ] **Step 1: Find current Alembic head**
+
+```bash
+cd backend && python -m alembic heads
+```
+Note the revision ID printed. Use it as `down_revision` in the migration below.
+
+- [ ] **Step 2: Create migration file**
+
+Create `backend/db/migrations/versions/e1f2a3b4c5d6_add_embedded_languages.py`:
+
+```python
+"""Add embedded_languages column to wanted_items.
+
+Revision ID: e1f2a3b4c5d6
+Revises: <REPLACE_WITH_HEAD_FROM_STEP_1>
+Create Date: 2026-04-04
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "e1f2a3b4c5d6"
+down_revision = "<REPLACE_WITH_HEAD_FROM_STEP_1>"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("wanted_items") as batch_op:
+        batch_op.add_column(
+            sa.Column("embedded_languages", sa.Text(), nullable=True, server_default="[]")
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("wanted_items") as batch_op:
+        batch_op.drop_column("embedded_languages")
+```
+
+- [ ] **Step 3: Add column to ORM model**
+
+In `backend/db/models/core.py`, find the `WantedItem` class. After the `existing_sub` line (line 75), add:
+
+```python
+    embedded_languages: Mapped[str | None] = mapped_column(Text, default="[]")
+```
+
+- [ ] **Step 4: Run migration**
+
+```bash
+cd backend && python -m alembic upgrade head
+```
+Expected: `Running upgrade <old> -> e1f2a3b4c5d6, Add embedded_languages column to wanted_items`
+
+- [ ] **Step 5: Verify migration**
+
+```bash
+cd backend && python -m alembic current
+```
+Expected: `e1f2a3b4c5d6 (head)`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/db/migrations/versions/e1f2a3b4c5d6_add_embedded_languages.py backend/db/models/core.py
+git commit -m "feat: add embedded_languages column to wanted_items"
+```
+
+---
+
+## Task 3: Repository + Public Wrapper — propagate `embedded_languages`
+
+**Files:**
+- Modify: `backend/db/repositories/wanted.py`
+- Modify: `backend/db/wanted.py`
+
+- [ ] **Step 1: Update `WantedRepository.upsert_wanted_item` signature**
+
+In `backend/db/repositories/wanted.py`, find `upsert_wanted_item` (line 25). Add the new parameter after `subtitle_type`:
+
+```python
+    def upsert_wanted_item(
+        self,
+        item_type: str,
+        file_path: str,
+        title: str = "",
+        season_episode: str = "",
+        existing_sub: str = "",
+        missing_languages: list = None,
+        sonarr_series_id: int = None,
+        sonarr_episode_id: int = None,
+        radarr_movie_id: int = None,
+        standalone_series_id: int = None,
+        standalone_movie_id: int = None,
+        upgrade_candidate: bool = False,
+        current_score: int = 0,
+        target_language: str = "",
+        instance_name: str = "",
+        subtitle_type: str = "full",
+        embedded_languages: list = None,
+    ) -> tuple:
+```
+
+Also add near line 54 (after `langs_json = json.dumps(...)`):
+
+```python
+        embedded_json = json.dumps(embedded_languages or [])
+```
+
+Then in the **ignored-status update block** (around line 80), add:
+
+```python
+                existing.embedded_languages = embedded_json
+```
+
+In the **normal update block** (around line 96), add:
+
+```python
+                existing.embedded_languages = embedded_json
+```
+
+In the **new item INSERT block** (around line 117), add to the `WantedItem(...)` constructor:
+
+```python
+            embedded_languages=embedded_json,
+```
+
+- [ ] **Step 2: Update `_row_to_wanted` to parse `embedded_languages` JSON**
+
+In `backend/db/repositories/wanted.py`, find `_row_to_wanted` (line 488). After the `missing_languages` parsing block, add:
+
+```python
+        if d.get("embedded_languages"):
+            try:
+                d["embedded_languages"] = json.loads(d["embedded_languages"])
+            except json.JSONDecodeError:
+                d["embedded_languages"] = []
+        else:
+            d["embedded_languages"] = []
+```
+
+- [ ] **Step 3: Update public wrapper in `backend/db/wanted.py`**
+
+Find `upsert_wanted_item` (line 32). Add `embedded_languages: list = None` parameter and pass it through:
+
+```python
+def upsert_wanted_item(
+    item_type: str,
+    file_path: str,
+    title: str = "",
+    season_episode: str = "",
+    existing_sub: str = "",
+    missing_languages: list = None,
+    sonarr_series_id: int = None,
+    sonarr_episode_id: int = None,
+    radarr_movie_id: int = None,
+    standalone_series_id: int = None,
+    standalone_movie_id: int = None,
+    upgrade_candidate: bool = False,
+    current_score: int = 0,
+    target_language: str = "",
+    instance_name: str = "",
+    subtitle_type: str = "full",
+    embedded_languages: list = None,
+) -> tuple:
+    """Insert or update a wanted item. Returns (row_id, was_updated)."""
+    return _get_repo().upsert_wanted_item(
+        item_type,
+        file_path,
+        title,
+        season_episode,
+        existing_sub,
+        missing_languages,
+        sonarr_series_id,
+        sonarr_episode_id,
+        radarr_movie_id,
+        standalone_series_id,
+        standalone_movie_id,
+        upgrade_candidate,
+        current_score,
+        target_language,
+        instance_name,
+        subtitle_type,
+        embedded_languages,
+    )
+```
+
+- [ ] **Step 4: Run backend tests**
+
+```bash
+cd backend && python -m pytest --tb=short -q \
+  --ignore=tests/performance \
+  --ignore=tests/integration/test_provider_pipeline.py \
+  --ignore=tests/test_video_sync.py \
+  --ignore=tests/test_translation_backends.py \
+  -k "not (test_sonarr_download_webhook or test_radarr_download_webhook or test_parse_llm_response_too_many_merge or test_record_backend_success)"
+```
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/db/repositories/wanted.py backend/db/wanted.py
+git commit -m "feat: propagate embedded_languages through repository and public wrapper"
+```
+
+---
+
+## Task 4: Scanner — detect all embedded streams
+
+**Files:**
+- Modify: `backend/services/wanted_scanner_core.py`
+
+There are **two call sites** in this file — one for movies (~line 341) and one for episodes (~line 619). Update both identically.
+
+- [ ] **Step 1: Add import at top of scanner file**
+
+Find the imports section in `backend/services/wanted_scanner_core.py`. Add (or verify it's not already there):
+
+```python
+from ass_utils import get_all_subtitle_streams
+```
+
+- [ ] **Step 2: Update movies call site**
+
+Find the movie scanning block around line 355 where `embedded_sub` is set. After the block:
+
+```python
+            embedded_sub = None
+            if probe_data:
+                ...
+                embedded_sub = has_target_language_stream(probe_data, target_lang)
+                if embedded_sub == "ass":
+                    existing = "embedded_ass"
+                elif embedded_sub == "srt":
+                    existing = "embedded_srt"
+```
+
+Immediately after that block (before `title = movie_title`), add:
+
+```python
+            embedded_langs = []
+            if probe_data:
+                embedded_langs = get_all_subtitle_streams(probe_data, exclude_language=target_lang)
+```
+
+Then find the `upsert_wanted_item` call for movies and add `embedded_languages=embedded_langs`:
+
+```python
+            item_id, was_updated = upsert_wanted_item(
+                ...
+                embedded_languages=embedded_langs,
+            )
+```
+
+- [ ] **Step 3: Update episodes call site**
+
+Find the episode scanning block around line 619 where `embedded_sub` is set. Apply the exact same change:
+
+After the `embedded_sub` detection block:
+```python
+                embedded_langs = []
+                if probe_data:
+                    embedded_langs = get_all_subtitle_streams(probe_data, exclude_language=target_lang)
+```
+
+And add `embedded_languages=embedded_langs` to the `upsert_wanted_item` call for episodes.
+
+- [ ] **Step 4: Run backend tests**
+
+```bash
+cd backend && python -m pytest --tb=short -q \
+  --ignore=tests/performance \
+  --ignore=tests/integration/test_provider_pipeline.py \
+  --ignore=tests/test_video_sync.py \
+  --ignore=tests/test_translation_backends.py \
+  -k "not (test_sonarr_download_webhook or test_radarr_download_webhook or test_parse_llm_response_too_many_merge or test_record_backend_success)"
+```
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/services/wanted_scanner_core.py
+git commit -m "feat: detect all embedded subtitle streams in wanted scanner"
+```
+
+---
+
+## Task 5: Frontend types + i18n
+
+**Files:**
+- Modify: `frontend/src/types/wanted.ts`
+- Modify: `frontend/src/i18n/locales/de/library.json`
+- Modify: `frontend/src/i18n/locales/en/library.json`
+
+- [ ] **Step 1: Add `embedded_languages` to `WantedItem`**
+
+In `frontend/src/types/wanted.ts`, find the `WantedItem` interface (line 3). After `existing_sub: string`, add:
+
+```ts
+  embedded_languages: Array<{ lang: string; format: string }>
+```
+
+- [ ] **Step 2: Rename column header in DE i18n**
+
+In `frontend/src/i18n/locales/de/library.json`, find line:
+```json
+"existing_col": "Vorhanden",
+```
+Replace with:
+```json
+"existing_col": "Untertitel",
+```
+
+- [ ] **Step 3: Rename column header in EN i18n**
+
+In `frontend/src/i18n/locales/en/library.json`, find line:
+```json
+"existing_col": "Existing",
+```
+Replace with:
+```json
+"existing_col": "Subtitles",
+```
+
+- [ ] **Step 4: Run TypeScript check**
+
+```bash
+cd frontend && npx tsc --noEmit
+```
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/types/wanted.ts frontend/src/i18n/locales/de/library.json frontend/src/i18n/locales/en/library.json
+git commit -m "feat: add embedded_languages type field, rename wanted column header"
+```
+
+---
+
+## Task 6: `SubtitlePresencePills` component
+
+**Files:**
+- Create: `frontend/src/pages/wanted/SubtitlePresencePills.tsx`
+- Create: `frontend/src/test/SubtitlePresencePills.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `frontend/src/test/SubtitlePresencePills.test.tsx`:
+
+```tsx
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { SubtitlePresencePills } from '@/pages/wanted/SubtitlePresencePills'
+
+const noEmbedded: Array<{ lang: string; format: string }> = []
+const enAss = [{ lang: 'eng', format: 'ass' }]
+const enAssJaSrt = [{ lang: 'eng', format: 'ass' }, { lang: 'jpn', format: 'srt' }]
+const threeLangs = [
+  { lang: 'eng', format: 'ass' },
+  { lang: 'jpn', format: 'srt' },
+  { lang: 'fra', format: 'srt' },
+]
+
+describe('SubtitlePresencePills', () => {
+  it('shows DE ✗ when existingSub is empty', () => {
+    render(
+      <SubtitlePresencePills
+        existingSub=""
+        targetLanguage="de"
+        sourceLanguage="en"
+        embeddedLanguages={noEmbedded}
+      />
+    )
+    expect(screen.getByText('DE ✗')).toBeTruthy()
+  })
+
+  it('shows Kein Sub when nothing embedded', () => {
+    render(
+      <SubtitlePresencePills
+        existingSub=""
+        targetLanguage="de"
+        sourceLanguage="en"
+        embeddedLanguages={noEmbedded}
+      />
+    )
+    expect(screen.getByText('Kein Sub')).toBeTruthy()
+  })
+
+  it('shows DE SRT ↑ for srt existing_sub', () => {
+    render(
+      <SubtitlePresencePills
+        existingSub="srt"
+        targetLanguage="de"
+        sourceLanguage="en"
+        embeddedLanguages={enAss}
+      />
+    )
+    expect(screen.getByText('DE SRT ↑')).toBeTruthy()
+  })
+
+  it('shows DE ↓ ASS for embedded_ass', () => {
+    render(
+      <SubtitlePresencePills
+        existingSub="embedded_ass"
+        targetLanguage="de"
+        sourceLanguage="en"
+        embeddedLanguages={enAss}
+      />
+    )
+    expect(screen.getByText('DE ↓ ASS')).toBeTruthy()
+  })
+
+  it('shows embedded lang pill', () => {
+    render(
+      <SubtitlePresencePills
+        existingSub=""
+        targetLanguage="de"
+        sourceLanguage="en"
+        embeddedLanguages={enAss}
+      />
+    )
+    expect(screen.getByText('ENG ↓ ASS')).toBeTruthy()
+  })
+
+  it('shows +N button when more than 2 embedded', () => {
+    render(
+      <SubtitlePresencePills
+        existingSub=""
+        targetLanguage="de"
+        sourceLanguage="en"
+        embeddedLanguages={threeLangs}
+      />
+    )
+    expect(screen.getByText('+1 ▾')).toBeTruthy()
+  })
+
+  it('expands overflow on click', () => {
+    render(
+      <SubtitlePresencePills
+        existingSub=""
+        targetLanguage="de"
+        sourceLanguage="en"
+        embeddedLanguages={threeLangs}
+      />
+    )
+    const btn = screen.getByText('+1 ▾')
+    fireEvent.click(btn)
+    expect(screen.getByText('FRA ↓ SRT')).toBeTruthy()
+  })
+
+  it('sorts sourceLanguage first in right group', () => {
+    render(
+      <SubtitlePresencePills
+        existingSub=""
+        targetLanguage="de"
+        sourceLanguage="en"
+        embeddedLanguages={[{ lang: 'jpn', format: 'srt' }, { lang: 'eng', format: 'ass' }]}
+      />
+    )
+    const pills = document.querySelectorAll('[data-testid="embedded-pill"]')
+    expect(pills[0].textContent).toBe('ENG ↓ ASS')
+    expect(pills[1].textContent).toBe('JPN ↓ SRT')
+  })
+})
+```
+
+- [ ] **Step 2: Run tests — verify they fail**
+
+```bash
+cd frontend && npm run test -- --run --reporter=verbose src/test/SubtitlePresencePills.test.tsx
+```
+Expected: FAIL — component not found.
+
+- [ ] **Step 3: Create `SubtitlePresencePills.tsx`**
+
+Create `frontend/src/pages/wanted/SubtitlePresencePills.tsx`:
+
+```tsx
+import { useState } from 'react'
+
+interface EmbeddedLang {
+  lang: string
+  format: string
+}
+
+interface SubtitlePresencePillsProps {
+  existingSub: string
+  targetLanguage: string
+  sourceLanguage: string
+  embeddedLanguages: EmbeddedLang[]
+}
+
+const PILL_BASE: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  padding: '2px 6px',
+  borderRadius: 4,
+  fontSize: 10,
+  fontWeight: 700,
+  fontFamily: 'var(--font-mono)',
+  whiteSpace: 'nowrap',
+  border: '1px solid',
+}
+
+const PILL_MISS: React.CSSProperties = {
+  ...PILL_BASE,
+  background: 'rgba(239,68,68,0.1)',
+  color: '#ef4444',
+  borderColor: 'rgba(239,68,68,0.2)',
+}
+
+const PILL_SRT: React.CSSProperties = {
+  ...PILL_BASE,
+  background: 'rgba(234,179,8,0.12)',
+  color: '#eab308',
+  borderColor: 'rgba(234,179,8,0.25)',
+}
+
+const PILL_EMB: React.CSSProperties = {
+  ...PILL_BASE,
+  background: 'rgba(16,185,129,0.12)',
+  color: '#10b981',
+  borderColor: 'rgba(16,185,129,0.25)',
+}
+
+const PILL_OTHER: React.CSSProperties = {
+  ...PILL_BASE,
+  background: 'rgba(29,184,212,0.12)',
+  color: '#1db8d4',
+  borderColor: 'rgba(29,184,212,0.25)',
+}
+
+const PILL_NONE: React.CSSProperties = {
+  ...PILL_BASE,
+  background: 'rgba(255,255,255,0.04)',
+  color: 'var(--text-muted)',
+  borderColor: 'rgba(255,255,255,0.07)',
+  fontStyle: 'italic',
+}
+
+const INLINE_LIMIT = 2
+
+export function SubtitlePresencePills({
+  existingSub,
+  targetLanguage,
+  sourceLanguage,
+  embeddedLanguages,
+}: SubtitlePresencePillsProps) {
+  const [expanded, setExpanded] = useState(false)
+  const lang = targetLanguage.toUpperCase()
+
+  // Left pill — target language status
+  let leftPill: React.ReactNode
+  if (existingSub === 'embedded_ass') {
+    leftPill = <span style={PILL_EMB}>{lang} ↓ ASS</span>
+  } else if (existingSub === 'embedded_srt') {
+    leftPill = <span style={PILL_EMB}>{lang} ↓ SRT</span>
+  } else if (existingSub === 'ass') {
+    leftPill = <span style={PILL_EMB}>{lang} ASS</span>
+  } else if (existingSub === 'srt') {
+    leftPill = <span style={PILL_SRT}>{lang} SRT ↑</span>
+  } else {
+    leftPill = <span style={PILL_MISS}>{lang} ✗</span>
+  }
+
+  // Right group — sort sourceLanguage first, then alphabetically
+  const sorted = [...embeddedLanguages].sort((a, b) => {
+    const aIsSource = a.lang === sourceLanguage || a.lang.startsWith(sourceLanguage)
+    const bIsSource = b.lang === sourceLanguage || b.lang.startsWith(sourceLanguage)
+    if (aIsSource && !bIsSource) return -1
+    if (!aIsSource && bIsSource) return 1
+    return a.lang.localeCompare(b.lang)
+  })
+
+  const inline = sorted.slice(0, INLINE_LIMIT)
+  const overflow = sorted.slice(INLINE_LIMIT)
+
+  const rightContent =
+    embeddedLanguages.length === 0 ? (
+      <span style={PILL_NONE}>Kein Sub</span>
+    ) : (
+      inline.map((e, i) => (
+        <span key={i} data-testid="embedded-pill" style={PILL_OTHER}>
+          {e.lang.toUpperCase()} ↓ {e.format.toUpperCase()}
+        </span>
+      ))
+    )
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 4, flexWrap: 'wrap' }}>
+      {leftPill}
+      <span
+        style={{ width: 1, height: 14, background: 'var(--border)', margin: '0 2px', flexShrink: 0 }}
+      />
+      {rightContent}
+      {overflow.length > 0 && (
+        <>
+          <button
+            onClick={() => setExpanded((e) => !e)}
+            style={{
+              ...PILL_BASE,
+              background: 'rgba(255,255,255,0.06)',
+              color: 'var(--text-muted)',
+              borderColor: 'rgba(255,255,255,0.1)',
+              cursor: 'pointer',
+            }}
+          >
+            +{overflow.length} {expanded ? '▲' : '▾'}
+          </button>
+          {expanded && (
+            <div
+              style={{
+                width: '100%',
+                display: 'flex',
+                gap: 4,
+                flexWrap: 'wrap',
+                marginTop: 4,
+                padding: '6px 8px',
+                background: 'var(--bg-surface)',
+                borderRadius: 4,
+                border: '1px solid var(--border)',
+              }}
+            >
+              {overflow.map((e, i) => (
+                <span key={i} data-testid="embedded-pill" style={PILL_OTHER}>
+                  {e.lang.toUpperCase()} ↓ {e.format.toUpperCase()}
+                </span>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Run tests — verify they pass**
+
+```bash
+cd frontend && npm run test -- --run --reporter=verbose src/test/SubtitlePresencePills.test.tsx
+```
+Expected: all 8 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/wanted/SubtitlePresencePills.tsx frontend/src/test/SubtitlePresencePills.test.tsx
+git commit -m "feat: add SubtitlePresencePills component"
+```
+
+---
+
+## Task 7: Wire `SubtitlePresencePills` into `WantedTableRow`
+
+**Files:**
+- Modify: `frontend/src/pages/wanted/WantedTableRow.tsx`
+
+- [ ] **Step 1: Add `sourceLanguage` prop to `WantedTableRowProps`**
+
+In `frontend/src/pages/wanted/WantedTableRow.tsx`, find the `WantedTableRowProps` interface (line 160). Add:
+
+```ts
+  sourceLanguage: string
+```
+
+Also add `sourceLanguage` to the destructured props in the `WantedTableRow` function signature.
+
+- [ ] **Step 2: Add import for `SubtitlePresencePills`**
+
+At the top of `WantedTableRow.tsx`, add:
+
+```ts
+import { SubtitlePresencePills } from '@/pages/wanted/SubtitlePresencePills'
+```
+
+- [ ] **Step 3: Replace existing_sub cell with `SubtitlePresencePills`**
+
+Find the cell that currently renders the existing_sub text (around line 296-319):
+
+```tsx
+<td className="px-3 py-2.5 hidden sm:table-cell">
+  <div className="flex items-center gap-1.5">
+    <span
+      className="text-xs uppercase"
+      style={{
+        fontFamily: 'var(--font-mono)',
+        color: item.existing_sub === 'srt' ? 'var(--warning)' : 'var(--text-muted)',
+      }}
+    >
+      {item.existing_sub || 'none'}
+    </span>
+    {item.upgrade_candidate === 1 && (
+      <span
+        className="text-[9px] px-1 py-0.5 rounded font-bold uppercase"
+        style={{
+          backgroundColor: 'rgba(16,185,129,0.1)',
+          color: 'var(--success)',
+        }}
+      >
+        SRT&rarr;ASS
+      </span>
+    )}
+  </div>
+</td>
+```
+
+Replace the entire `<td>` with:
+
+```tsx
+<td className="px-3 py-2.5 hidden sm:table-cell">
+  <SubtitlePresencePills
+    existingSub={item.existing_sub}
+    targetLanguage={item.target_language}
+    sourceLanguage={sourceLanguage}
+    embeddedLanguages={item.embedded_languages ?? []}
+  />
+</td>
+```
+
+- [ ] **Step 4: Run TypeScript check**
+
+```bash
+cd frontend && npx tsc --noEmit
+```
+Expected: no errors (TypeScript will flag missing `sourceLanguage` prop in `Wanted.tsx` — fix in Task 8).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/wanted/WantedTableRow.tsx
+git commit -m "feat: replace existing_sub text with SubtitlePresencePills in WantedTableRow"
+```
+
+---
+
+## Task 8: Pass `sourceLanguage` from `Wanted.tsx`
+
+**Files:**
+- Modify: `frontend/src/pages/Wanted.tsx`
+
+- [ ] **Step 1: Add config query to `Wanted.tsx`**
+
+In `frontend/src/pages/Wanted.tsx`, find the imports section. Add:
+
+```ts
+import { useQuery } from '@tanstack/react-query'
+import { getConfig } from '@/api/settings'
+```
+
+(`useQuery` is likely already imported — check first and skip if so.)
+
+- [ ] **Step 2: Add the query inside the component**
+
+In the `Wanted` component function body, add the config query near the top with other queries:
+
+```ts
+const { data: config } = useQuery({ queryKey: ['config'], queryFn: getConfig })
+const sourceLanguage = config?.source_language ?? 'en'
+```
+
+- [ ] **Step 3: Pass `sourceLanguage` to every `WantedTableRow`**
+
+Find all `<WantedTableRow` usages in `Wanted.tsx` and add the prop:
+
+```tsx
+<WantedTableRow
+  ...
+  sourceLanguage={sourceLanguage}
+/>
+```
+
+- [ ] **Step 4: Run full frontend checks**
+
+```bash
+cd frontend && npx tsc --noEmit && npm run lint && npm run test -- --run
+```
+Expected: no errors, all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/Wanted.tsx
+git commit -m "feat: fetch source_language from config and pass to SubtitlePresencePills"
+```
+
+---
+
+## Task 9: Manual smoke test
+
+- [ ] **Step 1: Start dev server**
+
+```bash
+npm run dev
+```
+
+- [ ] **Step 2: Open Wanted page**
+
+Navigate to `http://localhost:5173/wanted`.
+
+Check:
+- Column header now reads "Untertitel" (DE) or "Subtitles" (EN)
+- Items with no embedded subs show `DE ✗ | Kein Sub`
+- Items with EN ASS embedded show `DE ✗ | ENG ↓ ASS`
+- Items with DE SRT sidecar show `DE SRT ↑ | ...`
+- Items with 3+ embedded langs show `+N ▾` button that expands on click
+
+- [ ] **Step 3: Trigger a wanted scan** (or use "Eingebettet scannen") to populate `embedded_languages` for existing items.
+
+- [ ] **Step 4: Final pre-PR checks**
+
+```bash
+cd backend && ruff check . && ruff format --check .
+cd backend && python -m pytest --tb=short -q \
+  --ignore=tests/performance \
+  --ignore=tests/integration/test_provider_pipeline.py \
+  --ignore=tests/test_video_sdk.py \
+  --ignore=tests/test_translation_backends.py \
+  -k "not (test_sonarr_download_webhook or test_radarr_download_webhook or test_parse_llm_response_too_many_merge or test_record_backend_success)"
+cd frontend && npm run lint && npx tsc --noEmit && npm run test -- --run
+```
+Expected: all green.

--- a/docs/superpowers/specs/2026-04-04-wanted-subtitle-presence-pills-design.md
+++ b/docs/superpowers/specs/2026-04-04-wanted-subtitle-presence-pills-design.md
@@ -42,7 +42,7 @@ The language code matches the row's `target_language` field.
 | `Kein Sub` | Nothing embedded at all | Muted grey |
 | `+N ▾` | More than 2 additional embedded languages — opens inline dropdown | Muted grey |
 
-The right group shows embedded streams sorted by: configured second-priority language first (e.g. EN), then others alphabetically. Up to 2 pills are shown inline; additional ones collapse into a `+N ▾` dropdown that expands below the cell on click.
+The right group shows embedded streams sorted by: `source_language` (existing config field, e.g. "en") first, then others alphabetically. Up to 2 pills are shown inline; additional ones collapse into a `+N ▾` dropdown that expands below the cell on click.
 
 ### Examples
 
@@ -95,21 +95,27 @@ Props:
 interface SubtitlePresencePillsProps {
   existingSub: string          // current field: '', 'srt', 'ass', 'embedded_srt', 'embedded_ass'
   targetLanguage: string       // e.g. 'de'
+  sourceLanguage: string       // e.g. 'en' — from global settings, used for sort priority
   embeddedLanguages: Array<{ lang: string; format: string }>
 }
 ```
 
 Logic:
 - Left pill derived from `existingSub` + `targetLanguage`.
-- Right pills derived from `embeddedLanguages`, sorted with EN first (hardcoded priority — no second-priority concept exists in Sublarr currently), others alphabetically.
+- Right pills derived from `embeddedLanguages`, sorted with `sourceLanguage` first, others alphabetically.
 - First 2 right pills shown inline; remainder behind `+N ▾` toggle.
 - Toggle state is local (`useState`) — no global state needed.
+- `sourceLanguage` is read from the existing `useSettings()` hook (or passed down from the page) — no new API call needed.
 
 **`WantedTableRow.tsx` changes**
 
 - Replace the `existing_sub` text span + `upgrade_candidate` badge with `<SubtitlePresencePills />`.
-- Pass the new `embedded_languages` field from `WantedItem`.
+- Pass `embedded_languages` from `WantedItem` and `source_language` from settings.
 - `WantedItem` interface gains `embedded_languages: Array<{ lang: string; format: string }>`.
+
+**Settings integration**
+
+`source_language` already exists in Sublarr config (`config.py`, default `"en"`). The Wanted page reads it via the existing settings API/hook and passes it to `SubtitlePresencePills` as `sourceLanguage`. No new setting or API endpoint required.
 
 **i18n**
 

--- a/docs/superpowers/specs/2026-04-04-wanted-subtitle-presence-pills-design.md
+++ b/docs/superpowers/specs/2026-04-04-wanted-subtitle-presence-pills-design.md
@@ -1,0 +1,124 @@
+# Wanted Page — Subtitle Presence Pills
+
+**Date:** 2026-04-04  
+**Status:** Approved  
+
+## Problem
+
+The "Vorhanden" column in the Wanted page only shows the target-language subtitle status (`none`, `srt`, `ass`, `embedded_ass`, `embedded_srt`) as plain text. This is misleading because:
+
+1. "NONE" implies no subtitle exists at all — but the video file may have embedded subtitles in other languages (e.g. EN ASS in an anime MKV).
+2. Users with multiple target languages (e.g. DE + EN) cannot tell from the column which target language a given row refers to.
+3. The column name "Vorhanden" (Available) sounds like a general subtitle presence check, not a target-language-specific one.
+
+## Solution
+
+Replace the text display with a **pill-based component** that communicates both the target-language status and available embedded languages in a compact, scannable format.
+
+## Visual Design
+
+The column is renamed to **"Untertitel"** and displays two pill groups separated by a thin vertical divider:
+
+```
+[ DE ✗ ] | [ EN ↓ ASS ]  [ +2 ▾ ]
+ └─ left ┘   └──────── right ────────┘
+```
+
+### Left group — Target language status (always 1 pill)
+
+| Pill | Condition | Color |
+|------|-----------|-------|
+| `DE ✗` | No target-language sub exists | Red |
+| `DE SRT ↑` | SRT sidecar exists, ASS upgrade possible | Yellow |
+| `DE ↓ ASS` | Target language embedded, extractable | Green |
+
+The language code matches the row's `target_language` field.
+
+### Right group — Embedded languages
+
+| Pill | Condition | Color |
+|------|-----------|-------|
+| `EN ↓ ASS` | Another language embedded in the video file | Cyan |
+| `Kein Sub` | Nothing embedded at all | Muted grey |
+| `+N ▾` | More than 2 additional embedded languages — opens inline dropdown | Muted grey |
+
+The right group shows embedded streams sorted by: configured second-priority language first (e.g. EN), then others alphabetically. Up to 2 pills are shown inline; additional ones collapse into a `+N ▾` dropdown that expands below the cell on click.
+
+### Examples
+
+| Scenario | Pills |
+|----------|-------|
+| DE missing, EN embedded | `DE ✗` \| `EN ↓ ASS` |
+| DE missing, nothing embedded | `DE ✗` \| `Kein Sub` |
+| DE SRT sidecar, EN+JA+FR embedded | `DE SRT ↑` \| `EN ↓ ASS` `+2 ▾` |
+| DE ASS embedded (extractable), EN embedded | `DE ↓ ASS` \| `EN ↓ ASS` |
+| Multiple targets: DE row, JA embedded | `DE ✗` \| `JA ↓ ASS` |
+| Multiple targets: EN row, JA embedded | `EN ✗` \| `JA ↓ ASS` |
+
+## Architecture
+
+### Backend
+
+**New field: `embedded_languages`**
+
+Added to the `wanted_items` DB table and returned by the Wanted API:
+
+```python
+embedded_languages: list[dict]  # e.g. [{"lang": "en", "format": "ass"}, {"lang": "ja", "format": "srt"}]
+```
+
+Stored as JSON in a new `embedded_languages` TEXT column (default `"[]"`).
+
+**Scanner changes (`wanted_scanner_core.py`)**
+
+Currently `has_target_language_stream()` is called to check only the target language stream. New behaviour:
+- After `get_media_streams()`, call a new helper `get_all_subtitle_streams(probe_data)` that returns all subtitle streams as `list[{lang, format}]`.
+- Exclude the target language from this list (it is already represented in `existing_sub`).
+- Store the result in `embedded_languages` when inserting or updating a wanted item.
+
+**Migration**
+
+New Alembic migration: add `embedded_languages TEXT NOT NULL DEFAULT '[]'` to `wanted_items`.
+
+**API**
+
+The existing Wanted list endpoint already serialises all `wanted_items` fields. Adding `embedded_languages` to the serialisation is sufficient — no route changes needed.
+
+### Frontend
+
+**New component: `SubtitlePresencePills`**
+
+Located in `frontend/src/pages/wanted/SubtitlePresencePills.tsx`.
+
+Props:
+```ts
+interface SubtitlePresencePillsProps {
+  existingSub: string          // current field: '', 'srt', 'ass', 'embedded_srt', 'embedded_ass'
+  targetLanguage: string       // e.g. 'de'
+  embeddedLanguages: Array<{ lang: string; format: string }>
+}
+```
+
+Logic:
+- Left pill derived from `existingSub` + `targetLanguage`.
+- Right pills derived from `embeddedLanguages`, sorted with EN first (hardcoded priority — no second-priority concept exists in Sublarr currently), others alphabetically.
+- First 2 right pills shown inline; remainder behind `+N ▾` toggle.
+- Toggle state is local (`useState`) — no global state needed.
+
+**`WantedTableRow.tsx` changes**
+
+- Replace the `existing_sub` text span + `upgrade_candidate` badge with `<SubtitlePresencePills />`.
+- Pass the new `embedded_languages` field from `WantedItem`.
+- `WantedItem` interface gains `embedded_languages: Array<{ lang: string; format: string }>`.
+
+**i18n**
+
+- `de/library.json`: rename `existing_col` value from `"Vorhanden"` to `"Untertitel"`.
+- `en/library.json`: same key → `"Subtitles"`.
+
+## Out of scope
+
+- Showing embedded language info anywhere other than the Wanted page.
+- Changing how `existing_sub` itself is derived — it remains the target-language-only status field.
+- Sorting or filtering the Wanted list by embedded language.
+- Persisting which embedded languages the user has expanded in the dropdown.

--- a/frontend/src/api/core.ts
+++ b/frontend/src/api/core.ts
@@ -37,6 +37,9 @@ api.interceptors.response.use(
           source_language: 'en', target_language: 'de', media_path: '/media', port: 5765, log_level: 'INFO'
         } })
       }
+      if (url.includes('/providers/stats')) {
+        return Promise.resolve({ data: { cache: {} } })
+      }
       if (url.includes('/providers')) {
         return Promise.resolve({ data: {
           providers: [

--- a/frontend/src/i18n/locales/de/library.json
+++ b/frontend/src/i18n/locales/de/library.json
@@ -61,7 +61,7 @@
     "title_col": "Titel",
     "se_col": "S/E",
     "status_col": "Status",
-    "existing_col": "Vorhanden",
+    "existing_col": "Untertitel",
     "searches_col": "Suchen",
     "last_search_col": "Letzte Suche",
     "added_col": "Hinzugefügt",

--- a/frontend/src/i18n/locales/en/library.json
+++ b/frontend/src/i18n/locales/en/library.json
@@ -61,7 +61,7 @@
     "title_col": "Title",
     "se_col": "S/E",
     "status_col": "Status",
-    "existing_col": "Existing",
+    "existing_col": "Subtitles",
     "searches_col": "Searches",
     "last_search_col": "Last Search",
     "added_col": "Added",

--- a/frontend/src/pages/Wanted.tsx
+++ b/frontend/src/pages/Wanted.tsx
@@ -19,7 +19,8 @@ import type { FilterDef, ActiveFilter } from '@/components/filters/FilterBar'
 import { BatchActionBar } from '@/components/batch/BatchActionBar'
 import { useSelectionStore } from '@/stores/selectionStore'
 import { useWebSocket } from '@/hooks/useWebSocket'
-import { useQueryClient } from '@tanstack/react-query'
+import { useQueryClient, useQuery } from '@tanstack/react-query'
+import { getConfig } from '@/api/settings'
 import { WantedToolbar } from './wanted/WantedToolbar'
 import { WantedFilterPanel } from './wanted/WantedFilterPanel'
 import { WantedTableRow } from './wanted/WantedTableRow'
@@ -114,6 +115,8 @@ export function WantedPage() {
   const selectAll = useSelectionStore((s) => s.selectAll)
   const clearSelection = useSelectionStore((s) => s.clearSelection)
   const isSelected = useCallback((id: number) => (scopeSelections ?? new Set()).has(id), [scopeSelections])
+  const { data: config } = useQuery({ queryKey: ['config'], queryFn: getConfig })
+  const sourceLanguage = (config?.source_language as string | undefined) ?? 'en'
   const { data: summary } = useWantedSummary()
   const {
     data: wanted,
@@ -526,6 +529,7 @@ export function WantedPage() {
                       itemIndex={i}
                       isSelected={isSelected(item.id)}
                       expandedItem={expandedItem}
+                      sourceLanguage={sourceLanguage}
                       searchingItems={searchingItems}
                       searchResults={searchResults}
                       extractingItemId={extractingItemId}

--- a/frontend/src/pages/__tests__/Wanted.toolbar.test.tsx
+++ b/frontend/src/pages/__tests__/Wanted.toolbar.test.tsx
@@ -48,7 +48,16 @@ vi.mock('@/hooks/useWebSocket', () => ({
 
 vi.mock('@tanstack/react-query', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@tanstack/react-query')>()
-  return { ...actual, useQueryClient: () => ({ invalidateQueries: vi.fn() }) }
+  return {
+    ...actual,
+    useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+    useQuery: ({ queryKey }: { queryKey: unknown[] }) => {
+      if (Array.isArray(queryKey) && queryKey[0] === 'config') {
+        return { data: { source_language: 'en' } }
+      }
+      return { data: undefined }
+    },
+  }
 })
 
 vi.mock('@/components/wanted/VirtualWantedTable', () => ({

--- a/frontend/src/pages/wanted/SubtitlePresencePills.tsx
+++ b/frontend/src/pages/wanted/SubtitlePresencePills.tsx
@@ -11,6 +11,7 @@ interface SubtitlePresencePillsProps {
   targetLanguage: string
   sourceLanguage: string
   embeddedLanguages: EmbeddedLang[]
+  upgradeCandidate?: boolean
 }
 
 const PILL_BASE: CSSProperties = {
@@ -63,11 +64,19 @@ const PILL_NONE: CSSProperties = {
 
 const INLINE_LIMIT = 2
 
+// Map ISO 639-1 (2-letter, from Sublarr config) to ISO 639-2 (3-letter, from ffprobe tags)
+const ISO1_TO_ISO2: Record<string, string> = {
+  ar: 'ara', de: 'deu', en: 'eng', es: 'spa', fr: 'fra', it: 'ita',
+  ja: 'jpn', ko: 'kor', nl: 'nld', no: 'nor', pl: 'pol', pt: 'por',
+  ru: 'rus', sv: 'swe', tr: 'tur', zh: 'chi',
+}
+
 export function SubtitlePresencePills({
   existingSub,
   targetLanguage,
   sourceLanguage,
   embeddedLanguages,
+  upgradeCandidate = false,
 }: SubtitlePresencePillsProps) {
   const [expanded, setExpanded] = useState(false)
   const lang = targetLanguage.toUpperCase()
@@ -81,15 +90,16 @@ export function SubtitlePresencePills({
   } else if (existingSub === 'ass') {
     leftPill = <span style={PILL_EMB}>{lang} ASS</span>
   } else if (existingSub === 'srt') {
-    leftPill = <span style={PILL_SRT}>{lang} SRT ↑</span>
+    leftPill = <span style={PILL_SRT}>{lang} SRT{upgradeCandidate ? ' ↑' : ''}</span>
   } else {
     leftPill = <span style={PILL_MISS}>{lang} ✗</span>
   }
 
   // Right group — sort sourceLanguage first, then alphabetically
+  const sourceLang3 = ISO1_TO_ISO2[sourceLanguage] ?? sourceLanguage
   const sorted = [...embeddedLanguages].sort((a, b) => {
-    const aIsSource = a.lang === sourceLanguage || a.lang.startsWith(sourceLanguage)
-    const bIsSource = b.lang === sourceLanguage || b.lang.startsWith(sourceLanguage)
+    const aIsSource = a.lang === sourceLanguage || a.lang === sourceLang3
+    const bIsSource = b.lang === sourceLanguage || b.lang === sourceLang3
     if (aIsSource && !bIsSource) return -1
     if (!aIsSource && bIsSource) return 1
     return a.lang.localeCompare(b.lang)

--- a/frontend/src/pages/wanted/SubtitlePresencePills.tsx
+++ b/frontend/src/pages/wanted/SubtitlePresencePills.tsx
@@ -1,0 +1,157 @@
+import { useState } from 'react'
+
+interface EmbeddedLang {
+  lang: string
+  format: string
+}
+
+interface SubtitlePresencePillsProps {
+  existingSub: string
+  targetLanguage: string
+  sourceLanguage: string
+  embeddedLanguages: EmbeddedLang[]
+}
+
+const PILL_BASE: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  padding: '2px 6px',
+  borderRadius: 4,
+  fontSize: 10,
+  fontWeight: 700,
+  fontFamily: 'var(--font-mono)',
+  whiteSpace: 'nowrap',
+  border: '1px solid',
+}
+
+const PILL_MISS: React.CSSProperties = {
+  ...PILL_BASE,
+  background: 'rgba(239,68,68,0.1)',
+  color: '#ef4444',
+  borderColor: 'rgba(239,68,68,0.2)',
+}
+
+const PILL_SRT: React.CSSProperties = {
+  ...PILL_BASE,
+  background: 'rgba(234,179,8,0.12)',
+  color: '#eab308',
+  borderColor: 'rgba(234,179,8,0.25)',
+}
+
+const PILL_EMB: React.CSSProperties = {
+  ...PILL_BASE,
+  background: 'rgba(16,185,129,0.12)',
+  color: '#10b981',
+  borderColor: 'rgba(16,185,129,0.25)',
+}
+
+const PILL_OTHER: React.CSSProperties = {
+  ...PILL_BASE,
+  background: 'rgba(29,184,212,0.12)',
+  color: '#1db8d4',
+  borderColor: 'rgba(29,184,212,0.25)',
+}
+
+const PILL_NONE: React.CSSProperties = {
+  ...PILL_BASE,
+  background: 'rgba(255,255,255,0.04)',
+  color: 'var(--text-muted)',
+  borderColor: 'rgba(255,255,255,0.07)',
+  fontStyle: 'italic',
+}
+
+const INLINE_LIMIT = 2
+
+export function SubtitlePresencePills({
+  existingSub,
+  targetLanguage,
+  sourceLanguage,
+  embeddedLanguages,
+}: SubtitlePresencePillsProps) {
+  const [expanded, setExpanded] = useState(false)
+  const lang = targetLanguage.toUpperCase()
+
+  // Left pill — target language status
+  let leftPill: React.ReactNode
+  if (existingSub === 'embedded_ass') {
+    leftPill = <span style={PILL_EMB}>{lang} ↓ ASS</span>
+  } else if (existingSub === 'embedded_srt') {
+    leftPill = <span style={PILL_EMB}>{lang} ↓ SRT</span>
+  } else if (existingSub === 'ass') {
+    leftPill = <span style={PILL_EMB}>{lang} ASS</span>
+  } else if (existingSub === 'srt') {
+    leftPill = <span style={PILL_SRT}>{lang} SRT ↑</span>
+  } else {
+    leftPill = <span style={PILL_MISS}>{lang} ✗</span>
+  }
+
+  // Right group — sort sourceLanguage first, then alphabetically
+  const sorted = [...embeddedLanguages].sort((a, b) => {
+    const aIsSource = a.lang === sourceLanguage || a.lang.startsWith(sourceLanguage)
+    const bIsSource = b.lang === sourceLanguage || b.lang.startsWith(sourceLanguage)
+    if (aIsSource && !bIsSource) return -1
+    if (!aIsSource && bIsSource) return 1
+    return a.lang.localeCompare(b.lang)
+  })
+
+  const inline = sorted.slice(0, INLINE_LIMIT)
+  const overflow = sorted.slice(INLINE_LIMIT)
+
+  const rightContent =
+    embeddedLanguages.length === 0 ? (
+      <span style={PILL_NONE}>Kein Sub</span>
+    ) : (
+      inline.map((e, i) => (
+        <span key={i} data-testid="embedded-pill" style={PILL_OTHER}>
+          {e.lang.toUpperCase()} ↓ {e.format.toUpperCase()}
+        </span>
+      ))
+    )
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 4, flexWrap: 'wrap' }}>
+      {leftPill}
+      <span
+        style={{ width: 1, height: 14, background: 'var(--border)', margin: '0 2px', flexShrink: 0 }}
+      />
+      {rightContent}
+      {overflow.length > 0 && (
+        <>
+          <button
+            onClick={() => setExpanded((e) => !e)}
+            style={{
+              ...PILL_BASE,
+              background: 'rgba(255,255,255,0.06)',
+              color: 'var(--text-muted)',
+              borderColor: 'rgba(255,255,255,0.1)',
+              cursor: 'pointer',
+            }}
+          >
+            +{overflow.length} {expanded ? '▲' : '▾'}
+          </button>
+          {expanded && (
+            <div
+              style={{
+                width: '100%',
+                display: 'flex',
+                gap: 4,
+                flexWrap: 'wrap',
+                marginTop: 4,
+                padding: '6px 8px',
+                background: 'var(--bg-surface)',
+                borderRadius: 4,
+                border: '1px solid var(--border)',
+              }}
+            >
+              {overflow.map((e, i) => (
+                <span key={i} data-testid="embedded-pill" style={PILL_OTHER}>
+                  {e.lang.toUpperCase()} ↓ {e.format.toUpperCase()}
+                </span>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/wanted/SubtitlePresencePills.tsx
+++ b/frontend/src/pages/wanted/SubtitlePresencePills.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import type { CSSProperties, ReactNode } from 'react'
 
 interface EmbeddedLang {
   lang: string
@@ -12,7 +13,7 @@ interface SubtitlePresencePillsProps {
   embeddedLanguages: EmbeddedLang[]
 }
 
-const PILL_BASE: React.CSSProperties = {
+const PILL_BASE: CSSProperties = {
   display: 'inline-flex',
   alignItems: 'center',
   padding: '2px 6px',
@@ -24,35 +25,35 @@ const PILL_BASE: React.CSSProperties = {
   border: '1px solid',
 }
 
-const PILL_MISS: React.CSSProperties = {
+const PILL_MISS: CSSProperties = {
   ...PILL_BASE,
   background: 'rgba(239,68,68,0.1)',
   color: '#ef4444',
   borderColor: 'rgba(239,68,68,0.2)',
 }
 
-const PILL_SRT: React.CSSProperties = {
+const PILL_SRT: CSSProperties = {
   ...PILL_BASE,
   background: 'rgba(234,179,8,0.12)',
   color: '#eab308',
   borderColor: 'rgba(234,179,8,0.25)',
 }
 
-const PILL_EMB: React.CSSProperties = {
+const PILL_EMB: CSSProperties = {
   ...PILL_BASE,
   background: 'rgba(16,185,129,0.12)',
   color: '#10b981',
   borderColor: 'rgba(16,185,129,0.25)',
 }
 
-const PILL_OTHER: React.CSSProperties = {
+const PILL_OTHER: CSSProperties = {
   ...PILL_BASE,
   background: 'rgba(29,184,212,0.12)',
   color: '#1db8d4',
   borderColor: 'rgba(29,184,212,0.25)',
 }
 
-const PILL_NONE: React.CSSProperties = {
+const PILL_NONE: CSSProperties = {
   ...PILL_BASE,
   background: 'rgba(255,255,255,0.04)',
   color: 'var(--text-muted)',
@@ -72,7 +73,7 @@ export function SubtitlePresencePills({
   const lang = targetLanguage.toUpperCase()
 
   // Left pill — target language status
-  let leftPill: React.ReactNode
+  let leftPill: ReactNode
   if (existingSub === 'embedded_ass') {
     leftPill = <span style={PILL_EMB}>{lang} ↓ ASS</span>
   } else if (existingSub === 'embedded_srt') {
@@ -101,8 +102,8 @@ export function SubtitlePresencePills({
     embeddedLanguages.length === 0 ? (
       <span style={PILL_NONE}>Kein Sub</span>
     ) : (
-      inline.map((e, i) => (
-        <span key={i} data-testid="embedded-pill" style={PILL_OTHER}>
+      inline.map((e) => (
+        <span key={e.lang} data-testid="embedded-pill" style={PILL_OTHER}>
           {e.lang.toUpperCase()} ↓ {e.format.toUpperCase()}
         </span>
       ))
@@ -143,8 +144,8 @@ export function SubtitlePresencePills({
                 border: '1px solid var(--border)',
               }}
             >
-              {overflow.map((e, i) => (
-                <span key={i} data-testid="embedded-pill" style={PILL_OTHER}>
+              {overflow.map((e) => (
+                <span key={e.lang} data-testid="embedded-pill" style={PILL_OTHER}>
                   {e.lang.toUpperCase()} ↓ {e.format.toUpperCase()}
                 </span>
               ))}

--- a/frontend/src/pages/wanted/WantedTableRow.tsx
+++ b/frontend/src/pages/wanted/WantedTableRow.tsx
@@ -303,6 +303,7 @@ export function WantedTableRow({
             targetLanguage={item.target_language}
             sourceLanguage={sourceLanguage}
             embeddedLanguages={item.embedded_languages ?? []}
+            upgradeCandidate={item.upgrade_candidate === 1}
           />
         </td>
         <td

--- a/frontend/src/pages/wanted/WantedTableRow.tsx
+++ b/frontend/src/pages/wanted/WantedTableRow.tsx
@@ -8,6 +8,7 @@ import { StatusBadge, SubtitleTypeBadge } from '@/components/shared/StatusBadge'
 import { formatRelativeTime, truncatePath } from '@/lib/utils'
 import { FailureReasonRow } from '@/pages/Wanted'
 import type { WantedSearchResponse } from '@/lib/types'
+import { SubtitlePresencePills } from '@/pages/wanted/SubtitlePresencePills'
 
 interface SearchResultsRowProps {
   results: WantedSearchResponse | null
@@ -146,6 +147,7 @@ export interface WantedItem {
   status: string
   season_episode: string | null
   existing_sub: string
+  embedded_languages: Array<{ lang: string; format: string }>
   target_language: string
   subtitle_type: string
   instance_name: string
@@ -162,6 +164,7 @@ export interface WantedTableRowProps {
   itemIndex: number
   isSelected: boolean
   expandedItem: number | null
+  sourceLanguage: string
   searchingItems: Set<number>
   searchResults: Record<number, WantedSearchResponse>
   extractingItemId: number | null
@@ -193,6 +196,7 @@ export function WantedTableRow({
   itemIndex,
   isSelected,
   expandedItem,
+  sourceLanguage,
   searchingItems,
   searchResults,
   extractingItemId,
@@ -294,28 +298,12 @@ export function WantedTableRow({
           </div>
         </td>
         <td className="px-3 py-2.5 hidden sm:table-cell">
-          <div className="flex items-center gap-1.5">
-            <span
-              className="text-xs uppercase"
-              style={{
-                fontFamily: 'var(--font-mono)',
-                color: item.existing_sub === 'srt' ? 'var(--warning)' : 'var(--text-muted)',
-              }}
-            >
-              {item.existing_sub || 'none'}
-            </span>
-            {item.upgrade_candidate === 1 && (
-              <span
-                className="text-[9px] px-1 py-0.5 rounded font-bold uppercase"
-                style={{
-                  backgroundColor: 'rgba(16,185,129,0.1)',
-                  color: 'var(--success)',
-                }}
-              >
-                SRT&rarr;ASS
-              </span>
-            )}
-          </div>
+          <SubtitlePresencePills
+            existingSub={item.existing_sub}
+            targetLanguage={item.target_language}
+            sourceLanguage={sourceLanguage}
+            embeddedLanguages={item.embedded_languages ?? []}
+          />
         </td>
         <td
           className="px-3 py-2.5 text-xs tabular-nums hidden md:table-cell"

--- a/frontend/src/test/SubtitlePresencePills.test.tsx
+++ b/frontend/src/test/SubtitlePresencePills.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { SubtitlePresencePills } from '@/pages/wanted/SubtitlePresencePills'
+
+const noEmbedded: Array<{ lang: string; format: string }> = []
+const enAss = [{ lang: 'eng', format: 'ass' }]
+const enAssJaSrt = [{ lang: 'eng', format: 'ass' }, { lang: 'jpn', format: 'srt' }]
+const threeLangs = [
+  { lang: 'eng', format: 'ass' },
+  { lang: 'jpn', format: 'srt' },
+  { lang: 'fra', format: 'srt' },
+]
+
+describe('SubtitlePresencePills', () => {
+  it('shows DE ✗ when existingSub is empty', () => {
+    render(
+      <SubtitlePresencePills
+        existingSub=""
+        targetLanguage="de"
+        sourceLanguage="en"
+        embeddedLanguages={noEmbedded}
+      />
+    )
+    expect(screen.getByText('DE ✗')).toBeTruthy()
+  })
+
+  it('shows Kein Sub when nothing embedded', () => {
+    render(
+      <SubtitlePresencePills
+        existingSub=""
+        targetLanguage="de"
+        sourceLanguage="en"
+        embeddedLanguages={noEmbedded}
+      />
+    )
+    expect(screen.getByText('Kein Sub')).toBeTruthy()
+  })
+
+  it('shows DE SRT ↑ for srt existing_sub', () => {
+    render(
+      <SubtitlePresencePills
+        existingSub="srt"
+        targetLanguage="de"
+        sourceLanguage="en"
+        embeddedLanguages={enAss}
+      />
+    )
+    expect(screen.getByText('DE SRT ↑')).toBeTruthy()
+  })
+
+  it('shows DE ↓ ASS for embedded_ass', () => {
+    render(
+      <SubtitlePresencePills
+        existingSub="embedded_ass"
+        targetLanguage="de"
+        sourceLanguage="en"
+        embeddedLanguages={enAss}
+      />
+    )
+    expect(screen.getByText('DE ↓ ASS')).toBeTruthy()
+  })
+
+  it('shows embedded lang pill', () => {
+    render(
+      <SubtitlePresencePills
+        existingSub=""
+        targetLanguage="de"
+        sourceLanguage="en"
+        embeddedLanguages={enAss}
+      />
+    )
+    expect(screen.getByText('ENG ↓ ASS')).toBeTruthy()
+  })
+
+  it('shows +N button when more than 2 embedded', () => {
+    render(
+      <SubtitlePresencePills
+        existingSub=""
+        targetLanguage="de"
+        sourceLanguage="en"
+        embeddedLanguages={threeLangs}
+      />
+    )
+    expect(screen.getByText('+1 ▾')).toBeTruthy()
+  })
+
+  it('expands overflow on click', () => {
+    render(
+      <SubtitlePresencePills
+        existingSub=""
+        targetLanguage="de"
+        sourceLanguage="en"
+        embeddedLanguages={threeLangs}
+      />
+    )
+    const btn = screen.getByText('+1 ▾')
+    fireEvent.click(btn)
+    expect(screen.getByText('FRA ↓ SRT')).toBeTruthy()
+  })
+
+  it('sorts sourceLanguage first in right group', () => {
+    render(
+      <SubtitlePresencePills
+        existingSub=""
+        targetLanguage="de"
+        sourceLanguage="en"
+        embeddedLanguages={[{ lang: 'jpn', format: 'srt' }, { lang: 'eng', format: 'ass' }]}
+      />
+    )
+    const pills = document.querySelectorAll('[data-testid="embedded-pill"]')
+    expect(pills[0].textContent).toBe('ENG ↓ ASS')
+    expect(pills[1].textContent).toBe('JPN ↓ SRT')
+  })
+})

--- a/frontend/src/test/SubtitlePresencePills.test.tsx
+++ b/frontend/src/test/SubtitlePresencePills.test.tsx
@@ -36,13 +36,14 @@ describe('SubtitlePresencePills', () => {
     expect(screen.getByText('Kein Sub')).toBeTruthy()
   })
 
-  it('shows DE SRT ↑ for srt existing_sub', () => {
+  it('shows DE SRT ↑ for srt existing_sub when upgrade enabled', () => {
     render(
       <SubtitlePresencePills
         existingSub="srt"
         targetLanguage="de"
         sourceLanguage="en"
         embeddedLanguages={enAss}
+        upgradeCandidate={true}
       />
     )
     expect(screen.getByText('DE SRT ↑')).toBeTruthy()
@@ -122,7 +123,21 @@ describe('SubtitlePresencePills', () => {
     expect(screen.getByText('FRA ↓ SRT')).toBeTruthy()
   })
 
-  it('sorts sourceLanguage first in right group', () => {
+  it('sorts sourceLanguage first in right group (ISO 639-1 to 639-2 mapping)', () => {
+    render(
+      <SubtitlePresencePills
+        existingSub=""
+        targetLanguage="de"
+        sourceLanguage="es"
+        embeddedLanguages={[{ lang: 'jpn', format: 'srt' }, { lang: 'spa', format: 'ass' }]}
+      />
+    )
+    const pills = document.querySelectorAll('[data-testid="embedded-pill"]')
+    expect(pills[0].textContent).toBe('SPA ↓ ASS')
+    expect(pills[1].textContent).toBe('JPN ↓ SRT')
+  })
+
+  it('sorts eng first when sourceLanguage is en', () => {
     render(
       <SubtitlePresencePills
         existingSub=""
@@ -134,5 +149,31 @@ describe('SubtitlePresencePills', () => {
     const pills = document.querySelectorAll('[data-testid="embedded-pill"]')
     expect(pills[0].textContent).toBe('ENG ↓ ASS')
     expect(pills[1].textContent).toBe('JPN ↓ SRT')
+  })
+
+  it('shows SRT without arrow when upgrade is disabled', () => {
+    render(
+      <SubtitlePresencePills
+        existingSub="srt"
+        targetLanguage="de"
+        sourceLanguage="en"
+        embeddedLanguages={noEmbedded}
+        upgradeCandidate={false}
+      />
+    )
+    expect(screen.getByText('DE SRT')).toBeTruthy()
+  })
+
+  it('shows SRT ↑ when upgrade is enabled', () => {
+    render(
+      <SubtitlePresencePills
+        existingSub="srt"
+        targetLanguage="de"
+        sourceLanguage="en"
+        embeddedLanguages={noEmbedded}
+        upgradeCandidate={true}
+      />
+    )
+    expect(screen.getByText('DE SRT ↑')).toBeTruthy()
   })
 })

--- a/frontend/src/test/SubtitlePresencePills.test.tsx
+++ b/frontend/src/test/SubtitlePresencePills.test.tsx
@@ -4,7 +4,7 @@ import { SubtitlePresencePills } from '@/pages/wanted/SubtitlePresencePills'
 
 const noEmbedded: Array<{ lang: string; format: string }> = []
 const enAss = [{ lang: 'eng', format: 'ass' }]
-const enAssJaSrt = [{ lang: 'eng', format: 'ass' }, { lang: 'jpn', format: 'srt' }]
+const _enAssJaSrt = [{ lang: 'eng', format: 'ass' }, { lang: 'jpn', format: 'srt' }]
 const threeLangs = [
   { lang: 'eng', format: 'ass' },
   { lang: 'jpn', format: 'srt' },

--- a/frontend/src/test/SubtitlePresencePills.test.tsx
+++ b/frontend/src/test/SubtitlePresencePills.test.tsx
@@ -60,6 +60,30 @@ describe('SubtitlePresencePills', () => {
     expect(screen.getByText('DE ↓ ASS')).toBeTruthy()
   })
 
+  it('shows DE ↓ SRT for embedded_srt', () => {
+    render(
+      <SubtitlePresencePills
+        existingSub="embedded_srt"
+        targetLanguage="de"
+        sourceLanguage="en"
+        embeddedLanguages={noEmbedded}
+      />
+    )
+    expect(screen.getByText('DE ↓ SRT')).toBeTruthy()
+  })
+
+  it('shows DE ASS for ass sidecar existing_sub', () => {
+    render(
+      <SubtitlePresencePills
+        existingSub="ass"
+        targetLanguage="de"
+        sourceLanguage="en"
+        embeddedLanguages={noEmbedded}
+      />
+    )
+    expect(screen.getByText('DE ASS')).toBeTruthy()
+  })
+
   it('shows embedded lang pill', () => {
     render(
       <SubtitlePresencePills

--- a/frontend/src/types/wanted.ts
+++ b/frontend/src/types/wanted.ts
@@ -10,6 +10,7 @@ export interface WantedItem {
   season_episode: string
   file_path: string
   existing_sub: string
+  embedded_languages: Array<{ lang: string; format: string }>
   missing_languages: string[]
   target_language: string
   status: 'wanted' | 'searching' | 'found' | 'failed' | 'ignored' | 'extracted'


### PR DESCRIPTION
## Summary

- **New column display**: Replaces the misleading plain-text `Vorhanden` column with pill-based `SubtitlePresencePills` component — left pill shows target-language status (`DE ✗` / `DE SRT ↑` / `DE ↓ ASS`), right group shows all other embedded subtitle streams (`EN ↓ ASS`, `+2 ▾` overflow dropdown)
- **Backend**: New `get_all_subtitle_streams()` in `ass_utils.py`, new `embedded_languages` TEXT column on `wanted_items` (Alembic migration), scanner populates it at both movie and episode scan sites, partial-update call sites preserve existing data
- **i18n**: Column renamed `"Vorhanden"` → `"Untertitel"` (DE) and `"Existing"` → `"Subtitles"` (EN)

## Test Plan

- [ ] Run backend tests: `cd backend && python -m pytest --tb=short -q --ignore=tests/performance --ignore=tests/integration/test_provider_pipeline.py --ignore=tests/test_video_sync.py --ignore=tests/test_translation_backends.py -k "not (test_sonarr_download_webhook or test_radarr_download_webhook or test_parse_llm_response_too_many_merge or test_record_backend_success)"`
- [ ] Run frontend tests: `cd frontend && npm run test -- --run` (825 tests)
- [ ] Apply Alembic migration: `cd backend && python -m alembic upgrade head`
- [ ] Trigger a Sonarr/Radarr scan (or standalone scan) — verify `embedded_languages` is populated in DB
- [ ] Open Wanted page — verify column header reads "Untertitel", pills render correctly
- [ ] Confirm `DE ✗ | EN ↓ ASS` for episodes with English embedded subs but no German sub
- [ ] Confirm `+N ▾` overflow button expands for videos with 3+ embedded subtitle tracks
- [ ] Confirm `DE SRT ↑` arrow appears only when `upgrade_candidate = 1`