### PR TITLE
feat: dedicated Cleanup Rules settings page

### DIFF
--- a/backend/cleanup_scheduler.py
+++ b/backend/cleanup_scheduler.py
@@ -177,10 +177,18 @@ class CleanupScheduler:
             logger.warning("Zombie job expiry check failed: %s", e)
 
     def _execute_cleanup(self):
-        """Run all enabled cleanup rules in order."""
+        """Run all enabled scheduled cleanup rules in order."""
+        import os
+
         from config import get_settings
         from db.repositories.cleanup import CleanupRepository
         from dedup_engine import scan_for_duplicates, scan_orphaned_subtitles
+        from services.cleanup_executors import (
+            execute_format_upgrade,
+            execute_language_filter,
+            execute_orphan_db,
+            execute_orphan_files,
+        )
 
         self._executing = True
         try:
@@ -192,20 +200,83 @@ class CleanupScheduler:
             settings = get_settings()
             media_path = settings.media_path
 
-            enabled_rules = [r for r in rules if r.get("enabled")]
+            scheduled_rules = [
+                r
+                for r in rules
+                if r.get("enabled") and r.get("schedule") in ("daily", "weekly", "after_scan")
+            ]
 
-            if not enabled_rules:
-                logger.info("No enabled cleanup rules to execute")
+            if not scheduled_rules:
+                logger.info("No scheduled cleanup rules to execute")
                 return
 
-            logger.info("Executing %d enabled cleanup rules", len(enabled_rules))
+            logger.info("Executing %d scheduled cleanup rules", len(scheduled_rules))
 
-            for rule in enabled_rules:
+            for rule in scheduled_rules:
                 try:
                     rule_type = rule["rule_type"]
                     rule_id = rule["id"]
+                    config = rule.get("config_json", {})
 
-                    if rule_type == "dedup":
+                    if rule_type == "language_filter":
+                        result = execute_language_filter(media_path, config, dry_run=False)
+                        repo.update_rule_last_run(rule_id)
+                        repo.log_cleanup(
+                            action_type="scheduled_language_filter",
+                            files_deleted=result.get("deleted", 0),
+                            bytes_freed=result.get("bytes_freed", 0),
+                            rule_id=rule_id,
+                        )
+                        logger.info(
+                            "Scheduled language_filter: %d deleted, %d bytes freed",
+                            result.get("deleted", 0),
+                            result.get("bytes_freed", 0),
+                        )
+
+                    elif rule_type == "format_upgrade":
+                        result = execute_format_upgrade(media_path, config, dry_run=False)
+                        repo.update_rule_last_run(rule_id)
+                        repo.log_cleanup(
+                            action_type="scheduled_format_upgrade",
+                            files_deleted=result.get("deleted", 0),
+                            bytes_freed=result.get("bytes_freed", 0),
+                            rule_id=rule_id,
+                        )
+                        logger.info(
+                            "Scheduled format_upgrade: %d deleted, %d bytes freed",
+                            result.get("deleted", 0),
+                            result.get("bytes_freed", 0),
+                        )
+
+                    elif rule_type == "orphan_files":
+                        result = execute_orphan_files(media_path, config, dry_run=False)
+                        repo.update_rule_last_run(rule_id)
+                        repo.log_cleanup(
+                            action_type="scheduled_orphan_files",
+                            files_deleted=result.get("deleted", 0),
+                            bytes_freed=result.get("bytes_freed", 0),
+                            rule_id=rule_id,
+                        )
+                        logger.info(
+                            "Scheduled orphan_files: %d deleted, %d bytes freed",
+                            result.get("deleted", 0),
+                            result.get("bytes_freed", 0),
+                        )
+
+                    elif rule_type == "orphan_db":
+                        result = execute_orphan_db(config, dry_run=False)
+                        repo.update_rule_last_run(rule_id)
+                        repo.log_cleanup(
+                            action_type="scheduled_orphan_db",
+                            files_deleted=result.get("deleted", 0),
+                            rule_id=rule_id,
+                        )
+                        logger.info(
+                            "Scheduled orphan_db: %d DB entries removed",
+                            result.get("deleted", 0),
+                        )
+
+                    elif rule_type == "dedup":
                         result = scan_for_duplicates(media_path, socketio=self._socketio)
                         repo.update_rule_last_run(rule_id)
                         repo.log_cleanup(
@@ -231,8 +302,6 @@ class CleanupScheduler:
 
                     elif rule_type == "old_backups":
                         # Scan only, do not auto-delete backups
-                        import os
-
                         bak_count = 0
                         bak_size = 0
                         for root, _dirs, files in os.walk(media_path):
@@ -253,7 +322,7 @@ class CleanupScheduler:
                         )
 
                     else:
-                        logger.warning("Unknown rule type: %s", rule_type)
+                        logger.warning("Unknown rule type in scheduler: %s", rule_type)
 
                 except Exception as e:
                     logger.error("Failed to execute rule %d (%s): %s", rule["id"], rule["name"], e)

--- a/backend/db/migrations/versions/f0e1d2c3b4a5_add_schedule_to_cleanup_rules.py
+++ b/backend/db/migrations/versions/f0e1d2c3b4a5_add_schedule_to_cleanup_rules.py
@@ -1,0 +1,26 @@
+"""add schedule to cleanup_rules
+
+Revision ID: f0e1d2c3b4a5
+Revises: b3c2a1d4e5f6
+Create Date: 2026-04-04
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "f0e1d2c3b4a5"
+down_revision = "b3c2a1d4e5f6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("cleanup_rules") as batch_op:
+        batch_op.add_column(
+            sa.Column("schedule", sa.String(20), nullable=False, server_default="manual")
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("cleanup_rules") as batch_op:
+        batch_op.drop_column("schedule")

--- a/backend/db/migrations/versions/f0e1d2c3b4a5_add_schedule_to_cleanup_rules.py
+++ b/backend/db/migrations/versions/f0e1d2c3b4a5_add_schedule_to_cleanup_rules.py
@@ -1,7 +1,7 @@
 """add schedule to cleanup_rules
 
 Revision ID: f0e1d2c3b4a5
-Revises: b3c2a1d4e5f6
+Revises: a2b3c4d5e6f7
 Create Date: 2026-04-04
 """
 
@@ -9,7 +9,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision = "f0e1d2c3b4a5"
-down_revision = "b3c2a1d4e5f6"
+down_revision = "a2b3c4d5e6f7"
 branch_labels = None
 depends_on = None
 

--- a/backend/db/models/cleanup.py
+++ b/backend/db/models/cleanup.py
@@ -42,6 +42,7 @@ class CleanupRule(db.Model):
     rule_type: Mapped[str] = mapped_column(String(50), nullable=False)
     config_json: Mapped[str] = mapped_column(Text, default="{}")
     enabled: Mapped[int] = mapped_column(Integer, default=1)
+    schedule: Mapped[str] = mapped_column(String(20), default="manual")
     last_run_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)

--- a/backend/db/repositories/cleanup.py
+++ b/backend/db/repositories/cleanup.py
@@ -160,8 +160,37 @@ class CleanupRepository(BaseRepository):
 
     # ---- Cleanup Rules ---------------------------------------------------------
 
+    def _rule_to_dict(self, rule) -> dict:
+        """Serialize a CleanupRule ORM object to a dict.
+
+        Parses config_json from a JSON string into a dict and includes
+        the schedule field along with all standard rule fields.
+        """
+        import json as _json
+
+        try:
+            config = _json.loads(rule.config_json or "{}")
+        except (ValueError, TypeError):
+            config = {}
+        return {
+            "id": rule.id,
+            "name": rule.name,
+            "rule_type": rule.rule_type,
+            "config_json": config,
+            "enabled": bool(rule.enabled),
+            "schedule": rule.schedule,
+            "last_run_at": rule.last_run_at.isoformat() if rule.last_run_at else None,
+            "created_at": rule.created_at.isoformat(),
+            "updated_at": rule.updated_at.isoformat(),
+        }
+
     def create_rule(
-        self, name: str, rule_type: str, config_json: str = "{}", enabled: bool = True
+        self,
+        name: str,
+        rule_type: str,
+        config_json: str = "{}",
+        enabled: bool = True,
+        schedule: str = "manual",
     ) -> dict:
         """Create a new cleanup rule.
 
@@ -174,12 +203,13 @@ class CleanupRepository(BaseRepository):
             rule_type=rule_type,
             config_json=config_json,
             enabled=1 if enabled else 0,
+            schedule=schedule,
             created_at=now,
             updated_at=now,
         )
         self.session.add(entry)
         self._commit()
-        return self._to_dict(entry)
+        return self._rule_to_dict(entry)
 
     def get_rules(self) -> list[dict]:
         """Get all cleanup rules ordered by name.
@@ -189,7 +219,7 @@ class CleanupRepository(BaseRepository):
         """
         stmt = select(CleanupRule).order_by(CleanupRule.name)
         entries = self.session.execute(stmt).scalars().all()
-        return [self._to_dict(e) for e in entries]
+        return [self._rule_to_dict(e) for e in entries]
 
     def get_rule(self, rule_id: int) -> dict | None:
         """Get a single cleanup rule by ID.
@@ -199,12 +229,12 @@ class CleanupRepository(BaseRepository):
         """
         stmt = select(CleanupRule).where(CleanupRule.id == rule_id)
         result = self.session.execute(stmt).scalar_one_or_none()
-        return self._to_dict(result)
+        return self._rule_to_dict(result) if result is not None else None
 
     def update_rule(self, rule_id: int, **kwargs) -> dict | None:
         """Update a cleanup rule by ID.
 
-        Accepts any combination of: name, rule_type, config_json, enabled.
+        Accepts any combination of: name, rule_type, config_json, enabled, schedule.
 
         Returns:
             Updated dict or None if not found.
@@ -214,7 +244,7 @@ class CleanupRepository(BaseRepository):
         if entry is None:
             return None
 
-        allowed_fields = {"name", "rule_type", "config_json", "enabled"}
+        allowed_fields = {"name", "rule_type", "config_json", "enabled", "schedule"}
         for key, value in kwargs.items():
             if key in allowed_fields:
                 if key == "enabled":
@@ -223,7 +253,7 @@ class CleanupRepository(BaseRepository):
 
         entry.updated_at = self._now()
         self._commit()
-        return self._to_dict(entry)
+        return self._rule_to_dict(entry)
 
     def delete_rule(self, rule_id: int) -> bool:
         """Delete a cleanup rule by ID.

--- a/backend/db/repositories/subtitles.py
+++ b/backend/db/repositories/subtitles.py
@@ -1,0 +1,37 @@
+"""Subtitle file path repository — thin access layer for subtitle_downloads paths.
+
+Used by cleanup executors that need to enumerate all known subtitle paths
+and remove stale DB entries for files that no longer exist on disk.
+"""
+
+import logging
+
+from sqlalchemy import select
+
+from db.models.providers import SubtitleDownload
+from db.repositories.base import BaseRepository
+
+logger = logging.getLogger(__name__)
+
+
+class SubtitleRepository(BaseRepository):
+    """Repository for subtitle file path operations used by cleanup executors."""
+
+    def get_all_subtitle_paths(self) -> list[str]:
+        """Return a list of all file_path values from subtitle_downloads.
+
+        Returns:
+            List of file path strings (may include paths that no longer exist).
+        """
+        stmt = select(SubtitleDownload.file_path)
+        rows = self.session.execute(stmt).scalars().all()
+        return list(rows)
+
+    def delete_by_path(self, path: str) -> None:
+        """Delete all subtitle_downloads rows with the given file_path.
+
+        Args:
+            path: Absolute file path to match against file_path column.
+        """
+        self.session.query(SubtitleDownload).filter_by(file_path=path).delete()
+        self._commit()

--- a/backend/routes/cleanup.py
+++ b/backend/routes/cleanup.py
@@ -559,11 +559,20 @@ def create_rule():
     rule_type = data.get("rule_type", "").strip()
     config_json = data.get("config_json", "{}")
     enabled = data.get("enabled", True)
+    schedule = data.get("schedule", "manual")
 
     if not name:
         return jsonify({"error": "name is required"}), 400
 
-    valid_types = {"dedup", "orphaned", "old_backups"}
+    valid_types = {
+        "dedup",
+        "orphaned",
+        "old_backups",
+        "language_filter",
+        "format_upgrade",
+        "orphan_files",
+        "orphan_db",
+    }
     if rule_type not in valid_types:
         return jsonify({"error": f"rule_type must be one of: {sorted(valid_types)}"}), 400
 
@@ -582,6 +591,7 @@ def create_rule():
         rule_type=rule_type,
         config_json=config_json,
         enabled=enabled,
+        schedule=schedule,
     )
 
     return jsonify(rule), 201
@@ -613,11 +623,14 @@ def update_rule(rule_id: int):
                   type: string
                 rule_type:
                   type: string
-                  enum: [dedup, orphaned, old_backups]
+                  enum: [dedup, orphaned, old_backups, language_filter, format_upgrade, orphan_files, orphan_db]
                 config_json:
                   type: string
                 enabled:
                   type: boolean
+                schedule:
+                  type: string
+                  enum: [manual, daily, weekly, after_scan]
       responses:
         200:
           description: Rule updated
@@ -703,10 +716,18 @@ def run_rule(rule_id: int):
         500:
           description: Execution error
     """
+    import os
+
     from config import get_settings
     from db.repositories.cleanup import CleanupRepository
     from dedup_engine import scan_for_duplicates, scan_orphaned_subtitles
     from extensions import socketio
+    from services.cleanup_executors import (
+        execute_format_upgrade,
+        execute_language_filter,
+        execute_orphan_db,
+        execute_orphan_files,
+    )
 
     repo = CleanupRepository()
     rule = repo.get_rule(rule_id)
@@ -716,52 +737,130 @@ def run_rule(rule_id: int):
 
     settings = get_settings()
     media_path = settings.media_path
+    rule_type = rule["rule_type"]
+    config = rule.get("config_json", {})
 
-    if rule["rule_type"] == "dedup":
-        result = scan_for_duplicates(media_path, socketio=socketio)
-        repo.update_rule_last_run(rule_id)
-        return jsonify({"status": "completed", "rule": rule["name"], "result": result})
+    try:
+        if rule_type == "language_filter":
+            result = execute_language_filter(media_path, config, dry_run=False)
+        elif rule_type == "format_upgrade":
+            result = execute_format_upgrade(media_path, config, dry_run=False)
+        elif rule_type == "orphan_files":
+            result = execute_orphan_files(media_path, config, dry_run=False)
+        elif rule_type == "orphan_db":
+            result = execute_orphan_db(config, dry_run=False)
+        elif rule_type == "dedup":
+            result = scan_for_duplicates(media_path, socketio=socketio)
+            repo.update_rule_last_run(rule_id)
+            return jsonify({"status": "completed", "rule": rule["name"], "result": result})
+        elif rule_type == "orphaned":
+            result = scan_orphaned_subtitles(media_path)
+            repo.update_rule_last_run(rule_id)
+            return jsonify(
+                {
+                    "status": "completed",
+                    "rule": rule["name"],
+                    "orphaned": result,
+                    "count": len(result),
+                }
+            )
+        elif rule_type == "old_backups":
+            bak_files = []
+            for root, _dirs, files in os.walk(media_path):
+                for filename in files:
+                    if ".bak" in filename:
+                        full_path = os.path.join(root, filename)
+                        try:
+                            size = os.path.getsize(full_path)
+                        except OSError:
+                            size = 0
+                        bak_files.append({"path": full_path, "size": size})
+            repo.update_rule_last_run(rule_id)
+            return jsonify(
+                {
+                    "status": "completed",
+                    "rule": rule["name"],
+                    "backup_files": bak_files,
+                    "count": len(bak_files),
+                    "total_size": sum(f["size"] for f in bak_files),
+                }
+            )
+        else:
+            return jsonify({"error": f"Unknown rule type: {rule_type}"}), 400
 
-    elif rule["rule_type"] == "orphaned":
-        result = scan_orphaned_subtitles(media_path)
         repo.update_rule_last_run(rule_id)
-        return jsonify(
-            {
-                "status": "completed",
-                "rule": rule["name"],
-                "orphaned": result,
-                "count": len(result),
-            }
+        repo.log_cleanup(
+            action_type=rule_type,
+            rule_id=rule_id,
+            files_deleted=result.get("deleted", 0),
+            bytes_freed=result.get("bytes_freed", 0),
         )
+        return jsonify({"status": "ok", "result": result})
+    except Exception as e:
+        logger.error("Rule %d (%s) failed: %s", rule_id, rule_type, e)
+        return jsonify({"error": str(e)}), 500
 
-    elif rule["rule_type"] == "old_backups":
-        # Scan for .bak files and report
-        import os
 
-        bak_files = []
-        for root, _dirs, files in os.walk(media_path):
-            for filename in files:
-                if ".bak" in filename:
-                    full_path = os.path.join(root, filename)
-                    try:
-                        size = os.path.getsize(full_path)
-                    except OSError:
-                        size = 0
-                    bak_files.append({"path": full_path, "size": size})
+@bp.route("/rules/<int:rule_id>/preview", methods=["POST"])
+def preview_rule(rule_id: int):
+    """Dry-run a cleanup rule — return what would be deleted without deleting.
+    ---
+    post:
+      tags:
+        - Cleanup
+      summary: Preview cleanup rule
+      description: Runs a cleanup rule in dry-run mode and returns what would be affected without making any changes.
+      parameters:
+        - in: path
+          name: rule_id
+          required: true
+          schema:
+            type: integer
+      responses:
+        200:
+          description: Preview results
+        404:
+          description: Rule not found
+        400:
+          description: Preview not supported for rule type
+        500:
+          description: Preview error
+    """
+    from config import get_settings
+    from db.repositories.cleanup import CleanupRepository
+    from services.cleanup_executors import (
+        execute_format_upgrade,
+        execute_language_filter,
+        execute_orphan_db,
+        execute_orphan_files,
+    )
 
-        repo.update_rule_last_run(rule_id)
-        return jsonify(
-            {
-                "status": "completed",
-                "rule": rule["name"],
-                "backup_files": bak_files,
-                "count": len(bak_files),
-                "total_size": sum(f["size"] for f in bak_files),
-            }
-        )
+    repo = CleanupRepository()
+    rule = repo.get_rule(rule_id)
+    if not rule:
+        return jsonify({"error": "Rule not found"}), 404
 
-    else:
-        return jsonify({"error": f"Unknown rule type: {rule['rule_type']}"}), 400
+    settings = get_settings()
+    media_path = settings.media_path
+    rule_type = rule["rule_type"]
+    config = rule.get("config_json", {})
+
+    try:
+        if rule_type == "language_filter":
+            result = execute_language_filter(media_path, config, dry_run=True)
+        elif rule_type == "format_upgrade":
+            result = execute_format_upgrade(media_path, config, dry_run=True)
+        elif rule_type == "orphan_files":
+            result = execute_orphan_files(media_path, config, dry_run=True)
+        elif rule_type == "orphan_db":
+            result = execute_orphan_db(config, dry_run=True)
+        else:
+            return jsonify({"error": f"Preview not supported for rule type: {rule_type}"}), 400
+
+        return jsonify({"rule_id": rule_id, "rule_type": rule_type, "preview": result})
+    except Exception as e:
+        logger.error("Preview for rule %d failed: %s", rule_id, e)
+        return jsonify({"error": str(e)}), 500
 
 
 # ---- Dashboard Endpoints -------------------------------------------------------

--- a/backend/services/cleanup_executors.py
+++ b/backend/services/cleanup_executors.py
@@ -1,0 +1,232 @@
+"""Cleanup rule executors — one function per rule_type.
+
+Each executor takes (media_path, config, dry_run) and returns a result dict.
+NFO files (.nfo) are never deleted by any executor.
+
+Rule types:
+  language_filter  — delete sidecars in non-allowed languages
+  format_upgrade   — delete SRT when ASS exists for same episode+language
+  orphan_files     — delete subtitle sidecars with no matching video on disk
+  orphan_db        — remove DB entries whose file no longer exists
+"""
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+# Module-level import seam so tests can monkeypatch SubtitleRepository.
+# Wrapped in try/except to allow importing this module outside a Flask app context.
+try:
+    from db.repositories.subtitles import SubtitleRepository  # noqa: F401
+except ImportError:  # pragma: no cover
+    SubtitleRepository = None  # type: ignore[assignment,misc]
+
+SUBTITLE_EXTENSIONS = {".ass", ".ssa", ".srt", ".vtt", ".sub"}
+VIDEO_EXTENSIONS = {".mkv", ".mp4", ".avi", ".mov", ".m4v", ".ts", ".wmv"}
+
+
+def _subtitle_files(root: str) -> list[str]:
+    """Walk root recursively, return paths of all subtitle files (never NFO)."""
+    found = []
+    for dirpath, _, filenames in os.walk(root):
+        for fname in filenames:
+            ext = os.path.splitext(fname)[1].lower()
+            if ext in SUBTITLE_EXTENSIONS:
+                found.append(os.path.join(dirpath, fname))
+    return found
+
+
+def _parse_lang_from_filename(filename: str) -> str | None:
+    """Extract language tag from sidecar filename.
+
+    Expects pattern: <basename>.<lang>.<ext>
+    e.g. "Movie.de.ass" -> "de", "Show.S01E01.en.srt" -> "en"
+    Returns None if filename doesn't match the pattern.
+    """
+    parts = filename.rsplit(".", 2)
+    if len(parts) == 3:
+        return parts[1].lower()
+    return None
+
+
+def execute_language_filter(media_path: str, config: dict, dry_run: bool = False) -> dict:
+    """Delete subtitle sidecars in languages not in keep_languages list.
+
+    Args:
+        media_path: Root directory to scan recursively.
+        config: {"keep_languages": ["de", "en"]}
+        dry_run: If True, return counts without deleting.
+
+    Returns:
+        {"deleted": int, "kept": int, "bytes_freed": int} or
+        {"would_delete": int, "would_keep": int} in dry_run mode.
+    """
+    keep_languages = {lang.lower() for lang in config.get("keep_languages", [])}
+    deleted = 0
+    kept = 0
+    bytes_freed = 0
+    would_delete = 0
+    would_keep = 0
+
+    for path in _subtitle_files(media_path):
+        fname = os.path.basename(path)
+        lang = _parse_lang_from_filename(fname)
+
+        if lang is None or lang in keep_languages:
+            kept += 1
+            would_keep += 1
+            continue
+
+        file_size = os.path.getsize(path)
+        if dry_run:
+            would_delete += 1
+            logger.debug("Would delete (language_filter): %s", path)
+        else:
+            try:
+                os.remove(path)
+                deleted += 1
+                bytes_freed += file_size
+                logger.info("Deleted (language_filter): %s", path)
+            except OSError as e:
+                logger.warning("Failed to delete %s: %s", path, e)
+
+    if dry_run:
+        return {"would_delete": would_delete, "would_keep": would_keep}
+    return {"deleted": deleted, "kept": kept, "bytes_freed": bytes_freed}
+
+
+def execute_format_upgrade(media_path: str, config: dict, dry_run: bool = False) -> dict:
+    """Delete lower-quality format when higher-quality exists for same base+language.
+
+    Args:
+        media_path: Root directory to scan recursively.
+        config: {"keep_format": "ass"} — "ass" deletes SRT when ASS exists;
+                "srt" vice versa; "any" is a no-op.
+        dry_run: If True, return counts without deleting.
+
+    Returns:
+        {"deleted": int, "bytes_freed": int} or {"would_delete": int} in dry_run mode.
+    """
+    keep_format = config.get("keep_format", "any").lower()
+    if keep_format == "any":
+        return {"deleted": 0, "bytes_freed": 0}
+
+    if keep_format == "ass":
+        preferred_ext, inferior_ext = ".ass", ".srt"
+    else:
+        preferred_ext, inferior_ext = ".srt", ".ass"
+
+    from collections import defaultdict
+
+    # index: (dirpath, base_without_ext) -> set of extensions present
+    index: dict[tuple[str, str], set[str]] = defaultdict(set)
+    path_map: dict[tuple[str, str, str], str] = {}
+
+    for path in _subtitle_files(media_path):
+        dirpath = os.path.dirname(path)
+        fname = os.path.basename(path)
+        base, ext = os.path.splitext(fname)
+        key = (dirpath, base)
+        index[key].add(ext.lower())
+        path_map[(dirpath, base, ext.lower())] = path
+
+    deleted = 0
+    bytes_freed = 0
+    would_delete = 0
+
+    for (dirpath, base), exts in index.items():
+        if preferred_ext in exts and inferior_ext in exts:
+            inferior_path = path_map.get((dirpath, base, inferior_ext))
+            if inferior_path:
+                file_size = os.path.getsize(inferior_path)
+                if dry_run:
+                    would_delete += 1
+                    logger.debug("Would delete (format_upgrade): %s", inferior_path)
+                else:
+                    try:
+                        os.remove(inferior_path)
+                        deleted += 1
+                        bytes_freed += file_size
+                        logger.info("Deleted (format_upgrade): %s", inferior_path)
+                    except OSError as e:
+                        logger.warning("Failed to delete %s: %s", inferior_path, e)
+
+    if dry_run:
+        return {"would_delete": would_delete}
+    return {"deleted": deleted, "bytes_freed": bytes_freed}
+
+
+def execute_orphan_files(media_path: str, config: dict, dry_run: bool = False) -> dict:
+    """Delete subtitle sidecars with no matching video file in the same directory.
+
+    A subtitle is considered orphaned when its directory contains no video files.
+
+    Args:
+        media_path: Root directory to scan recursively.
+        config: {} (no configuration needed)
+        dry_run: If True, return counts without deleting.
+
+    Returns:
+        {"deleted": int, "bytes_freed": int} or {"would_delete": int} in dry_run mode.
+    """
+    deleted = 0
+    bytes_freed = 0
+    would_delete = 0
+
+    for path in _subtitle_files(media_path):
+        dirpath = os.path.dirname(path)
+        try:
+            siblings = os.listdir(dirpath)
+        except OSError:
+            continue
+        has_video = any(os.path.splitext(s)[1].lower() in VIDEO_EXTENSIONS for s in siblings)
+        if not has_video:
+            file_size = os.path.getsize(path)
+            if dry_run:
+                would_delete += 1
+                logger.debug("Would delete (orphan_files): %s", path)
+            else:
+                try:
+                    os.remove(path)
+                    deleted += 1
+                    bytes_freed += file_size
+                    logger.info("Deleted (orphan_files): %s", path)
+                except OSError as e:
+                    logger.warning("Failed to delete %s: %s", path, e)
+
+    if dry_run:
+        return {"would_delete": would_delete}
+    return {"deleted": deleted, "bytes_freed": bytes_freed}
+
+
+def execute_orphan_db(config: dict, dry_run: bool = False) -> dict:
+    """Remove DB subtitle entries whose file no longer exists on disk.
+
+    Args:
+        config: {} (no configuration needed)
+        dry_run: If True, return counts without deleting.
+
+    Returns:
+        {"deleted": int} or {"would_delete": int} in dry_run mode.
+    """
+    import services.cleanup_executors as _self
+
+    repo = _self.SubtitleRepository()
+    paths = repo.get_all_subtitle_paths()
+    deleted = 0
+    would_delete = 0
+
+    for path in paths:
+        if not os.path.exists(path):
+            if dry_run:
+                would_delete += 1
+                logger.debug("Would remove DB entry (orphan_db): %s", path)
+            else:
+                repo.delete_by_path(path)
+                deleted += 1
+                logger.info("Removed DB entry (orphan_db): %s", path)
+
+    if dry_run:
+        return {"would_delete": would_delete}
+    return {"deleted": deleted}

--- a/backend/tests/test_cleanup_executors.py
+++ b/backend/tests/test_cleanup_executors.py
@@ -1,0 +1,92 @@
+"""Tests for cleanup_executors — language_filter, format_upgrade, orphan_files, orphan_db."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def test_language_filter_deletes_non_kept_languages(tmp_path):
+    """Files not in keep_languages should be deleted; NFO files are never touched."""
+    from services.cleanup_executors import execute_language_filter
+
+    (tmp_path / "show.de.ass").write_text("german sub")
+    (tmp_path / "show.en.srt").write_text("english sub")
+    (tmp_path / "show.fr.ass").write_text("french sub")
+    (tmp_path / "show.de.nfo").write_text("nfo file")  # never deleted
+
+    config = {"keep_languages": ["de"]}
+    result = execute_language_filter(str(tmp_path), config, dry_run=False)
+
+    assert result["deleted"] == 2  # fr.ass + en.srt
+    assert (tmp_path / "show.de.ass").exists()
+    assert (tmp_path / "show.de.nfo").exists()
+    assert not (tmp_path / "show.fr.ass").exists()
+    assert not (tmp_path / "show.en.srt").exists()
+
+
+def test_language_filter_dry_run_deletes_nothing(tmp_path):
+    """dry_run=True must not delete any files."""
+    from services.cleanup_executors import execute_language_filter
+
+    (tmp_path / "show.fr.ass").write_text("french sub")
+    config = {"keep_languages": ["de"]}
+    result = execute_language_filter(str(tmp_path), config, dry_run=True)
+
+    assert result["would_delete"] >= 1
+    assert (tmp_path / "show.fr.ass").exists()
+
+
+def test_format_upgrade_removes_srt_when_ass_exists(tmp_path):
+    """SRT should be deleted when ASS exists for same base+language."""
+    from services.cleanup_executors import execute_format_upgrade
+
+    (tmp_path / "show.de.ass").write_text("german ass")
+    (tmp_path / "show.de.srt").write_text("german srt")
+    (tmp_path / "show.en.srt").write_text("english srt only")  # no ASS counterpart
+
+    config = {"keep_format": "ass"}
+    result = execute_format_upgrade(str(tmp_path), config, dry_run=False)
+
+    assert result["deleted"] == 1  # only de.srt
+    assert (tmp_path / "show.de.ass").exists()
+    assert not (tmp_path / "show.de.srt").exists()
+    assert (tmp_path / "show.en.srt").exists()  # kept, no ASS counterpart
+
+
+def test_orphan_files_deletes_subs_without_video(tmp_path):
+    """Subtitle without a video file in same dir should be detected as orphan."""
+    from services.cleanup_executors import execute_orphan_files
+
+    subdir = tmp_path / "nosub"
+    subdir.mkdir()
+    (subdir / "orphan.de.ass").write_text("sub without video")
+
+    paired_dir = tmp_path / "paired"
+    paired_dir.mkdir()
+    (paired_dir / "movie.mkv").write_text("video")
+    (paired_dir / "movie.de.ass").write_text("paired sub")
+
+    result = execute_orphan_files(str(tmp_path), {}, dry_run=False)
+
+    assert result["deleted"] == 1
+    assert not (subdir / "orphan.de.ass").exists()
+    assert (paired_dir / "movie.de.ass").exists()
+
+
+def test_orphan_db_removes_stale_db_entries(tmp_path):
+    """DB rows pointing to non-existent files should be removed."""
+    from services.cleanup_executors import execute_orphan_db
+
+    existing = str(tmp_path / "exists.de.ass")
+    missing = str(tmp_path / "missing.de.ass")
+    open(existing, "w").close()  # create the existing file
+
+    mock_repo = MagicMock()
+    mock_repo.get_all_subtitle_paths.return_value = [existing, missing]
+
+    with patch("services.cleanup_executors.SubtitleRepository", return_value=mock_repo):
+        result = execute_orphan_db({}, dry_run=False)
+
+    assert result["deleted"] == 1
+    mock_repo.delete_by_path.assert_called_once_with(missing)

--- a/docs/superpowers/plans/2026-04-04-cleanup-rules-page.md
+++ b/docs/superpowers/plans/2026-04-04-cleanup-rules-page.md
@@ -1,0 +1,2120 @@
+# Cleanup Rules Page Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the embedded CleanupTab with a dedicated first-class Settings page that provides a sidebar/detail rule management UI with 4 structured rule types, per-rule scheduling, and language/format pickers.
+
+**Architecture:** A new `CleanupSettings` page replaces `CleanupTab` everywhere it was embedded. The backend gets 4 new rule type executors, a `schedule` column on `cleanup_rules`, and a per-rule preview endpoint. The frontend sidebar lists rules; the detail view renders type-specific config components.
+
+**Tech Stack:** Python/Flask, SQLAlchemy, Alembic, React 19, TypeScript, React Query (TanStack Query), Vitest, pytest
+
+---
+
+## File Map
+
+### Backend — New / Modified
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `backend/db/migrations/versions/<hash>_add_schedule_to_cleanup_rules.py` | Create | Alembic migration: add `schedule` column |
+| `backend/db/models/cleanup.py` | Modify | Add `schedule` mapped column to `CleanupRule` |
+| `backend/db/repositories/cleanup.py` | Modify | Include `schedule` in `create_rule`, `update_rule`, `get_rules` output |
+| `backend/services/cleanup_executors.py` | Create | 4 rule type executors: `language_filter`, `format_upgrade`, `orphan_files`, `orphan_db` |
+| `backend/routes/cleanup.py` | Modify | Wire `run_rule` to new executors; add `POST /rules/<id>/preview` endpoint |
+| `backend/cleanup_scheduler.py` | Modify | Per-rule `schedule` field respected; dispatch to new executors |
+| `backend/tests/test_cleanup_executors.py` | Create | Unit tests for all 4 executors |
+
+### Frontend — New / Modified
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `frontend/src/types/system.ts` | Modify | Extend `CleanupRule` type: new `rule_type` values, add `schedule` field |
+| `frontend/src/api/system/tasks.ts` | Modify | Add `previewCleanupRule(id)` API call |
+| `frontend/src/hooks/useSystemApi.ts` | Modify | Add `useRulePreview` mutation hook |
+| `frontend/src/pages/Settings/CleanupSettings.tsx` | Create | Full-page Cleanup Settings: sidebar + detail view + dedup section + history |
+| `frontend/src/components/cleanup/RuleSidebar.tsx` | Create | Rule list sidebar with type icons, status dots, badges |
+| `frontend/src/components/cleanup/RuleDetail.tsx` | Create | Detail view: header + last-run bar + config sections + preview box |
+| `frontend/src/components/cleanup/LanguageFilterConfig.tsx` | Create | Tag-style language picker for `language_filter` rules |
+| `frontend/src/components/cleanup/FormatUpgradeConfig.tsx` | Create | 3-card format picker for `format_upgrade` rules |
+| `frontend/src/components/cleanup/SchedulePicker.tsx` | Create | Chip-style schedule selector (manual/daily/weekly/after_scan) |
+| `frontend/src/components/settings/SettingsGrid.tsx` | Modify | Add `cleanup` tile to CATEGORIES |
+| `frontend/src/pages/Settings/index.tsx` | Modify | Add `/settings/cleanup` route → `CleanupSettings` |
+| `frontend/src/pages/Settings/SubtitlesSettings.tsx` | Modify | Remove `CleanupTab` section (Cleanup has its own page now) |
+| `frontend/src/pages/Settings/__tests__/CleanupSettings.test.tsx` | Create | Component tests for the new page |
+
+---
+
+## Task 1: DB Migration — add `schedule` to `cleanup_rules`
+
+**Files:**
+- Create: `backend/db/migrations/versions/a1b2c3d4e5f6_add_schedule_to_cleanup_rules.py`
+
+- [ ] **Step 1: Generate migration**
+
+```bash
+cd backend
+flask db revision --autogenerate -m "add_schedule_to_cleanup_rules"
+```
+
+This creates a new file under `db/migrations/versions/`. Rename it to `a1b2c3d4e5f6_add_schedule_to_cleanup_rules.py` and replace its content:
+
+```python
+"""add schedule to cleanup_rules
+
+Revision ID: a1b2c3d4e5f6
+Revises: make_glossary_series_id_nullable
+Create Date: 2026-04-04
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'a1b2c3d4e5f6'
+down_revision = 'make_glossary_series_id_nullable'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('cleanup_rules') as batch_op:
+        batch_op.add_column(
+            sa.Column('schedule', sa.String(20), nullable=False, server_default='manual')
+        )
+
+
+def downgrade():
+    with op.batch_alter_table('cleanup_rules') as batch_op:
+        batch_op.drop_column('schedule')
+```
+
+- [ ] **Step 2: Run migration**
+
+```bash
+cd backend
+flask db upgrade
+```
+
+Expected: `Running upgrade ... -> a1b2c3d4e5f6, add schedule to cleanup_rules`
+
+- [ ] **Step 3: Verify column exists**
+
+```bash
+cd backend
+python -c "
+from app import create_app
+app = create_app()
+with app.app_context():
+    from extensions import db
+    result = db.session.execute(db.text('PRAGMA table_info(cleanup_rules)')).fetchall()
+    print([r[1] for r in result])
+"
+```
+
+Expected output includes `'schedule'`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/db/migrations/versions/a1b2c3d4e5f6_add_schedule_to_cleanup_rules.py
+git commit -m "feat: add schedule column to cleanup_rules"
+```
+
+---
+
+## Task 2: Backend Model + Repository
+
+**Files:**
+- Modify: `backend/db/models/cleanup.py`
+- Modify: `backend/db/repositories/cleanup.py`
+
+- [ ] **Step 1: Update CleanupRule model**
+
+In `backend/db/models/cleanup.py`, add `schedule` to `CleanupRule`:
+
+```python
+class CleanupRule(db.Model):
+    """Configurable cleanup rules."""
+
+    __tablename__ = "cleanup_rules"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(100), nullable=False)
+    rule_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    config_json: Mapped[str] = mapped_column(Text, default="{}")
+    enabled: Mapped[int] = mapped_column(Integer, default=1)
+    schedule: Mapped[str] = mapped_column(String(20), default="manual")
+    last_run_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+```
+
+- [ ] **Step 2: Update CleanupRepository.create_rule to accept schedule**
+
+In `backend/db/repositories/cleanup.py`, find `create_rule` and add `schedule` parameter:
+
+```python
+def create_rule(
+    self,
+    name: str,
+    rule_type: str,
+    config_json: dict | None = None,
+    enabled: bool = True,
+    schedule: str = "manual",
+) -> dict:
+    from db.models.cleanup import CleanupRule
+
+    now = datetime.now(UTC)
+    rule = CleanupRule(
+        name=name,
+        rule_type=rule_type,
+        config_json=json.dumps(config_json or {}),
+        enabled=1 if enabled else 0,
+        schedule=schedule,
+        created_at=now,
+        updated_at=now,
+    )
+    db.session.add(rule)
+    db.session.commit()
+    return self._rule_to_dict(rule)
+```
+
+- [ ] **Step 3: Ensure `_rule_to_dict` includes schedule and update_rule handles it**
+
+Find or add `_rule_to_dict` helper in `CleanupRepository`. It must include `schedule`:
+
+```python
+def _rule_to_dict(self, rule) -> dict:
+    import json as _json
+    try:
+        config = _json.loads(rule.config_json or "{}")
+    except (ValueError, TypeError):
+        config = {}
+    return {
+        "id": rule.id,
+        "name": rule.name,
+        "rule_type": rule.rule_type,
+        "config_json": config,
+        "enabled": bool(rule.enabled),
+        "schedule": rule.schedule,
+        "last_run_at": rule.last_run_at.isoformat() if rule.last_run_at else None,
+        "created_at": rule.created_at.isoformat(),
+        "updated_at": rule.updated_at.isoformat(),
+    }
+```
+
+Then update `update_rule` to accept `schedule`:
+
+```python
+def update_rule(self, rule_id: int, **kwargs) -> dict | None:
+    from db.models.cleanup import CleanupRule
+
+    rule = db.session.get(CleanupRule, rule_id)
+    if not rule:
+        return None
+
+    if "name" in kwargs:
+        rule.name = kwargs["name"]
+    if "enabled" in kwargs:
+        rule.enabled = 1 if kwargs["enabled"] else 0
+    if "config_json" in kwargs:
+        rule.config_json = json.dumps(kwargs["config_json"])
+    if "schedule" in kwargs:
+        rule.schedule = kwargs["schedule"]
+    rule.updated_at = datetime.now(UTC)
+    db.session.commit()
+    return self._rule_to_dict(rule)
+```
+
+- [ ] **Step 4: Update `get_rules` and `get_rule` to use `_rule_to_dict`**
+
+Replace any inline dict construction in `get_rules` and `get_rule` with `self._rule_to_dict(r)`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/db/models/cleanup.py backend/db/repositories/cleanup.py
+git commit -m "feat: add schedule field to CleanupRule model and repository"
+```
+
+---
+
+## Task 3: Rule Executors
+
+**Files:**
+- Create: `backend/services/cleanup_executors.py`
+- Create: `backend/tests/test_cleanup_executors.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `backend/tests/test_cleanup_executors.py`:
+
+```python
+"""Tests for cleanup_executors — language_filter, format_upgrade, orphan_files, orphan_db."""
+
+import json
+import os
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+def test_language_filter_deletes_non_kept_languages(tmp_path):
+    """Files not in keep_languages should be deleted; NFO files are never touched."""
+    from services.cleanup_executors import execute_language_filter
+
+    # Create test sidecar files
+    (tmp_path / "show.de.ass").write_text("german sub")
+    (tmp_path / "show.en.srt").write_text("english sub")
+    (tmp_path / "show.fr.ass").write_text("french sub")
+    (tmp_path / "show.de.nfo").write_text("nfo file")  # never deleted
+
+    config = {"keep_languages": ["de"]}
+    result = execute_language_filter(str(tmp_path), config, dry_run=False)
+
+    assert result["deleted"] == 1  # only fr.ass
+    assert result["kept"] >= 1
+    assert (tmp_path / "show.de.ass").exists()
+    assert (tmp_path / "show.de.nfo").exists()
+    assert not (tmp_path / "show.fr.ass").exists()
+    # en.srt also deleted since "en" not in keep_languages
+    assert not (tmp_path / "show.en.srt").exists()
+
+
+def test_language_filter_dry_run_deletes_nothing(tmp_path):
+    """dry_run=True must not delete any files."""
+    from services.cleanup_executors import execute_language_filter
+
+    (tmp_path / "show.fr.ass").write_text("french sub")
+    config = {"keep_languages": ["de"]}
+    result = execute_language_filter(str(tmp_path), config, dry_run=True)
+
+    assert result["would_delete"] >= 1
+    assert (tmp_path / "show.fr.ass").exists()
+
+
+def test_format_upgrade_removes_srt_when_ass_exists(tmp_path):
+    """SRT should be deleted when ASS exists for same language."""
+    from services.cleanup_executors import execute_format_upgrade
+
+    (tmp_path / "show.de.ass").write_text("german ass")
+    (tmp_path / "show.de.srt").write_text("german srt")
+    (tmp_path / "show.en.srt").write_text("english srt only")  # no ASS counterpart
+
+    config = {"keep_format": "ass"}
+    result = execute_format_upgrade(str(tmp_path), config, dry_run=False)
+
+    assert result["deleted"] == 1  # only de.srt
+    assert (tmp_path / "show.de.ass").exists()
+    assert not (tmp_path / "show.de.srt").exists()
+    assert (tmp_path / "show.en.srt").exists()  # kept, no ASS counterpart
+
+
+def test_orphan_files_deletes_subs_without_video(tmp_path):
+    """Subtitle without a video file in same dir should be detected as orphan."""
+    from services.cleanup_executors import execute_orphan_files
+
+    (tmp_path / "orphan.de.ass").write_text("sub without video")
+    (tmp_path / "movie.mkv").write_text("video")
+    (tmp_path / "movie.de.ass").write_text("paired sub")
+
+    result = execute_orphan_files(str(tmp_path), {}, dry_run=False)
+
+    assert result["deleted"] == 1
+    assert not (tmp_path / "orphan.de.ass").exists()
+    assert (tmp_path / "movie.de.ass").exists()
+
+
+def test_orphan_db_removes_stale_db_entries(tmp_path):
+    """DB rows pointing to non-existent files should be removed."""
+    from services.cleanup_executors import execute_orphan_db
+
+    mock_repo = MagicMock()
+    mock_repo.get_all_subtitle_paths.return_value = [
+        str(tmp_path / "exists.de.ass"),
+        str(tmp_path / "missing.de.ass"),
+    ]
+    (tmp_path / "exists.de.ass").write_text("exists")
+
+    with patch("services.cleanup_executors.SubtitleRepository", return_value=mock_repo):
+        result = execute_orphan_db({}, dry_run=False)
+
+    assert result["deleted"] == 1
+    mock_repo.delete_by_path.assert_called_once_with(str(tmp_path / "missing.de.ass"))
+```
+
+- [ ] **Step 2: Run tests — confirm they fail**
+
+```bash
+cd backend
+python -m pytest tests/test_cleanup_executors.py -v 2>&1 | head -30
+```
+
+Expected: `ModuleNotFoundError: No module named 'services.cleanup_executors'`
+
+- [ ] **Step 3: Implement cleanup_executors.py**
+
+Create `backend/services/cleanup_executors.py`:
+
+```python
+"""Cleanup rule executors — one function per rule_type.
+
+Each executor takes (media_path, config, dry_run) and returns a result dict.
+NFO files (.nfo) are never deleted by any executor.
+
+Rule types:
+  language_filter  — delete sidecars in non-allowed languages
+  format_upgrade   — delete SRT when ASS exists for same episode+language
+  orphan_files     — delete subtitle sidecars with no matching video on disk
+  orphan_db        — remove DB entries whose file no longer exists
+"""
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+# Subtitle extensions handled by all executors
+SUBTITLE_EXTENSIONS = {".ass", ".ssa", ".srt", ".vtt", ".sub"}
+# Video extensions used to find "paired" video files
+VIDEO_EXTENSIONS = {".mkv", ".mp4", ".avi", ".mov", ".m4v", ".ts", ".wmv"}
+# Never touch NFO files
+EXCLUDED_EXTENSIONS = {".nfo"}
+
+
+def _subtitle_files(root: str) -> list[str]:
+    """Walk root recursively, return paths of all subtitle files."""
+    found = []
+    for dirpath, _, filenames in os.walk(root):
+        for fname in filenames:
+            ext = os.path.splitext(fname)[1].lower()
+            if ext in SUBTITLE_EXTENSIONS:
+                found.append(os.path.join(dirpath, fname))
+    return found
+
+
+def _parse_lang_from_filename(filename: str) -> str | None:
+    """Extract language tag from sidecar filename.
+
+    Expects pattern: <basename>.<lang>.<ext>
+    e.g. "Movie.de.ass" → "de", "Show.S01E01.en.srt" → "en"
+    Returns None if no language tag found.
+    """
+    parts = filename.rsplit(".", 2)
+    if len(parts) == 3:
+        return parts[1].lower()
+    return None
+
+
+def execute_language_filter(media_path: str, config: dict, dry_run: bool = False) -> dict:
+    """Delete subtitle sidecars in languages not in keep_languages list.
+
+    Args:
+        media_path: Root directory to scan recursively.
+        config: {"keep_languages": ["de", "en"]}
+        dry_run: If True, return counts without deleting.
+
+    Returns:
+        {"deleted": int, "kept": int, "bytes_freed": int}
+        In dry_run mode: {"would_delete": int, "would_keep": int}
+    """
+    keep_languages = {lang.lower() for lang in config.get("keep_languages", [])}
+    deleted = 0
+    kept = 0
+    bytes_freed = 0
+    would_delete = 0
+    would_keep = 0
+
+    for path in _subtitle_files(media_path):
+        fname = os.path.basename(path)
+        lang = _parse_lang_from_filename(fname)
+
+        if lang is None or lang in keep_languages:
+            kept += 1
+            would_keep += 1
+            continue
+
+        file_size = os.path.getsize(path)
+        if dry_run:
+            would_delete += 1
+            logger.debug("Would delete (language_filter): %s", path)
+        else:
+            try:
+                os.remove(path)
+                deleted += 1
+                bytes_freed += file_size
+                logger.info("Deleted (language_filter): %s", path)
+            except OSError as e:
+                logger.warning("Failed to delete %s: %s", path, e)
+
+    if dry_run:
+        return {"would_delete": would_delete, "would_keep": would_keep}
+    return {"deleted": deleted, "kept": kept, "bytes_freed": bytes_freed}
+
+
+def execute_format_upgrade(media_path: str, config: dict, dry_run: bool = False) -> dict:
+    """Delete lower-quality format when higher-quality exists for same episode+language.
+
+    Args:
+        media_path: Root directory to scan recursively.
+        config: {"keep_format": "ass"}  — "ass" deletes SRT when ASS exists; "srt" vice versa; "any" is a no-op.
+        dry_run: If True, return counts without deleting.
+
+    Returns:
+        {"deleted": int, "bytes_freed": int}
+    """
+    keep_format = config.get("keep_format", "any").lower()
+    if keep_format == "any":
+        return {"deleted": 0, "bytes_freed": 0}
+
+    # preferred: the format to keep; inferior: the format to delete when preferred exists
+    if keep_format == "ass":
+        preferred_ext, inferior_ext = ".ass", ".srt"
+    else:
+        preferred_ext, inferior_ext = ".srt", ".ass"
+
+    # Build index: (dirpath, basename_without_lang_ext) → set of extensions present
+    from collections import defaultdict
+    index: dict[tuple[str, str], set[str]] = defaultdict(set)
+    path_map: dict[tuple[str, str, str], str] = {}
+
+    for path in _subtitle_files(media_path):
+        dirpath = os.path.dirname(path)
+        fname = os.path.basename(path)
+        # Strip lang tag: "Movie.de.ass" → ("Movie.de", ".ass")
+        base, ext = os.path.splitext(fname)
+        key = (dirpath, base)
+        index[key].add(ext.lower())
+        path_map[(dirpath, base, ext.lower())] = path
+
+    deleted = 0
+    bytes_freed = 0
+    would_delete = 0
+
+    for (dirpath, base), exts in index.items():
+        if preferred_ext in exts and inferior_ext in exts:
+            inferior_path = path_map.get((dirpath, base, inferior_ext))
+            if inferior_path:
+                file_size = os.path.getsize(inferior_path)
+                if dry_run:
+                    would_delete += 1
+                    logger.debug("Would delete (format_upgrade): %s", inferior_path)
+                else:
+                    try:
+                        os.remove(inferior_path)
+                        deleted += 1
+                        bytes_freed += file_size
+                        logger.info("Deleted (format_upgrade): %s", inferior_path)
+                    except OSError as e:
+                        logger.warning("Failed to delete %s: %s", inferior_path, e)
+
+    if dry_run:
+        return {"would_delete": would_delete}
+    return {"deleted": deleted, "bytes_freed": bytes_freed}
+
+
+def execute_orphan_files(media_path: str, config: dict, dry_run: bool = False) -> dict:
+    """Delete subtitle sidecars that have no matching video file in the same directory.
+
+    A subtitle is considered orphaned when no file with a video extension shares
+    the same directory.
+
+    Args:
+        media_path: Root directory to scan recursively.
+        config: {} (no configuration needed)
+        dry_run: If True, return counts without deleting.
+
+    Returns:
+        {"deleted": int, "bytes_freed": int}
+    """
+    deleted = 0
+    bytes_freed = 0
+    would_delete = 0
+
+    for path in _subtitle_files(media_path):
+        dirpath = os.path.dirname(path)
+        siblings = os.listdir(dirpath)
+        has_video = any(
+            os.path.splitext(s)[1].lower() in VIDEO_EXTENSIONS for s in siblings
+        )
+        if not has_video:
+            file_size = os.path.getsize(path)
+            if dry_run:
+                would_delete += 1
+                logger.debug("Would delete (orphan_files): %s", path)
+            else:
+                try:
+                    os.remove(path)
+                    deleted += 1
+                    bytes_freed += file_size
+                    logger.info("Deleted (orphan_files): %s", path)
+                except OSError as e:
+                    logger.warning("Failed to delete %s: %s", path, e)
+
+    if dry_run:
+        return {"would_delete": would_delete}
+    return {"deleted": deleted, "bytes_freed": bytes_freed}
+
+
+def execute_orphan_db(config: dict, dry_run: bool = False) -> dict:
+    """Remove DB subtitle entries whose file no longer exists on disk.
+
+    Args:
+        config: {} (no configuration needed)
+        dry_run: If True, return counts without deleting.
+
+    Returns:
+        {"deleted": int}
+    """
+    from db.repositories.subtitles import SubtitleRepository
+
+    repo = SubtitleRepository()
+    paths = repo.get_all_subtitle_paths()
+    deleted = 0
+    would_delete = 0
+
+    for path in paths:
+        if not os.path.exists(path):
+            if dry_run:
+                would_delete += 1
+                logger.debug("Would remove DB entry (orphan_db): %s", path)
+            else:
+                repo.delete_by_path(path)
+                deleted += 1
+                logger.info("Removed DB entry (orphan_db): %s", path)
+
+    if dry_run:
+        return {"would_delete": would_delete}
+    return {"deleted": deleted}
+```
+
+- [ ] **Step 4: Run tests — confirm they pass**
+
+```bash
+cd backend
+python -m pytest tests/test_cleanup_executors.py -v
+```
+
+Expected: 4 PASSED
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/services/cleanup_executors.py backend/tests/test_cleanup_executors.py
+git commit -m "feat: add language_filter, format_upgrade, orphan_files, orphan_db executors"
+```
+
+---
+
+## Task 4: Backend Routes — wire executors + add preview endpoint
+
+**Files:**
+- Modify: `backend/routes/cleanup.py`
+
+- [ ] **Step 1: Update `run_rule` to dispatch to new executors**
+
+Find the `run_rule` function (around line 682). Replace the rule execution section:
+
+```python
+@bp.route("/rules/<int:rule_id>/run", methods=["POST"])
+def run_rule(rule_id: int):
+    """Execute a cleanup rule immediately."""
+    from config import get_settings
+    from db.repositories.cleanup import CleanupRepository
+    from services.cleanup_executors import (
+        execute_language_filter,
+        execute_format_upgrade,
+        execute_orphan_files,
+        execute_orphan_db,
+    )
+
+    repo = CleanupRepository()
+    rule = repo.get_rule(rule_id)
+    if not rule:
+        return jsonify({"error": "Rule not found"}), 404
+
+    settings = get_settings()
+    media_path = settings.media_path
+    rule_type = rule["rule_type"]
+    config = rule.get("config_json", {})
+
+    try:
+        if rule_type == "language_filter":
+            result = execute_language_filter(media_path, config, dry_run=False)
+        elif rule_type == "format_upgrade":
+            result = execute_format_upgrade(media_path, config, dry_run=False)
+        elif rule_type == "orphan_files":
+            result = execute_orphan_files(media_path, config, dry_run=False)
+        elif rule_type == "orphan_db":
+            result = execute_orphan_db(config, dry_run=False)
+        else:
+            return jsonify({"error": f"Unknown rule type: {rule_type}"}), 400
+
+        repo.update_rule_last_run(rule_id)
+        repo.log_cleanup(
+            action_type=rule_type,
+            rule_id=rule_id,
+            files_deleted=result.get("deleted", 0),
+            bytes_freed=result.get("bytes_freed", 0),
+        )
+        return jsonify({"status": "ok", "result": result})
+    except Exception as e:
+        logger.error("Rule %d (%s) failed: %s", rule_id, rule_type, e)
+        return jsonify({"error": str(e)}), 500
+```
+
+- [ ] **Step 2: Add `POST /rules/<id>/preview` endpoint**
+
+Add after the `run_rule` function:
+
+```python
+@bp.route("/rules/<int:rule_id>/preview", methods=["POST"])
+def preview_rule(rule_id: int):
+    """Dry-run a cleanup rule — return what would be deleted without deleting.
+    ---
+    post:
+      tags: [Cleanup]
+      summary: Preview rule execution (dry-run)
+      responses:
+        200:
+          description: Preview result
+        404:
+          description: Rule not found
+    """
+    from config import get_settings
+    from db.repositories.cleanup import CleanupRepository
+    from services.cleanup_executors import (
+        execute_language_filter,
+        execute_format_upgrade,
+        execute_orphan_files,
+        execute_orphan_db,
+    )
+
+    repo = CleanupRepository()
+    rule = repo.get_rule(rule_id)
+    if not rule:
+        return jsonify({"error": "Rule not found"}), 404
+
+    settings = get_settings()
+    media_path = settings.media_path
+    rule_type = rule["rule_type"]
+    config = rule.get("config_json", {})
+
+    try:
+        if rule_type == "language_filter":
+            result = execute_language_filter(media_path, config, dry_run=True)
+        elif rule_type == "format_upgrade":
+            result = execute_format_upgrade(media_path, config, dry_run=True)
+        elif rule_type == "orphan_files":
+            result = execute_orphan_files(media_path, config, dry_run=True)
+        elif rule_type == "orphan_db":
+            result = execute_orphan_db(config, dry_run=True)
+        else:
+            return jsonify({"error": f"Unknown rule type: {rule_type}"}), 400
+
+        return jsonify({"rule_id": rule_id, "rule_type": rule_type, "preview": result})
+    except Exception as e:
+        logger.error("Preview for rule %d failed: %s", rule_id, e)
+        return jsonify({"error": str(e)}), 500
+```
+
+- [ ] **Step 3: Update `create_rule` route to pass `schedule`**
+
+Find `create_rule` route (around line 518). In the call to `repo.create_rule(...)`, add:
+
+```python
+schedule = data.get("schedule", "manual")
+# ... existing validation ...
+rule = repo.create_rule(
+    name=name,
+    rule_type=rule_type,
+    config_json=config_json,
+    enabled=enabled,
+    schedule=schedule,
+)
+```
+
+- [ ] **Step 4: Update `update_rule` route to pass `schedule`**
+
+Find `update_rule` route (around line 590). Add handling for `schedule`:
+
+```python
+update_kwargs = {}
+if "name" in data:
+    update_kwargs["name"] = data["name"]
+if "enabled" in data:
+    update_kwargs["enabled"] = data["enabled"]
+if "config_json" in data:
+    update_kwargs["config_json"] = data["config_json"]
+if "schedule" in data:
+    update_kwargs["schedule"] = data["schedule"]
+updated = repo.update_rule(rule_id, **update_kwargs)
+```
+
+- [ ] **Step 5: Run pre-PR backend check**
+
+```bash
+cd backend
+ruff check . && ruff format --check .
+python -m pytest tests/test_cleanup_executors.py -v --tb=short -q
+```
+
+Expected: ruff clean, 4 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/routes/cleanup.py
+git commit -m "feat: wire new rule executors in cleanup routes, add preview endpoint"
+```
+
+---
+
+## Task 5: Scheduler — per-rule schedule + new executors
+
+**Files:**
+- Modify: `backend/cleanup_scheduler.py`
+
+- [ ] **Step 1: Update `_execute_cleanup` to dispatch per rule type and respect schedule**
+
+Find `_execute_cleanup` method. Replace the rule-type dispatch loop:
+
+```python
+def _execute_cleanup(self):
+    """Run enabled cleanup rules that match 'daily' or 'weekly' schedule."""
+    from config import get_settings
+    from db.repositories.cleanup import CleanupRepository
+    from dedup_engine import scan_for_duplicates
+    from services.cleanup_executors import (
+        execute_language_filter,
+        execute_format_upgrade,
+        execute_orphan_files,
+        execute_orphan_db,
+    )
+
+    self._executing = True
+    try:
+        self._expire_zombie_jobs()
+
+        repo = CleanupRepository()
+        rules = repo.get_rules()
+        settings = get_settings()
+        media_path = settings.media_path
+
+        scheduled_rules = [
+            r for r in rules
+            if r.get("enabled") and r.get("schedule") in ("daily", "weekly", "after_scan")
+        ]
+
+        if not scheduled_rules:
+            logger.info("No scheduled cleanup rules to execute")
+            return
+
+        logger.info("Executing %d scheduled cleanup rules", len(scheduled_rules))
+
+        for rule in scheduled_rules:
+            rule_type = rule["rule_type"]
+            rule_id = rule["id"]
+            config = rule.get("config_json", {})
+            try:
+                if rule_type == "language_filter":
+                    result = execute_language_filter(media_path, config, dry_run=False)
+                elif rule_type == "format_upgrade":
+                    result = execute_format_upgrade(media_path, config, dry_run=False)
+                elif rule_type == "orphan_files":
+                    result = execute_orphan_files(media_path, config, dry_run=False)
+                elif rule_type == "orphan_db":
+                    result = execute_orphan_db(config, dry_run=False)
+                elif rule_type == "dedup":
+                    result = scan_for_duplicates(media_path, socketio=self._socketio)
+                else:
+                    logger.warning("Unknown rule type in scheduler: %s", rule_type)
+                    continue
+
+                repo.update_rule_last_run(rule_id)
+                repo.log_cleanup(
+                    action_type=rule_type,
+                    rule_id=rule_id,
+                    files_deleted=result.get("deleted", 0),
+                    bytes_freed=result.get("bytes_freed", 0),
+                )
+                logger.info("Rule %d (%s) completed: %s", rule_id, rule_type, result)
+            except Exception as e:
+                logger.error("Rule %d (%s) failed: %s", rule_id, rule_type, e)
+    finally:
+        self._executing = False
+```
+
+- [ ] **Step 2: Run tests**
+
+```bash
+cd backend
+python -m pytest tests/test_cleanup_executors.py -v --tb=short -q
+```
+
+Expected: 4 PASSED (scheduler code has no dedicated test — covered by executor tests)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/cleanup_scheduler.py
+git commit -m "feat: cleanup scheduler dispatches per-rule type with schedule field"
+```
+
+---
+
+## Task 6: Frontend Types + API
+
+**Files:**
+- Modify: `frontend/src/types/system.ts`
+- Modify: `frontend/src/api/system/tasks.ts`
+- Modify: `frontend/src/hooks/useSystemApi.ts`
+
+- [ ] **Step 1: Update CleanupRule type**
+
+In `frontend/src/types/system.ts`, find `interface CleanupRule` (line 371) and replace:
+
+```typescript
+export interface CleanupRule {
+  id: number
+  name: string
+  rule_type: 'dedup' | 'orphaned' | 'old_backups' | 'language_filter' | 'format_upgrade' | 'orphan_files' | 'orphan_db'
+  config_json: Record<string, unknown>
+  enabled: boolean
+  schedule: 'manual' | 'daily' | 'weekly' | 'after_scan'
+  last_run_at: string | null
+  created_at: string
+}
+```
+
+- [ ] **Step 2: Add previewCleanupRule API call**
+
+In `frontend/src/api/system/tasks.ts`, add after `runCleanupRule`:
+
+```typescript
+export async function previewCleanupRule(id: number): Promise<{
+  rule_id: number
+  rule_type: string
+  preview: Record<string, number>
+}> {
+  const response = await client.post(`/api/v1/cleanup/rules/${id}/preview`)
+  return response.data
+}
+```
+
+Also update `createCleanupRule` to include `schedule` in the type:
+
+```typescript
+export async function createCleanupRule(rule: Omit<CleanupRule, 'id' | 'last_run_at' | 'created_at'>): Promise<CleanupRule> {
+  const response = await client.post('/api/v1/cleanup/rules', rule)
+  return response.data
+}
+```
+
+- [ ] **Step 3: Add useRulePreview hook**
+
+In `frontend/src/hooks/useSystemApi.ts`, add after `useRunCleanupRule`:
+
+```typescript
+export function useRulePreview() {
+  return useMutation({
+    mutationFn: (id: number) => previewCleanupRule(id),
+  })
+}
+```
+
+Add `previewCleanupRule` to the import from `@/api/system/tasks`.
+
+- [ ] **Step 4: Check TypeScript compiles**
+
+```bash
+cd frontend
+npx tsc --noEmit 2>&1 | head -20
+```
+
+Expected: No errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/types/system.ts frontend/src/api/system/tasks.ts frontend/src/hooks/useSystemApi.ts
+git commit -m "feat: extend CleanupRule type with schedule and new rule types, add preview hook"
+```
+
+---
+
+## Task 7: Frontend — Config Sub-Components
+
+**Files:**
+- Create: `frontend/src/components/cleanup/LanguageFilterConfig.tsx`
+- Create: `frontend/src/components/cleanup/FormatUpgradeConfig.tsx`
+- Create: `frontend/src/components/cleanup/SchedulePicker.tsx`
+
+- [ ] **Step 1: Create LanguageFilterConfig**
+
+Create `frontend/src/components/cleanup/LanguageFilterConfig.tsx`:
+
+```typescript
+import { useState } from 'react'
+import { X } from 'lucide-react'
+
+// Common languages for the picker dropdown
+const COMMON_LANGUAGES = [
+  { code: 'de', label: 'Deutsch', flag: '🇩🇪' },
+  { code: 'en', label: 'Englisch', flag: '🇬🇧' },
+  { code: 'ja', label: 'Japanisch', flag: '🇯🇵' },
+  { code: 'fr', label: 'Französisch', flag: '🇫🇷' },
+  { code: 'es', label: 'Spanisch', flag: '🇪🇸' },
+  { code: 'it', label: 'Italienisch', flag: '🇮🇹' },
+  { code: 'pt', label: 'Portugiesisch', flag: '🇵🇹' },
+  { code: 'ru', label: 'Russisch', flag: '🇷🇺' },
+  { code: 'ar', label: 'Arabisch', flag: '🇸🇦' },
+  { code: 'zh', label: 'Chinesisch', flag: '🇨🇳' },
+  { code: 'ko', label: 'Koreanisch', flag: '🇰🇷' },
+  { code: 'pl', label: 'Polnisch', flag: '🇵🇱' },
+]
+
+interface LanguageFilterConfigProps {
+  value: string[]
+  onChange: (langs: string[]) => void
+}
+
+export function LanguageFilterConfig({ value, onChange }: LanguageFilterConfigProps) {
+  const [showDropdown, setShowDropdown] = useState(false)
+
+  const addLang = (code: string) => {
+    if (!value.includes(code)) onChange([...value, code])
+    setShowDropdown(false)
+  }
+
+  const removeLang = (code: string) => onChange(value.filter((l) => l !== code))
+
+  const getLang = (code: string) =>
+    COMMON_LANGUAGES.find((l) => l.code === code) ?? { code, label: code.toUpperCase(), flag: '🌐' }
+
+  const available = COMMON_LANGUAGES.filter((l) => !value.includes(l.code))
+
+  return (
+    <div className="space-y-3">
+      <div className="text-[10px] font-semibold uppercase tracking-wide" style={{ color: 'var(--text-muted)' }}>
+        Behalten
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {value.map((code) => {
+          const lang = getLang(code)
+          return (
+            <span
+              key={code}
+              className="flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium"
+              style={{ background: 'var(--accent-bg)', border: '1px solid var(--accent)', color: 'var(--accent)' }}
+            >
+              <span>{lang.flag}</span>
+              {lang.label} ({code})
+              <button
+                onClick={() => removeLang(code)}
+                className="ml-0.5 opacity-70 hover:opacity-100"
+              >
+                <X size={10} />
+              </button>
+            </span>
+          )
+        })}
+
+        <div className="relative">
+          <button
+            onClick={() => setShowDropdown(!showDropdown)}
+            className="flex items-center gap-1 px-2.5 py-1 rounded-md text-xs border border-dashed"
+            style={{ borderColor: 'var(--border)', color: 'var(--text-muted)' }}
+          >
+            + Sprache hinzufügen
+          </button>
+          {showDropdown && available.length > 0 && (
+            <div
+              className="absolute top-8 left-0 z-10 rounded-lg shadow-lg py-1 min-w-[180px]"
+              style={{ background: 'var(--bg-surface)', border: '1px solid var(--border)' }}
+            >
+              {available.map((lang) => (
+                <button
+                  key={lang.code}
+                  onClick={() => addLang(lang.code)}
+                  className="w-full flex items-center gap-2 px-3 py-1.5 text-xs text-left hover:opacity-80"
+                  style={{ color: 'var(--text-primary)' }}
+                >
+                  <span>{lang.flag}</span> {lang.label}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+      <div className="text-xs" style={{ color: 'var(--text-muted)' }}>
+        NFO-Dateien (.nfo) werden nie angefasst.
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Create FormatUpgradeConfig**
+
+Create `frontend/src/components/cleanup/FormatUpgradeConfig.tsx`:
+
+```typescript
+type KeepFormat = 'any' | 'ass' | 'srt'
+
+interface FormatUpgradeConfigProps {
+  value: KeepFormat
+  onChange: (format: KeepFormat) => void
+}
+
+const OPTIONS: { value: KeepFormat; label: string; desc: string }[] = [
+  { value: 'any', label: 'Beide behalten', desc: 'SRT und ASS gleichzeitig' },
+  { value: 'ass', label: 'ASS bevorzugen', desc: 'SRT löschen wenn ASS vorhanden' },
+  { value: 'srt', label: 'SRT bevorzugen', desc: 'ASS löschen wenn SRT vorhanden' },
+]
+
+export function FormatUpgradeConfig({ value, onChange }: FormatUpgradeConfigProps) {
+  return (
+    <div className="flex gap-3">
+      {OPTIONS.map((opt) => (
+        <button
+          key={opt.value}
+          onClick={() => onChange(opt.value)}
+          className="flex-1 p-3 rounded-lg text-left transition-all"
+          style={{
+            background: value === opt.value ? 'var(--accent-bg)' : 'var(--bg-primary)',
+            border: `1px solid ${value === opt.value ? 'var(--accent)' : 'var(--border)'}`,
+          }}
+        >
+          <div
+            className="text-xs font-semibold mb-0.5"
+            style={{ color: value === opt.value ? 'var(--accent)' : 'var(--text-primary)' }}
+          >
+            {opt.label}
+          </div>
+          <div className="text-[11px]" style={{ color: 'var(--text-muted)' }}>
+            {opt.desc}
+          </div>
+        </button>
+      ))}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 3: Create SchedulePicker**
+
+Create `frontend/src/components/cleanup/SchedulePicker.tsx`:
+
+```typescript
+type Schedule = 'manual' | 'daily' | 'weekly' | 'after_scan'
+
+interface SchedulePickerProps {
+  value: Schedule
+  onChange: (schedule: Schedule) => void
+}
+
+const OPTIONS: { value: Schedule; label: string }[] = [
+  { value: 'manual', label: 'Manuell' },
+  { value: 'daily', label: 'Täglich (03:00)' },
+  { value: 'weekly', label: 'Wöchentlich' },
+  { value: 'after_scan', label: 'Nach jedem Scan' },
+]
+
+export function SchedulePicker({ value, onChange }: SchedulePickerProps) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {OPTIONS.map((opt) => (
+        <button
+          key={opt.value}
+          onClick={() => onChange(opt.value)}
+          className="px-3 py-1.5 rounded-full text-xs font-medium transition-all"
+          style={{
+            background: value === opt.value ? 'var(--accent-bg)' : 'var(--bg-primary)',
+            border: `1px solid ${value === opt.value ? 'var(--accent)' : 'var(--border)'}`,
+            color: value === opt.value ? 'var(--accent)' : 'var(--text-muted)',
+          }}
+        >
+          {opt.label}
+        </button>
+      ))}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: TypeScript check**
+
+```bash
+cd frontend
+npx tsc --noEmit 2>&1 | head -20
+```
+
+Expected: No errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/cleanup/LanguageFilterConfig.tsx \
+        frontend/src/components/cleanup/FormatUpgradeConfig.tsx \
+        frontend/src/components/cleanup/SchedulePicker.tsx
+git commit -m "feat: add LanguageFilterConfig, FormatUpgradeConfig, SchedulePicker components"
+```
+
+---
+
+## Task 8: Frontend — RuleSidebar + RuleDetail
+
+**Files:**
+- Create: `frontend/src/components/cleanup/RuleSidebar.tsx`
+- Create: `frontend/src/components/cleanup/RuleDetail.tsx`
+
+- [ ] **Step 1: Create RuleSidebar**
+
+Create `frontend/src/components/cleanup/RuleSidebar.tsx`:
+
+```typescript
+import { Plus } from 'lucide-react'
+import type { CleanupRule } from '@/types/system'
+
+const TYPE_META: Record<string, { icon: string; label: string; colorClass: string }> = {
+  language_filter: { icon: '🌐', label: 'Sprache', colorClass: 'type-lang' },
+  format_upgrade:  { icon: '⬆️', label: 'Qualität', colorClass: 'type-quality' },
+  orphan_files:    { icon: '🗑️', label: 'Orphan',  colorClass: 'type-orphan' },
+  orphan_db:       { icon: '🗄️', label: 'Datenbank', colorClass: 'type-db' },
+  dedup:           { icon: '🔍', label: 'Dedup',   colorClass: 'type-dedup' },
+}
+
+const SCHEDULE_LABELS: Record<string, string> = {
+  manual: 'Manuell',
+  daily: '🕐 Täglich',
+  weekly: '🕐 Wöchentlich',
+  after_scan: '🕐 Nach Scan',
+}
+
+interface RuleSidebarProps {
+  rules: CleanupRule[]
+  selectedId: number | null
+  onSelect: (id: number) => void
+  onNew: () => void
+}
+
+export function RuleSidebar({ rules, selectedId, onSelect, onNew }: RuleSidebarProps) {
+  return (
+    <div
+      className="flex flex-col flex-shrink-0"
+      style={{ width: 260, background: 'var(--bg-surface)', borderRight: '1px solid var(--border)' }}
+    >
+      <div className="flex items-center justify-between px-4 py-3">
+        <span className="text-[10px] font-semibold uppercase tracking-wide" style={{ color: 'var(--text-muted)' }}>
+          Regeln
+        </span>
+        <button
+          onClick={onNew}
+          className="flex items-center gap-1 px-2.5 py-1 rounded text-xs font-medium"
+          style={{ border: '1px solid var(--accent)', color: 'var(--accent)' }}
+        >
+          <Plus size={10} /> Neu
+        </button>
+      </div>
+
+      <div className="flex flex-col gap-1 px-2 overflow-y-auto">
+        {rules.map((rule) => {
+          const meta = TYPE_META[rule.rule_type] ?? { icon: '⚙️', label: rule.rule_type, colorClass: '' }
+          const isActive = rule.id === selectedId
+          return (
+            <button
+              key={rule.id}
+              onClick={() => onSelect(rule.id)}
+              className="w-full text-left rounded-lg p-2.5 transition-all"
+              style={{
+                background: isActive ? 'var(--accent-bg)' : 'transparent',
+                border: `1px solid ${isActive ? 'var(--accent)' : 'transparent'}`,
+              }}
+            >
+              <div className="flex items-center gap-2 mb-1">
+                <span
+                  className="flex items-center justify-center rounded-md text-sm flex-shrink-0"
+                  style={{ width: 28, height: 28, background: 'var(--bg-primary)' }}
+                >
+                  {meta.icon}
+                </span>
+                <span className="flex-1 text-sm font-medium truncate" style={{ color: 'var(--text-primary)' }}>
+                  {rule.name}
+                </span>
+                <span
+                  className="w-2 h-2 rounded-full flex-shrink-0"
+                  style={{ background: rule.enabled ? 'var(--success)' : 'var(--border)' }}
+                />
+              </div>
+              <div className="flex items-center gap-1.5 pl-9">
+                <span
+                  className="text-[10px] font-medium px-1.5 py-0.5 rounded uppercase"
+                  style={{ background: 'var(--bg-primary)', color: 'var(--accent)' }}
+                >
+                  {meta.label}
+                </span>
+                <span className="text-[10px]" style={{ color: 'var(--text-muted)' }}>
+                  {SCHEDULE_LABELS[rule.schedule] ?? rule.schedule}
+                </span>
+              </div>
+            </button>
+          )
+        })}
+
+        {rules.length === 0 && (
+          <div className="px-3 py-6 text-xs text-center" style={{ color: 'var(--text-muted)' }}>
+            Noch keine Regeln. Erstelle eine um loszulegen.
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Create RuleDetail**
+
+Create `frontend/src/components/cleanup/RuleDetail.tsx`:
+
+```typescript
+import { Play, Eye, Trash2, Power } from 'lucide-react'
+import type { CleanupRule } from '@/types/system'
+import { LanguageFilterConfig } from './LanguageFilterConfig'
+import { FormatUpgradeConfig } from './FormatUpgradeConfig'
+import { SchedulePicker } from './SchedulePicker'
+
+interface PreviewResult {
+  would_delete?: number
+  would_keep?: number
+  would_free_bytes?: number
+}
+
+interface RuleDetailProps {
+  rule: CleanupRule
+  previewResult: PreviewResult | null
+  isRunning: boolean
+  isPreviewing: boolean
+  onRun: () => void
+  onPreview: () => void
+  onDelete: () => void
+  onUpdate: (patch: Partial<CleanupRule>) => void
+}
+
+const TYPE_DESCRIPTIONS: Record<string, string> = {
+  language_filter: 'Löscht Sidecar-Dateien in nicht erlaubten Sprachen',
+  format_upgrade:  'Löscht SRT wenn ASS für dieselbe Episode existiert',
+  orphan_files:    'Löscht Subtitle-Sidecars ohne zugehörige Videodatei auf Disk',
+  orphan_db:       'Entfernt DB-Einträge deren Datei auf Disk fehlt',
+  dedup:           'Findet und löscht doppelte Untertitel-Dateien',
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 B'
+  const units = ['B', 'KB', 'MB', 'GB']
+  const i = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1)
+  return `${(bytes / Math.pow(1024, i)).toFixed(1)} ${units[i]}`
+}
+
+export function RuleDetail({
+  rule, previewResult, isRunning, isPreviewing,
+  onRun, onPreview, onDelete, onUpdate,
+}: RuleDetailProps) {
+  const config = rule.config_json as Record<string, unknown>
+
+  const updateConfig = (patch: Record<string, unknown>) =>
+    onUpdate({ config_json: { ...config, ...patch } })
+
+  return (
+    <div className="flex flex-col gap-5 p-6 overflow-y-auto flex-1">
+      {/* Header */}
+      <div className="flex items-start justify-between">
+        <div className="flex items-center gap-3">
+          <div
+            className="flex items-center justify-center rounded-xl text-2xl flex-shrink-0"
+            style={{ width: 44, height: 44, background: 'var(--accent-bg)' }}
+          >
+            {rule.rule_type === 'language_filter' ? '🌐' :
+             rule.rule_type === 'format_upgrade' ? '⬆️' :
+             rule.rule_type === 'orphan_files' ? '🗑️' :
+             rule.rule_type === 'orphan_db' ? '🗄️' : '⚙️'}
+          </div>
+          <div>
+            <div className="text-lg font-semibold" style={{ color: 'var(--text-primary)' }}>{rule.name}</div>
+            <div className="text-xs" style={{ color: 'var(--text-muted)' }}>
+              {TYPE_DESCRIPTIONS[rule.rule_type] ?? rule.rule_type}
+            </div>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => onUpdate({ enabled: !rule.enabled })}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium"
+            style={{
+              border: '1px solid var(--border)',
+              color: rule.enabled ? 'var(--success)' : 'var(--text-muted)',
+            }}
+          >
+            <Power size={12} />
+            {rule.enabled ? 'Aktiv' : 'Deaktiviert'}
+          </button>
+          <button
+            onClick={onPreview}
+            disabled={isPreviewing}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium"
+            style={{ border: '1px solid var(--border)', color: 'var(--text-secondary)' }}
+          >
+            <Eye size={12} />
+            {isPreviewing ? 'Lädt...' : 'Vorschau'}
+          </button>
+          <button
+            onClick={onRun}
+            disabled={isRunning}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium text-white"
+            style={{ background: 'var(--accent)' }}
+          >
+            <Play size={12} />
+            {isRunning ? 'Läuft...' : 'Jetzt ausführen'}
+          </button>
+          <button
+            onClick={onDelete}
+            className="flex items-center gap-1.5 px-2 py-1.5 rounded-lg text-xs"
+            style={{ border: '1px solid var(--error-dim, #3a1a1a)', color: 'var(--error)' }}
+          >
+            <Trash2 size={12} />
+          </button>
+        </div>
+      </div>
+
+      {/* Last run bar */}
+      {rule.last_run_at && (
+        <div
+          className="flex items-center gap-2 px-3 py-2 rounded-lg text-xs"
+          style={{ background: 'var(--bg-surface)', border: '1px solid var(--border)' }}
+        >
+          <span className="w-2 h-2 rounded-full flex-shrink-0" style={{ background: 'var(--success)' }} />
+          <span style={{ color: 'var(--success)' }}>Letzter Lauf erfolgreich</span>
+          <span className="ml-auto" style={{ color: 'var(--text-muted)' }}>
+            {new Date(rule.last_run_at).toLocaleString('de-DE')}
+          </span>
+        </div>
+      )}
+
+      {/* Config sections */}
+      {rule.rule_type === 'language_filter' && (
+        <ConfigSection title="Erlaubte Sprachen" icon="🌐">
+          <LanguageFilterConfig
+            value={(config.keep_languages as string[]) ?? []}
+            onChange={(langs) => updateConfig({ keep_languages: langs })}
+          />
+        </ConfigSection>
+      )}
+
+      {rule.rule_type === 'format_upgrade' && (
+        <ConfigSection title="Format-Präferenz" icon="📄">
+          <FormatUpgradeConfig
+            value={(config.keep_format as 'any' | 'ass' | 'srt') ?? 'any'}
+            onChange={(fmt) => updateConfig({ keep_format: fmt })}
+          />
+        </ConfigSection>
+      )}
+
+      <ConfigSection title="Zeitplan" icon="🕐">
+        <SchedulePicker
+          value={rule.schedule}
+          onChange={(s) => onUpdate({ schedule: s })}
+        />
+      </ConfigSection>
+
+      {/* Preview result */}
+      {previewResult && (
+        <ConfigSection title="Vorschau" icon="👁️">
+          <div className="space-y-1.5">
+            {Object.entries(previewResult).map(([key, val]) => (
+              <div key={key} className="flex justify-between text-xs">
+                <span style={{ color: 'var(--text-muted)' }}>{key}</span>
+                <span style={{ color: 'var(--text-primary)', fontFamily: 'var(--font-mono)' }}>
+                  {typeof val === 'number' && key.includes('byte') ? formatBytes(val) : val}
+                </span>
+              </div>
+            ))}
+          </div>
+        </ConfigSection>
+      )}
+    </div>
+  )
+}
+
+function ConfigSection({ title, icon, children }: { title: string; icon: string; children: React.ReactNode }) {
+  return (
+    <div
+      className="rounded-xl overflow-hidden"
+      style={{ background: 'var(--bg-surface)', border: '1px solid var(--border)' }}
+    >
+      <div
+        className="flex items-center gap-2.5 px-4 py-3"
+        style={{ borderBottom: '1px solid var(--border)' }}
+      >
+        <span
+          className="flex items-center justify-center rounded-md text-sm"
+          style={{ width: 26, height: 26, background: 'var(--accent-bg)' }}
+        >
+          {icon}
+        </span>
+        <span className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>{title}</span>
+      </div>
+      <div className="p-4">{children}</div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 3: TypeScript check**
+
+```bash
+cd frontend
+npx tsc --noEmit 2>&1 | head -20
+```
+
+Expected: No errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/cleanup/RuleSidebar.tsx \
+        frontend/src/components/cleanup/RuleDetail.tsx
+git commit -m "feat: add RuleSidebar and RuleDetail components"
+```
+
+---
+
+## Task 9: Frontend — CleanupSettings page
+
+**Files:**
+- Create: `frontend/src/pages/Settings/CleanupSettings.tsx`
+- Create: `frontend/src/pages/Settings/__tests__/CleanupSettings.test.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `frontend/src/pages/Settings/__tests__/CleanupSettings.test.tsx`:
+
+```typescript
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+vi.mock('@/hooks/useSystemApi', () => ({
+  useCleanupRules: () => ({ data: [], isLoading: false }),
+  useCreateCleanupRule: () => ({ mutate: vi.fn(), isPending: false }),
+  useUpdateCleanupRule: () => ({ mutate: vi.fn() }),
+  useDeleteCleanupRule: () => ({ mutate: vi.fn() }),
+  useRunCleanupRule: () => ({ mutate: vi.fn(), isPending: false }),
+  useRulePreview: () => ({ mutate: vi.fn(), isPending: false }),
+  useCleanupStats: () => ({ data: null, isLoading: false }),
+  useStartCleanupScan: () => ({ mutate: vi.fn(), isPending: false }),
+  useCleanupScanStatus: () => ({ data: null }),
+  useDuplicates: () => ({ data: null, refetch: vi.fn() }),
+  useDeleteDuplicates: () => ({ mutate: vi.fn(), isPending: false }),
+  useOrphanedScan: () => ({ mutate: vi.fn(), isPending: false }),
+  useOrphanedFiles: () => ({ data: null, refetch: vi.fn() }),
+  useDeleteOrphaned: () => ({ mutate: vi.fn(), isPending: false }),
+  useCleanupHistory: () => ({ data: null }),
+  useCleanupPreview: () => ({ mutate: vi.fn() }),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string, fb: string) => fb ?? k }),
+}))
+
+function wrap(ui: React.ReactElement) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>)
+}
+
+describe('CleanupSettings', () => {
+  it('renders the page heading', async () => {
+    const { CleanupSettings } = await import('../CleanupSettings')
+    wrap(<CleanupSettings />)
+    expect(screen.getByText(/Cleanup Rules/i)).toBeTruthy()
+  })
+
+  it('shows empty state when no rules exist', async () => {
+    const { CleanupSettings } = await import('../CleanupSettings')
+    wrap(<CleanupSettings />)
+    expect(screen.getByText(/Noch keine Regeln/i)).toBeTruthy()
+  })
+
+  it('shows "+ Neu" button in sidebar', async () => {
+    const { CleanupSettings } = await import('../CleanupSettings')
+    wrap(<CleanupSettings />)
+    expect(screen.getByText('Neu')).toBeTruthy()
+  })
+})
+```
+
+- [ ] **Step 2: Run tests — confirm they fail**
+
+```bash
+cd frontend
+npm run test -- --run src/pages/Settings/__tests__/CleanupSettings.test.tsx 2>&1 | tail -10
+```
+
+Expected: FAIL — `CleanupSettings` not found.
+
+- [ ] **Step 3: Create CleanupSettings page**
+
+Create `frontend/src/pages/Settings/CleanupSettings.tsx`:
+
+```typescript
+/**
+ * CleanupSettings — dedicated Settings page for subtitle cleanup rule management.
+ *
+ * Layout:
+ *   Left sidebar: rule list + new rule button
+ *   Right main: disk space widget, rule detail, dedup section, history
+ */
+import { useState, useCallback, useEffect, lazy, Suspense } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Loader2 } from 'lucide-react'
+import { PageHeader } from '@/components/layout/PageHeader'
+import { RuleSidebar } from '@/components/cleanup/RuleSidebar'
+import { RuleDetail } from '@/components/cleanup/RuleDetail'
+import { DiskSpaceWidget } from '@/components/cleanup/DiskSpaceWidget'
+import { DedupGroupList } from '@/components/cleanup/DedupGroupList'
+import { CleanupPreview } from '@/components/cleanup/CleanupPreview'
+import { toast } from '@/components/shared/Toast'
+import {
+  useCleanupRules, useCreateCleanupRule, useUpdateCleanupRule,
+  useDeleteCleanupRule, useRunCleanupRule, useRulePreview,
+  useCleanupStats, useStartCleanupScan, useCleanupScanStatus,
+  useDuplicates, useDeleteDuplicates, useOrphanedScan, useOrphanedFiles,
+  useDeleteOrphaned, useCleanupHistory, useCleanupPreview,
+} from '@/hooks/useSystemApi'
+import type { CleanupRule, CleanupPreviewData } from '@/types/system'
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 B'
+  const units = ['B', 'KB', 'MB', 'GB']
+  const i = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1)
+  return `${(bytes / Math.pow(1024, i)).toFixed(1)} ${units[i]}`
+}
+
+// ─── New Rule Modal ──────────────────────────────────────────────────────────
+
+const RULE_TYPES = [
+  { value: 'language_filter', label: 'Sprach-Filter', desc: 'Löscht Sidecars in nicht erlaubten Sprachen' },
+  { value: 'format_upgrade',  label: 'Format-Upgrade', desc: 'Löscht SRT wenn ASS für gleiche Episode existiert' },
+  { value: 'orphan_files',    label: 'Verwaiste Dateien', desc: 'Löscht Subtitle-Sidecars ohne Video auf Disk' },
+  { value: 'orphan_db',       label: 'DB-Bereinigung', desc: 'Entfernt DB-Einträge ohne Datei auf Disk' },
+]
+
+function NewRuleModal({ onClose, onCreate }: {
+  onClose: () => void
+  onCreate: (name: string, rule_type: string) => void
+}) {
+  const [name, setName] = useState('')
+  const [ruleType, setRuleType] = useState('language_filter')
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div
+        className="rounded-xl p-6 w-96 space-y-4"
+        style={{ background: 'var(--bg-surface)', border: '1px solid var(--border)' }}
+      >
+        <h3 className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
+          Neue Cleanup-Regel
+        </h3>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Regelname"
+          className="w-full px-3 py-2 rounded-lg text-sm focus:outline-none"
+          style={{ background: 'var(--bg-primary)', border: '1px solid var(--border)', color: 'var(--text-primary)' }}
+        />
+        <div className="space-y-2">
+          {RULE_TYPES.map((rt) => (
+            <label
+              key={rt.value}
+              className="flex items-start gap-3 p-3 rounded-lg cursor-pointer"
+              style={{
+                background: ruleType === rt.value ? 'var(--accent-bg)' : 'var(--bg-primary)',
+                border: `1px solid ${ruleType === rt.value ? 'var(--accent)' : 'var(--border)'}`,
+              }}
+            >
+              <input
+                type="radio"
+                name="ruleType"
+                value={rt.value}
+                checked={ruleType === rt.value}
+                onChange={() => setRuleType(rt.value)}
+                className="mt-0.5"
+              />
+              <div>
+                <div className="text-xs font-semibold" style={{ color: 'var(--text-primary)' }}>{rt.label}</div>
+                <div className="text-[11px]" style={{ color: 'var(--text-muted)' }}>{rt.desc}</div>
+              </div>
+            </label>
+          ))}
+        </div>
+        <div className="flex gap-2 justify-end">
+          <button
+            onClick={onClose}
+            className="px-3 py-1.5 rounded text-xs"
+            style={{ color: 'var(--text-muted)' }}
+          >
+            Abbrechen
+          </button>
+          <button
+            onClick={() => { if (name.trim()) onCreate(name.trim(), ruleType) }}
+            disabled={!name.trim()}
+            className="px-4 py-1.5 rounded text-xs font-medium text-white disabled:opacity-50"
+            style={{ background: 'var(--accent)' }}
+          >
+            Erstellen
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ─── History Section ─────────────────────────────────────────────────────────
+
+function HistorySection() {
+  const { t } = useTranslation('settings')
+  const [page, setPage] = useState(1)
+  const { data: historyData } = useCleanupHistory(page)
+  const entries = historyData?.entries ?? []
+  const total = historyData?.total ?? 0
+
+  if (entries.length === 0) return null
+
+  return (
+    <div
+      className="rounded-xl overflow-hidden"
+      style={{ background: 'var(--bg-surface)', border: '1px solid var(--border)' }}
+    >
+      <div className="px-4 py-3" style={{ borderBottom: '1px solid var(--border)' }}>
+        <span className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
+          {t('cleanup.history.title', 'Cleanup History')}
+        </span>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full text-xs">
+          <thead>
+            <tr style={{ borderBottom: '1px solid var(--border)' }}>
+              {['Datum', 'Aktion', 'Verarbeitet', 'Gelöscht', 'Freigegeben'].map((h) => (
+                <th key={h} className="py-2 px-3 text-left font-medium" style={{ color: 'var(--text-muted)' }}>{h}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {entries.map((entry) => (
+              <tr key={entry.id} style={{ borderBottom: '1px solid var(--border)' }}>
+                <td className="py-2 px-3" style={{ color: 'var(--text-secondary)' }}>
+                  {new Date(entry.performed_at).toLocaleString('de-DE')}
+                </td>
+                <td className="py-2 px-3">
+                  <span
+                    className="px-1.5 py-0.5 rounded text-[10px] font-medium"
+                    style={{ background: 'var(--accent-bg)', color: 'var(--accent)' }}
+                  >
+                    {entry.action_type}
+                  </span>
+                </td>
+                <td className="py-2 px-3 tabular-nums" style={{ fontFamily: 'var(--font-mono)', color: 'var(--text-secondary)' }}>
+                  {entry.files_processed}
+                </td>
+                <td className="py-2 px-3 tabular-nums" style={{ fontFamily: 'var(--font-mono)', color: 'var(--error)' }}>
+                  {entry.files_deleted}
+                </td>
+                <td className="py-2 px-3 tabular-nums" style={{ fontFamily: 'var(--font-mono)', color: 'var(--success)' }}>
+                  {formatBytes(entry.bytes_freed)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {total > 50 && (
+        <div className="flex items-center justify-center gap-2 p-3">
+          <button
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+            disabled={page <= 1}
+            className="px-2 py-1 rounded text-xs disabled:opacity-40"
+            style={{ border: '1px solid var(--border)', color: 'var(--text-muted)' }}
+          >
+            Zurück
+          </button>
+          <span className="text-xs" style={{ color: 'var(--text-muted)' }}>
+            {page} / {Math.ceil(total / 50)}
+          </span>
+          <button
+            onClick={() => setPage((p) => p + 1)}
+            disabled={page >= Math.ceil(total / 50)}
+            className="px-2 py-1 rounded text-xs disabled:opacity-40"
+            style={{ border: '1px solid var(--border)', color: 'var(--text-muted)' }}
+          >
+            Weiter
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─── Main Page ───────────────────────────────────────────────────────────────
+
+export function CleanupSettings() {
+  const { t } = useTranslation('settings')
+  const { data: rules = [], isLoading } = useCleanupRules()
+  const { data: stats } = useCleanupStats()
+  const createRule = useCreateCleanupRule()
+  const updateRule = useUpdateCleanupRule()
+  const deleteRule = useDeleteCleanupRule()
+  const runRule = useRunCleanupRule()
+  const rulePreview = useRulePreview()
+  const startScan = useStartCleanupScan()
+  const [isScanning, setIsScanning] = useState(false)
+  const scanStatus = useCleanupScanStatus(isScanning)
+  const { data: duplicatesData, refetch: refetchDuplicates } = useDuplicates()
+  const deleteDuplicates = useDeleteDuplicates()
+  const cleanupPreview = useCleanupPreview()
+
+  const [selectedId, setSelectedId] = useState<number | null>(null)
+  const [showNewModal, setShowNewModal] = useState(false)
+  const [previewResult, setPreviewResult] = useState<Record<string, number> | null>(null)
+  const [dedupPreviewData, setDedupPreviewData] = useState<CleanupPreviewData | null>(null)
+  const [pendingDeleteSelections, setPendingDeleteSelections] = useState<{ keep: string; delete: string[] }[] | null>(null)
+
+  const selectedRule = rules.find((r) => r.id === selectedId) ?? null
+
+  // Auto-select first rule
+  useEffect(() => {
+    if (rules.length > 0 && selectedId === null) setSelectedId(rules[0].id)
+  }, [rules, selectedId])
+
+  // Stop scan polling when done
+  useEffect(() => {
+    if (scanStatus.data?.status === 'idle' && isScanning) {
+      setIsScanning(false)
+      void refetchDuplicates()
+    }
+  }, [scanStatus.data, isScanning, refetchDuplicates])
+
+  const handleCreate = useCallback((name: string, rule_type: string) => {
+    createRule.mutate(
+      { name, rule_type: rule_type as CleanupRule['rule_type'], config_json: {}, enabled: true, schedule: 'manual' },
+      {
+        onSuccess: (rule) => { setSelectedId(rule.id); setShowNewModal(false) },
+        onError: () => toast('Fehler beim Erstellen der Regel', 'error'),
+      }
+    )
+  }, [createRule])
+
+  const handleUpdate = useCallback((patch: Partial<CleanupRule>) => {
+    if (!selectedId) return
+    updateRule.mutate({ id: selectedId, data: patch }, {
+      onError: () => toast('Fehler beim Speichern', 'error'),
+    })
+  }, [selectedId, updateRule])
+
+  const handleDelete = useCallback(() => {
+    if (!selectedId) return
+    deleteRule.mutate(selectedId, {
+      onSuccess: () => { setSelectedId(null); toast('Regel gelöscht') },
+      onError: () => toast('Fehler beim Löschen', 'error'),
+    })
+  }, [selectedId, deleteRule])
+
+  const handleRun = useCallback(() => {
+    if (!selectedId) return
+    runRule.mutate(selectedId, {
+      onSuccess: () => toast('Regel erfolgreich ausgeführt'),
+      onError: () => toast('Fehler beim Ausführen', 'error'),
+    })
+  }, [selectedId, runRule])
+
+  const handlePreview = useCallback(() => {
+    if (!selectedId) return
+    rulePreview.mutate(selectedId, {
+      onSuccess: (data) => setPreviewResult(data.preview),
+      onError: () => toast('Vorschau fehlgeschlagen', 'error'),
+    })
+  }, [selectedId, rulePreview])
+
+  const handleStartScan = useCallback(() => {
+    startScan.mutate(undefined, {
+      onSuccess: () => setIsScanning(true),
+      onError: () => toast('Scan fehlgeschlagen', 'error'),
+    })
+  }, [startScan])
+
+  const handleDeleteDuplicates = useCallback((selections: { keep: string; delete: string[] }[]) => {
+    setPendingDeleteSelections(selections)
+    cleanupPreview.mutate(undefined, {
+      onSuccess: (data) => setDedupPreviewData(data),
+      onError: () => {
+        deleteDuplicates.mutate(selections, {
+          onSuccess: (result) => {
+            toast(`${result.deleted} Dateien gelöscht, ${formatBytes(result.bytes_freed)} freigegeben`)
+            setPendingDeleteSelections(null)
+          },
+          onError: () => toast('Fehler beim Löschen', 'error'),
+        })
+      },
+    })
+  }, [cleanupPreview, deleteDuplicates])
+
+  const handleConfirmDedupDelete = useCallback(() => {
+    if (!pendingDeleteSelections) return
+    deleteDuplicates.mutate(pendingDeleteSelections, {
+      onSuccess: (result) => {
+        toast(`${result.deleted} Dateien gelöscht, ${formatBytes(result.bytes_freed)} freigegeben`)
+        setPendingDeleteSelections(null)
+        setDedupPreviewData(null)
+      },
+      onError: () => toast('Fehler beim Löschen', 'error'),
+    })
+  }, [pendingDeleteSelections, deleteDuplicates])
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <Loader2 size={28} className="animate-spin" style={{ color: 'var(--accent)' }} />
+      </div>
+    )
+  }
+
+  const groups = duplicatesData?.groups ?? []
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="px-6 py-5" style={{ borderBottom: '1px solid var(--border)' }}>
+        <PageHeader
+          title={t('cleanup.page.title', 'Cleanup Rules')}
+          subtitle={t('cleanup.page.subtitle', 'Automatisierte Bereinigung von Sidecar-Dateien und Datenbankeinträgen')}
+        />
+      </div>
+
+      <div className="flex flex-1 overflow-hidden">
+        {/* Sidebar */}
+        <RuleSidebar
+          rules={rules}
+          selectedId={selectedId}
+          onSelect={(id) => { setSelectedId(id); setPreviewResult(null) }}
+          onNew={() => setShowNewModal(true)}
+        />
+
+        {/* Main content */}
+        <div className="flex-1 overflow-y-auto p-6 space-y-5">
+          {/* Disk space */}
+          {stats && <DiskSpaceWidget stats={stats} />}
+
+          {/* Rule detail */}
+          {selectedRule ? (
+            <RuleDetail
+              rule={selectedRule}
+              previewResult={previewResult}
+              isRunning={runRule.isPending}
+              isPreviewing={rulePreview.isPending}
+              onRun={handleRun}
+              onPreview={handlePreview}
+              onDelete={handleDelete}
+              onUpdate={handleUpdate}
+            />
+          ) : (
+            <div
+              className="rounded-xl p-12 text-center text-sm"
+              style={{ background: 'var(--bg-surface)', border: '1px solid var(--border)', color: 'var(--text-muted)' }}
+            >
+              Wähle eine Regel aus der Sidebar oder erstelle eine neue.
+            </div>
+          )}
+
+          {/* Dedup section */}
+          <div
+            className="rounded-xl overflow-hidden"
+            style={{ background: 'var(--bg-surface)', border: '1px solid var(--border)' }}
+          >
+            <div className="flex items-center justify-between px-4 py-3" style={{ borderBottom: '1px solid var(--border)' }}>
+              <span className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
+                {t('cleanup.dedup.title', 'Deduplication')}
+              </span>
+              <button
+                onClick={handleStartScan}
+                disabled={isScanning || startScan.isPending}
+                className="flex items-center gap-1.5 px-3 py-1.5 rounded text-xs font-medium text-white disabled:opacity-50"
+                style={{ background: 'var(--accent)' }}
+              >
+                {isScanning ? <Loader2 size={12} className="animate-spin" /> : null}
+                {isScanning ? 'Scannt...' : t('cleanup.dedup.scanButton', 'Scan for Duplicates')}
+              </button>
+            </div>
+            <div className="p-4">
+              {dedupPreviewData ? (
+                <CleanupPreview
+                  preview={dedupPreviewData}
+                  onConfirm={handleConfirmDedupDelete}
+                  onCancel={() => { setDedupPreviewData(null); setPendingDeleteSelections(null) }}
+                  isConfirming={deleteDuplicates.isPending}
+                />
+              ) : groups.length > 0 ? (
+                <DedupGroupList groups={groups} onDelete={handleDeleteDuplicates} isDeleting={deleteDuplicates.isPending} />
+              ) : (
+                <div className="text-sm text-center py-4" style={{ color: 'var(--text-muted)' }}>
+                  {t('cleanup.dedup.noResults', 'No duplicates found. Run a scan to check.')}
+                </div>
+              )}
+            </div>
+          </div>
+
+          <HistorySection />
+        </div>
+      </div>
+
+      {showNewModal && (
+        <NewRuleModal
+          onClose={() => setShowNewModal(false)}
+          onCreate={handleCreate}
+        />
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Run tests — confirm they pass**
+
+```bash
+cd frontend
+npm run test -- --run src/pages/Settings/__tests__/CleanupSettings.test.tsx 2>&1 | tail -15
+```
+
+Expected: 3 PASSED
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/Settings/CleanupSettings.tsx \
+        frontend/src/pages/Settings/__tests__/CleanupSettings.test.tsx
+git commit -m "feat: add CleanupSettings page with sidebar/detail layout"
+```
+
+---
+
+## Task 10: Wire Navigation — Settings tile + route + remove from SubtitlesSettings
+
+**Files:**
+- Modify: `frontend/src/components/settings/SettingsGrid.tsx`
+- Modify: `frontend/src/pages/Settings/index.tsx`
+- Modify: `frontend/src/pages/Settings/SubtitlesSettings.tsx`
+
+- [ ] **Step 1: Add cleanup tile to SettingsGrid**
+
+In `frontend/src/components/settings/SettingsGrid.tsx`, add `Trash2` to the lucide imports, then add to `CATEGORIES` array (before `about`):
+
+```typescript
+import {
+  Settings, Plug, Subtitles, Globe, Zap, Languages, Bell, Shield, Heart, Trash2,
+} from 'lucide-react'
+```
+
+```typescript
+  {
+    id: 'cleanup',
+    icon: Trash2,
+    titleKey: 'settings.categories.cleanup.title',
+    descKey: 'settings.categories.cleanup.description',
+    badge: 'Cleanup',
+  },
+```
+
+Also add to `CATEGORY_FALLBACKS`:
+
+```typescript
+  cleanup: { title: 'Cleanup', description: 'Language filters, format upgrades, orphan removal' },
+```
+
+- [ ] **Step 2: Add route in Settings/index.tsx**
+
+In `frontend/src/pages/Settings/index.tsx`, add the import:
+
+```typescript
+const CleanupSettings = lazy(() =>
+  import('./CleanupSettings').then((m) => ({ default: m.CleanupSettings }))
+)
+```
+
+Add the route inside `<Routes>`:
+
+```typescript
+<Route path="cleanup" element={<Suspense fallback={<FormSkeleton />}><CleanupSettings /></Suspense>} />
+```
+
+- [ ] **Step 3: Remove CleanupTab from SubtitlesSettings**
+
+In `frontend/src/pages/Settings/SubtitlesSettings.tsx`:
+
+1. Remove the lazy import of `CleanupTab` (lines ~35-37)
+2. Remove the `<div data-testid="section-cleanup">` block (and its contents) — the entire section including the `<SettingsSection>` wrapper and `<CleanupTab />`
+
+- [ ] **Step 4: Run full frontend checks**
+
+```bash
+cd frontend
+npm run lint && npx tsc --noEmit && npm run test -- --run 2>&1 | tail -20
+```
+
+Expected: lint clean, no type errors, all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/settings/SettingsGrid.tsx \
+        frontend/src/pages/Settings/index.tsx \
+        frontend/src/pages/Settings/SubtitlesSettings.tsx
+git commit -m "feat: add cleanup settings tile and route, remove CleanupTab from SubtitlesSettings"
+```
+
+---
+
+## Task 11: Final Pre-PR Check
+
+- [ ] **Step 1: Run full backend test suite**
+
+```bash
+cd backend
+python -m pytest --tb=short -q \
+  --ignore=tests/performance \
+  --ignore=tests/integration/test_provider_pipeline.py \
+  --ignore=tests/test_video_sync.py \
+  --ignore=tests/test_translation_backends.py \
+  -k "not (test_sonarr_download_webhook or test_radarr_download_webhook or test_parse_llm_response_too_many_merge or test_record_backend_success)"
+```
+
+Expected: All pass.
+
+- [ ] **Step 2: Run full frontend checks**
+
+```bash
+cd frontend
+npm run lint && npx tsc --noEmit && npm run test -- --run
+```
+
+Expected: lint clean, no type errors, all tests pass.
+
+- [ ] **Step 3: Run ruff on full backend**
+
+```bash
+cd backend
+ruff check . && ruff format --check .
+```
+
+Expected: Clean.
+
+- [ ] **Step 4: Final commit if any fixes were needed, then push**
+
+```bash
+git push
+```

--- a/docs/superpowers/specs/2026-04-04-cleanup-rules-page-design.md
+++ b/docs/superpowers/specs/2026-04-04-cleanup-rules-page-design.md
@@ -1,0 +1,168 @@
+# Cleanup Rules Page — Design Spec
+
+**Date:** 2026-04-04  
+**Status:** Approved  
+**Scope:** Dedicated Cleanup Rules settings page replacing the existing CleanupTab
+
+---
+
+## 1. Overview
+
+Replace the existing `CleanupTab` (Settings → Cleanup tab) with a dedicated first-class Settings page — accessible as its own tile in the Settings grid alongside General, About, etc.
+
+The page provides a full cleanup workflow UI: rule list sidebar + detail view, replacing the current scattered approach (comma-separated text fields in config, non-functional rule CRUD, separate scan buttons).
+
+**Out of scope:** NFO files (`.nfo`) are system-wide excluded from all cleanup operations — this is hardcoded, not configurable.
+
+---
+
+## 2. Navigation & Layout
+
+### Settings Grid
+
+Add a `Cleanup` tile to the Settings overview grid. Clicking navigates to `/settings/cleanup`.
+
+### Page Layout
+
+```
+┌─────────────────────────────────────────────────────┐
+│  Topbar: Settings / Cleanup                         │
+├──────────────┬──────────────────────────────────────┤
+│              │  [DiskSpace Widget]                  │
+│  Sidebar     │                                      │
+│  ─────────   │  [Rule Detail View]                  │
+│  Rule list   │    - Header (name, icon, actions)    │
+│  + New Rule  │    - Last run bar                    │
+│              │    - Config sections                  │
+│              │    - Preview box                     │
+│              ├──────────────────────────────────────┤
+│              │  [History] (collapsible)             │
+└──────────────┴──────────────────────────────────────┘
+```
+
+**Sidebar (260px fixed):**
+- Section label "Regeln" + "+ Neu" button
+- Each rule shown as a card: type icon, name, enabled dot, type badge, schedule badge
+- Active rule highlighted with accent border
+
+**Main area:**
+- DiskSpace widget at top (moved from old CleanupTab)
+- Rule detail view when a rule is selected
+- Deduplication section (interactive hash-based scan — kept separate, not a rule type)
+- History table (collapsible, paginated, at bottom)
+
+---
+
+## 3. Rule Types
+
+Four rule types, selectable when creating a new rule:
+
+| Type | Key | Description | Config fields |
+|------|-----|-------------|---------------|
+| Sprach-Filter | `language_filter` | Deletes sidecar files in non-allowed languages | `keep_languages: string[]` |
+| Format-Upgrade | `format_upgrade` | Deletes SRT when ASS exists for the same episode | `keep_format: "ass" \| "srt" \| "any"` |
+| Verwaiste Dateien | `orphan_files` | Deletes subtitle sidecars with no matching video on disk | _(no extra config)_ |
+| DB-Bereinigung | `orphan_db` | Removes DB subtitle entries whose file no longer exists on disk | _(no extra config)_ |
+
+Every rule additionally has:
+- `name: string` — user-defined label
+- `enabled: boolean` — toggle on/off
+- `schedule: "manual" | "daily" | "weekly" | "after_scan"` — when the rule runs automatically
+
+---
+
+## 4. Rule Detail UI
+
+### Header
+- Type icon (32×32 rounded, type-colored background) + rule name + description
+- Action buttons: **Vorschau** (ghost), **Jetzt ausführen** (accent), **Löschen** (danger)
+- Inline name editing (click to edit)
+
+### Last Run Bar
+- Green dot + "Letzter Lauf erfolgreich" + stats (files deleted, MB freed) + timestamp
+- Red dot + error message if last run failed
+- Hidden if rule has never run
+
+### Config Sections (per rule type)
+
+**Language Filter — "Erlaubte Sprachen"**
+- Tag-style picker: each language shown as a removable pill with flag emoji + ISO code
+- "+ Sprache hinzufügen" opens a searchable dropdown of languages
+- Hint text: "NFO-Dateien (.nfo) werden nie angefasst."
+
+**Format Upgrade — "Format-Präferenz"**
+- Three clickable cards: "Beide behalten" / "ASS bevorzugen" / "SRT bevorzugen"
+- Selected card gets accent border + accent text
+
+**Schedule — "Zeitplan" (all rule types)**
+- Chip selector: Manuell / Täglich 03:00 / Wöchentlich / Nach jedem Scan
+- Selected chip gets accent styling
+
+### Preview Box
+- Triggered by "Vorschau" button, result cached until next click
+- Shows: total sidecar files found, files that would be deleted, MB to free, NFO files excluded (always 0 deleted)
+- Displayed inline below config sections
+
+---
+
+## 5. Deduplication Section
+
+Kept as a standalone section (not a rule type) because it requires interactive group selection — the user must choose which duplicate to keep per group.
+
+- "Scan starten" button + progress bar
+- `DedupGroupList` component (unchanged from current implementation)
+- `CleanupPreview` modal before confirming deletion
+
+---
+
+## 6. Backend Changes
+
+### DB Model: `cleanup_rules`
+
+Extend existing model — add `schedule` column, make `config_json` structured:
+
+```python
+# New columns
+schedule: str = "manual"  # "manual" | "daily" | "weekly" | "after_scan"
+
+# config_json structure per type
+# language_filter:  {"keep_languages": ["de", "en"]}
+# format_upgrade:   {"keep_format": "ass"}
+# orphan_files:     {}
+# orphan_db:        {}
+```
+
+### API Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/api/v1/cleanup/rules` | List all rules (extend existing) |
+| `POST` | `/api/v1/cleanup/rules` | Create rule (extend existing) |
+| `PATCH` | `/api/v1/cleanup/rules/{id}` | Update rule config/schedule/enabled |
+| `DELETE` | `/api/v1/cleanup/rules/{id}` | Delete rule (existing) |
+| `POST` | `/api/v1/cleanup/rules/{id}/preview` | Dry-run: returns files that would be deleted |
+| `POST` | `/api/v1/cleanup/rules/{id}/run` | Execute rule immediately (existing, extend) |
+
+### Scheduler Integration
+
+`cleanup_scheduler.py` checks `schedule` field on all enabled rules and runs them at the configured interval. After-scan trigger hooks into the existing post-scan event.
+
+### Config.py
+
+`auto_cleanup_keep_languages` and `auto_cleanup_keep_formats` remain in `config.py` as fallback defaults for the batch-extract flow (`auto_cleanup_after_extract`). They are no longer exposed in the UI — the Rules page writes directly to `config_json` in the DB.
+
+---
+
+## 7. Migration
+
+- Existing cleanup rules in DB: `schedule` defaults to `"manual"`, `config_json` defaults to `{}`
+- The old CleanupTab component is removed; its hooks/API calls are reused in the new page
+- Alembic migration adds `schedule` column to `cleanup_rules` table
+
+---
+
+## 8. What Is Never Touched
+
+- `.nfo` files — hardcoded exclusion in all cleanup executors
+- Video files (`.mkv`, `.mp4`, `.avi`, etc.)
+- Any file not matching known subtitle extensions (`.ass`, `.ssa`, `.srt`, `.vtt`, `.sub`)

--- a/frontend/src/api/system/tasks.ts
+++ b/frontend/src/api/system/tasks.ts
@@ -188,6 +188,15 @@ export async function runCleanupRule(id: number): Promise<{ message: string }> {
   return data
 }
 
+export async function previewCleanupRule(id: number): Promise<{
+  rule_id: number
+  rule_type: string
+  preview: Record<string, number>
+}> {
+  const { data } = await api.post(`/cleanup/rules/${id}/preview`)
+  return data
+}
+
 export async function getCleanupHistory(page = 1, perPage = 50): Promise<{ entries: CleanupHistoryEntry[]; total: number; page: number }> {
   const { data } = await api.get('/cleanup/history', { params: { page, per_page: perPage } })
   return data

--- a/frontend/src/components/cleanup/FormatUpgradeConfig.tsx
+++ b/frontend/src/components/cleanup/FormatUpgradeConfig.tsx
@@ -1,0 +1,40 @@
+type KeepFormat = 'any' | 'ass' | 'srt'
+
+interface FormatUpgradeConfigProps {
+  value: KeepFormat
+  onChange: (format: KeepFormat) => void
+}
+
+const OPTIONS: { value: KeepFormat; label: string; desc: string }[] = [
+  { value: 'any', label: 'Beide behalten', desc: 'SRT und ASS gleichzeitig' },
+  { value: 'ass', label: 'ASS bevorzugen', desc: 'SRT löschen wenn ASS vorhanden' },
+  { value: 'srt', label: 'SRT bevorzugen', desc: 'ASS löschen wenn SRT vorhanden' },
+]
+
+export function FormatUpgradeConfig({ value, onChange }: FormatUpgradeConfigProps) {
+  return (
+    <div className="flex gap-3">
+      {OPTIONS.map((opt) => (
+        <button
+          key={opt.value}
+          onClick={() => onChange(opt.value)}
+          className="flex-1 p-3 rounded-lg text-left transition-all"
+          style={{
+            background: value === opt.value ? 'var(--accent-bg)' : 'var(--bg-primary)',
+            border: `1px solid ${value === opt.value ? 'var(--accent)' : 'var(--border)'}`,
+          }}
+        >
+          <div
+            className="text-xs font-semibold mb-0.5"
+            style={{ color: value === opt.value ? 'var(--accent)' : 'var(--text-primary)' }}
+          >
+            {opt.label}
+          </div>
+          <div className="text-[11px]" style={{ color: 'var(--text-muted)' }}>
+            {opt.desc}
+          </div>
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/components/cleanup/LanguageFilterConfig.tsx
+++ b/frontend/src/components/cleanup/LanguageFilterConfig.tsx
@@ -1,0 +1,101 @@
+import { useState } from 'react'
+import { X } from 'lucide-react'
+
+const COMMON_LANGUAGES = [
+  { code: 'de', label: 'Deutsch', flag: '🇩🇪' },
+  { code: 'en', label: 'Englisch', flag: '🇬🇧' },
+  { code: 'ja', label: 'Japanisch', flag: '🇯🇵' },
+  { code: 'fr', label: 'Französisch', flag: '🇫🇷' },
+  { code: 'es', label: 'Spanisch', flag: '🇪🇸' },
+  { code: 'it', label: 'Italienisch', flag: '🇮🇹' },
+  { code: 'pt', label: 'Portugiesisch', flag: '🇵🇹' },
+  { code: 'ru', label: 'Russisch', flag: '🇷🇺' },
+  { code: 'ar', label: 'Arabisch', flag: '🇸🇦' },
+  { code: 'zh', label: 'Chinesisch', flag: '🇨🇳' },
+  { code: 'ko', label: 'Koreanisch', flag: '🇰🇷' },
+  { code: 'pl', label: 'Polnisch', flag: '🇵🇱' },
+]
+
+interface LanguageFilterConfigProps {
+  value: string[]
+  onChange: (langs: string[]) => void
+}
+
+export function LanguageFilterConfig({ value, onChange }: LanguageFilterConfigProps) {
+  const [showDropdown, setShowDropdown] = useState(false)
+
+  const addLang = (code: string) => {
+    if (!value.includes(code)) onChange([...value, code])
+    setShowDropdown(false)
+  }
+
+  const removeLang = (code: string) => onChange(value.filter((l) => l !== code))
+
+  const getLang = (code: string) =>
+    COMMON_LANGUAGES.find((l) => l.code === code) ?? { code, label: code.toUpperCase(), flag: '🌐' }
+
+  const available = COMMON_LANGUAGES.filter((l) => !value.includes(l.code))
+
+  return (
+    <div className="space-y-3">
+      <div
+        className="text-[10px] font-semibold uppercase tracking-wide"
+        style={{ color: 'var(--text-muted)' }}
+      >
+        Behalten
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {value.map((code) => {
+          const lang = getLang(code)
+          return (
+            <span
+              key={code}
+              className="flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium"
+              style={{
+                background: 'var(--accent-bg)',
+                border: '1px solid var(--accent)',
+                color: 'var(--accent)',
+              }}
+            >
+              <span>{lang.flag}</span>
+              {lang.label} ({code})
+              <button onClick={() => removeLang(code)} className="ml-0.5 opacity-70 hover:opacity-100">
+                <X size={10} />
+              </button>
+            </span>
+          )
+        })}
+
+        <div className="relative">
+          <button
+            onClick={() => setShowDropdown(!showDropdown)}
+            className="flex items-center gap-1 px-2.5 py-1 rounded-md text-xs border border-dashed"
+            style={{ borderColor: 'var(--border)', color: 'var(--text-muted)' }}
+          >
+            + Sprache hinzufügen
+          </button>
+          {showDropdown && available.length > 0 && (
+            <div
+              className="absolute top-8 left-0 z-10 rounded-lg shadow-lg py-1 min-w-[180px]"
+              style={{ background: 'var(--bg-surface)', border: '1px solid var(--border)' }}
+            >
+              {available.map((lang) => (
+                <button
+                  key={lang.code}
+                  onClick={() => addLang(lang.code)}
+                  className="w-full flex items-center gap-2 px-3 py-1.5 text-xs text-left hover:opacity-80"
+                  style={{ color: 'var(--text-primary)' }}
+                >
+                  <span>{lang.flag}</span> {lang.label}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+      <div className="text-xs" style={{ color: 'var(--text-muted)' }}>
+        NFO-Dateien (.nfo) werden nie angefasst.
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/cleanup/RuleDetail.tsx
+++ b/frontend/src/components/cleanup/RuleDetail.tsx
@@ -1,0 +1,215 @@
+import { Play, Eye, Trash2, Power } from 'lucide-react'
+import type { CleanupRule } from '@/types/system'
+import { LanguageFilterConfig } from './LanguageFilterConfig'
+import { FormatUpgradeConfig } from './FormatUpgradeConfig'
+import { SchedulePicker } from './SchedulePicker'
+
+interface PreviewResult {
+  would_delete?: number
+  would_keep?: number
+  [key: string]: number | undefined
+}
+
+interface RuleDetailProps {
+  rule: CleanupRule
+  previewResult: PreviewResult | null
+  isRunning: boolean
+  isPreviewing: boolean
+  onRun: () => void
+  onPreview: () => void
+  onDelete: () => void
+  onUpdate: (patch: Partial<CleanupRule>) => void
+}
+
+const TYPE_DESCRIPTIONS: Record<string, string> = {
+  language_filter: 'Löscht Sidecar-Dateien in nicht erlaubten Sprachen',
+  format_upgrade: 'Löscht SRT wenn ASS für dieselbe Episode existiert',
+  orphan_files: 'Löscht Subtitle-Sidecars ohne zugehörige Videodatei auf Disk',
+  orphan_db: 'Entfernt DB-Einträge deren Datei auf Disk fehlt',
+  dedup: 'Findet und löscht doppelte Untertitel-Dateien',
+}
+
+const TYPE_ICONS: Record<string, string> = {
+  language_filter: '🌐',
+  format_upgrade: '⬆️',
+  orphan_files: '🗑️',
+  orphan_db: '🗄️',
+  dedup: '🔍',
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 B'
+  const units = ['B', 'KB', 'MB', 'GB']
+  const i = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1)
+  return `${(bytes / Math.pow(1024, i)).toFixed(1)} ${units[i]}`
+}
+
+function ConfigSection({
+  title,
+  icon,
+  children,
+}: {
+  title: string
+  icon: string
+  children: React.ReactNode
+}) {
+  return (
+    <div
+      className="rounded-xl overflow-hidden"
+      style={{ background: 'var(--bg-surface)', border: '1px solid var(--border)' }}
+    >
+      <div
+        className="flex items-center gap-2.5 px-4 py-3"
+        style={{ borderBottom: '1px solid var(--border)' }}
+      >
+        <span
+          className="flex items-center justify-center rounded-md text-sm"
+          style={{ width: 26, height: 26, background: 'var(--accent-bg)' }}
+        >
+          {icon}
+        </span>
+        <span className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
+          {title}
+        </span>
+      </div>
+      <div className="p-4">{children}</div>
+    </div>
+  )
+}
+
+export function RuleDetail({
+  rule,
+  previewResult,
+  isRunning,
+  isPreviewing,
+  onRun,
+  onPreview,
+  onDelete,
+  onUpdate,
+}: RuleDetailProps) {
+  const config = rule.config_json as Record<string, unknown>
+
+  const updateConfig = (patch: Record<string, unknown>) =>
+    onUpdate({ config_json: { ...config, ...patch } })
+
+  return (
+    <div className="flex flex-col gap-5">
+      {/* Header */}
+      <div className="flex items-start justify-between">
+        <div className="flex items-center gap-3">
+          <div
+            className="flex items-center justify-center rounded-xl text-2xl flex-shrink-0"
+            style={{ width: 44, height: 44, background: 'var(--accent-bg)' }}
+          >
+            {TYPE_ICONS[rule.rule_type] ?? '⚙️'}
+          </div>
+          <div>
+            <div className="text-lg font-semibold" style={{ color: 'var(--text-primary)' }}>
+              {rule.name}
+            </div>
+            <div className="text-xs" style={{ color: 'var(--text-muted)' }}>
+              {TYPE_DESCRIPTIONS[rule.rule_type] ?? rule.rule_type}
+            </div>
+          </div>
+        </div>
+        <div className="flex items-center gap-2 flex-wrap justify-end">
+          <button
+            onClick={() => onUpdate({ enabled: !rule.enabled })}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium"
+            style={{
+              border: '1px solid var(--border)',
+              color: rule.enabled ? 'var(--success)' : 'var(--text-muted)',
+            }}
+          >
+            <Power size={12} />
+            {rule.enabled ? 'Aktiv' : 'Deaktiviert'}
+          </button>
+          <button
+            onClick={onPreview}
+            disabled={isPreviewing}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium"
+            style={{ border: '1px solid var(--border)', color: 'var(--text-secondary)' }}
+          >
+            <Eye size={12} />
+            {isPreviewing ? 'Lädt...' : 'Vorschau'}
+          </button>
+          <button
+            onClick={onRun}
+            disabled={isRunning}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium text-white disabled:opacity-50"
+            style={{ background: 'var(--accent)' }}
+          >
+            <Play size={12} />
+            {isRunning ? 'Läuft...' : 'Jetzt ausführen'}
+          </button>
+          <button
+            onClick={onDelete}
+            className="flex items-center gap-1.5 px-2 py-1.5 rounded-lg text-xs"
+            style={{ border: '1px solid #3a1a1a', color: 'var(--error)' }}
+          >
+            <Trash2 size={12} />
+          </button>
+        </div>
+      </div>
+
+      {/* Last run bar */}
+      {rule.last_run_at && (
+        <div
+          className="flex items-center gap-2 px-3 py-2 rounded-lg text-xs"
+          style={{ background: 'var(--bg-surface)', border: '1px solid var(--border)' }}
+        >
+          <span
+            className="w-2 h-2 rounded-full flex-shrink-0"
+            style={{ background: 'var(--success)' }}
+          />
+          <span style={{ color: 'var(--success)' }}>Letzter Lauf erfolgreich</span>
+          <span className="ml-auto" style={{ color: 'var(--text-muted)' }}>
+            {new Date(rule.last_run_at).toLocaleString('de-DE')}
+          </span>
+        </div>
+      )}
+
+      {/* Type-specific config */}
+      {rule.rule_type === 'language_filter' && (
+        <ConfigSection title="Erlaubte Sprachen" icon="🌐">
+          <LanguageFilterConfig
+            value={(config.keep_languages as string[]) ?? []}
+            onChange={(langs) => updateConfig({ keep_languages: langs })}
+          />
+        </ConfigSection>
+      )}
+
+      {rule.rule_type === 'format_upgrade' && (
+        <ConfigSection title="Format-Präferenz" icon="📄">
+          <FormatUpgradeConfig
+            value={(config.keep_format as 'any' | 'ass' | 'srt') ?? 'any'}
+            onChange={(fmt) => updateConfig({ keep_format: fmt })}
+          />
+        </ConfigSection>
+      )}
+
+      {/* Schedule (all types) */}
+      <ConfigSection title="Zeitplan" icon="🕐">
+        <SchedulePicker value={rule.schedule} onChange={(s) => onUpdate({ schedule: s })} />
+      </ConfigSection>
+
+      {/* Preview result */}
+      {previewResult && (
+        <ConfigSection title="Vorschau" icon="👁️">
+          <div className="space-y-1.5">
+            {Object.entries(previewResult).map(([key, val]) => (
+              <div key={key} className="flex justify-between text-xs">
+                <span style={{ color: 'var(--text-muted)' }}>{key}</span>
+                <span
+                  style={{ color: 'var(--text-primary)', fontFamily: 'var(--font-mono)' }}
+                >
+                  {typeof val === 'number' && key.includes('byte') ? formatBytes(val) : val}
+                </span>
+              </div>
+            ))}
+          </div>
+        </ConfigSection>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/cleanup/RuleDetail.tsx
+++ b/frontend/src/components/cleanup/RuleDetail.tsx
@@ -145,7 +145,7 @@ export function RuleDetail({
           <button
             onClick={onDelete}
             className="flex items-center gap-1.5 px-2 py-1.5 rounded-lg text-xs"
-            style={{ border: '1px solid #3a1a1a', color: 'var(--error)' }}
+            style={{ border: '1px solid var(--error-dim, #3a1a1a)', color: 'var(--error)' }}
           >
             <Trash2 size={12} />
           </button>

--- a/frontend/src/components/cleanup/RuleSidebar.tsx
+++ b/frontend/src/components/cleanup/RuleSidebar.tsx
@@ -1,0 +1,105 @@
+import { Plus } from 'lucide-react'
+import type { CleanupRule } from '@/types/system'
+
+const TYPE_META: Record<string, { icon: string; label: string }> = {
+  language_filter: { icon: '🌐', label: 'Sprache' },
+  format_upgrade: { icon: '⬆️', label: 'Qualität' },
+  orphan_files: { icon: '🗑️', label: 'Orphan' },
+  orphan_db: { icon: '🗄️', label: 'Datenbank' },
+  dedup: { icon: '🔍', label: 'Dedup' },
+  orphaned: { icon: '🗑️', label: 'Orphan' },
+  old_backups: { icon: '📦', label: 'Backups' },
+}
+
+const SCHEDULE_LABELS: Record<string, string> = {
+  manual: 'Manuell',
+  daily: '🕐 Täglich',
+  weekly: '🕐 Wöchentlich',
+  after_scan: '🕐 Nach Scan',
+}
+
+interface RuleSidebarProps {
+  rules: CleanupRule[]
+  selectedId: number | null
+  onSelect: (id: number) => void
+  onNew: () => void
+}
+
+export function RuleSidebar({ rules, selectedId, onSelect, onNew }: RuleSidebarProps) {
+  return (
+    <div
+      className="flex flex-col flex-shrink-0"
+      style={{ width: 260, background: 'var(--bg-surface)', borderRight: '1px solid var(--border)' }}
+    >
+      <div className="flex items-center justify-between px-4 py-3">
+        <span
+          className="text-[10px] font-semibold uppercase tracking-wide"
+          style={{ color: 'var(--text-muted)' }}
+        >
+          Regeln
+        </span>
+        <button
+          onClick={onNew}
+          className="flex items-center gap-1 px-2.5 py-1 rounded text-xs font-medium"
+          style={{ border: '1px solid var(--accent)', color: 'var(--accent)' }}
+        >
+          <Plus size={10} /> Neu
+        </button>
+      </div>
+
+      <div className="flex flex-col gap-1 px-2 overflow-y-auto">
+        {rules.map((rule) => {
+          const meta = TYPE_META[rule.rule_type] ?? { icon: '⚙️', label: rule.rule_type }
+          const isActive = rule.id === selectedId
+          return (
+            <button
+              key={rule.id}
+              onClick={() => onSelect(rule.id)}
+              className="w-full text-left rounded-lg p-2.5 transition-all"
+              style={{
+                background: isActive ? 'var(--accent-bg)' : 'transparent',
+                border: `1px solid ${isActive ? 'var(--accent)' : 'transparent'}`,
+              }}
+            >
+              <div className="flex items-center gap-2 mb-1">
+                <span
+                  className="flex items-center justify-center rounded-md text-sm flex-shrink-0"
+                  style={{ width: 28, height: 28, background: 'var(--bg-primary)' }}
+                >
+                  {meta.icon}
+                </span>
+                <span
+                  className="flex-1 text-sm font-medium truncate"
+                  style={{ color: 'var(--text-primary)' }}
+                >
+                  {rule.name}
+                </span>
+                <span
+                  className="w-2 h-2 rounded-full flex-shrink-0"
+                  style={{ background: rule.enabled ? 'var(--success)' : 'var(--border)' }}
+                />
+              </div>
+              <div className="flex items-center gap-1.5 pl-9">
+                <span
+                  className="text-[10px] font-medium px-1.5 py-0.5 rounded uppercase"
+                  style={{ background: 'var(--bg-primary)', color: 'var(--accent)' }}
+                >
+                  {meta.label}
+                </span>
+                <span className="text-[10px]" style={{ color: 'var(--text-muted)' }}>
+                  {SCHEDULE_LABELS[rule.schedule] ?? rule.schedule}
+                </span>
+              </div>
+            </button>
+          )
+        })}
+
+        {rules.length === 0 && (
+          <div className="px-3 py-6 text-xs text-center" style={{ color: 'var(--text-muted)' }}>
+            Noch keine Regeln. Erstelle eine um loszulegen.
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/cleanup/SchedulePicker.tsx
+++ b/frontend/src/components/cleanup/SchedulePicker.tsx
@@ -1,0 +1,34 @@
+type Schedule = 'manual' | 'daily' | 'weekly' | 'after_scan'
+
+interface SchedulePickerProps {
+  value: Schedule
+  onChange: (schedule: Schedule) => void
+}
+
+const OPTIONS: { value: Schedule; label: string }[] = [
+  { value: 'manual', label: 'Manuell' },
+  { value: 'daily', label: 'Täglich (03:00)' },
+  { value: 'weekly', label: 'Wöchentlich' },
+  { value: 'after_scan', label: 'Nach jedem Scan' },
+]
+
+export function SchedulePicker({ value, onChange }: SchedulePickerProps) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {OPTIONS.map((opt) => (
+        <button
+          key={opt.value}
+          onClick={() => onChange(opt.value)}
+          className="px-3 py-1.5 rounded-full text-xs font-medium transition-all"
+          style={{
+            background: value === opt.value ? 'var(--accent-bg)' : 'var(--bg-primary)',
+            border: `1px solid ${value === opt.value ? 'var(--accent)' : 'var(--border)'}`,
+            color: value === opt.value ? 'var(--accent)' : 'var(--text-muted)',
+          }}
+        >
+          {opt.label}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/components/settings/SettingsGrid.tsx
+++ b/frontend/src/components/settings/SettingsGrid.tsx
@@ -12,6 +12,7 @@ import {
   Bell,
   Shield,
   Heart,
+  Trash2,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import { cn } from '@/lib/utils'
@@ -83,6 +84,13 @@ const CATEGORIES: readonly SettingsCategory[] = [
     badge: 'System',
   },
   {
+    id: 'cleanup',
+    icon: Trash2,
+    titleKey: 'settings.categories.cleanup.title',
+    descKey: 'settings.categories.cleanup.description',
+    badge: 'Cleanup',
+  },
+  {
     id: 'about',
     icon: Heart,
     titleKey: 'settings.categories.about.title',
@@ -100,6 +108,7 @@ const CATEGORY_FALLBACKS: Record<string, { title: string; description: string }>
   translation: { title: 'Translation', description: 'AI translation backends' },
   notifications: { title: 'Notifications', description: 'Channels, templates' },
   system: { title: 'System', description: 'Security, backup, logs' },
+  cleanup: { title: 'Cleanup', description: 'Language filters, format upgrades, orphan removal' },
   about: { title: 'About', description: 'Version, GitHub, donate' },
 }
 

--- a/frontend/src/components/settings/__tests__/SettingsGrid.test.tsx
+++ b/frontend/src/components/settings/__tests__/SettingsGrid.test.tsx
@@ -33,18 +33,18 @@ describe('SettingsGrid', () => {
     mockNavigate.mockClear()
   })
 
-  it('renders all 9 category cards', () => {
+  it('renders all 10 category cards', () => {
     renderWithRouter(<SettingsGrid />)
     const cards = screen.getAllByRole('button').filter(
       (el) => el.getAttribute('data-testid')?.match(/^settings-card-[^-]+$/)
     )
-    expect(cards).toHaveLength(9)
+    expect(cards).toHaveLength(10)
   })
 
   it('renders each card with an icon box', () => {
     renderWithRouter(<SettingsGrid />)
     const iconBoxes = screen.getAllByTestId(/^settings-card-icon-/)
-    expect(iconBoxes).toHaveLength(9)
+    expect(iconBoxes).toHaveLength(10)
   })
 
   it('renders the General card with title and description', () => {
@@ -92,7 +92,19 @@ describe('SettingsGrid', () => {
   it('renders a count or tag element on each card', () => {
     renderWithRouter(<SettingsGrid />)
     const badges = screen.getAllByTestId(/^settings-card-badge-/)
-    expect(badges).toHaveLength(9)
+    expect(badges).toHaveLength(10)
+  })
+
+  it('renders the Cleanup card', () => {
+    renderWithRouter(<SettingsGrid />)
+    expect(screen.getByTestId('settings-card-cleanup')).toBeInTheDocument()
+  })
+
+  it('navigates to /settings/cleanup when Cleanup card is clicked', async () => {
+    const user = userEvent.setup()
+    renderWithRouter(<SettingsGrid />)
+    await user.click(screen.getByTestId('settings-card-cleanup'))
+    expect(mockNavigate).toHaveBeenCalledWith('/settings/cleanup')
   })
 
   it('renders the About card', () => {

--- a/frontend/src/hooks/useSystemApi.ts
+++ b/frontend/src/hooks/useSystemApi.ts
@@ -24,7 +24,7 @@ import {
   getCleanupStats, startCleanupScan, getCleanupScanStatus,
   getDuplicates, deleteDuplicates,
   scanOrphaned, getOrphanedFiles, deleteOrphaned,
-  getCleanupRules, createCleanupRule, updateCleanupRule, deleteCleanupRule, runCleanupRule,
+  getCleanupRules, createCleanupRule, updateCleanupRule, deleteCleanupRule, runCleanupRule, previewCleanupRule,
   getCleanupHistory, getCleanupPreview,
   getSupportedLanguages,
   testSonarrInstance, testRadarrInstance,
@@ -712,6 +712,12 @@ export function useRunCleanupRule() {
       void qc.invalidateQueries({ queryKey: ['cleanup-stats'] })
       void qc.invalidateQueries({ queryKey: ['cleanup-history'] })
     },
+  })
+}
+
+export function useRulePreview() {
+  return useMutation({
+    mutationFn: (id: number) => previewCleanupRule(id),
   })
 }
 

--- a/frontend/src/pages/Settings/CleanupSettings.tsx
+++ b/frontend/src/pages/Settings/CleanupSettings.tsx
@@ -1,0 +1,498 @@
+/**
+ * CleanupSettings — dedicated Settings page for subtitle cleanup rule management.
+ *
+ * Layout:
+ *   Left sidebar (260px): rule list + new rule button (RuleSidebar)
+ *   Right main: disk space widget, rule detail, dedup section, history
+ */
+import { useState, useCallback, useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Loader2 } from 'lucide-react'
+import { PageHeader } from '@/components/layout/PageHeader'
+import { RuleSidebar } from '@/components/cleanup/RuleSidebar'
+import { RuleDetail } from '@/components/cleanup/RuleDetail'
+import { DiskSpaceWidget } from '@/components/cleanup/DiskSpaceWidget'
+import { DedupGroupList } from '@/components/cleanup/DedupGroupList'
+import { CleanupPreview } from '@/components/cleanup/CleanupPreview'
+import { toast } from '@/components/shared/Toast'
+import {
+  useCleanupRules, useCreateCleanupRule, useUpdateCleanupRule,
+  useDeleteCleanupRule, useRunCleanupRule, useRulePreview,
+  useCleanupStats, useStartCleanupScan, useCleanupScanStatus,
+  useDuplicates, useDeleteDuplicates,
+  useCleanupHistory, useCleanupPreview,
+} from '@/hooks/useSystemApi'
+import type { CleanupRule, CleanupPreviewData } from '@/lib/types'
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 B'
+  const units = ['B', 'KB', 'MB', 'GB']
+  const i = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1)
+  return `${(bytes / Math.pow(1024, i)).toFixed(1)} ${units[i]}`
+}
+
+// ─── Rule Type Options (for new rule modal) ──────────────────────────────────
+
+const RULE_TYPES = [
+  { value: 'language_filter', label: 'Sprach-Filter', desc: 'Löscht Sidecars in nicht erlaubten Sprachen' },
+  { value: 'format_upgrade', label: 'Format-Upgrade', desc: 'Löscht SRT wenn ASS für gleiche Episode existiert' },
+  { value: 'orphan_files', label: 'Verwaiste Dateien', desc: 'Löscht Subtitle-Sidecars ohne Video auf Disk' },
+  { value: 'orphan_db', label: 'DB-Bereinigung', desc: 'Entfernt DB-Einträge ohne Datei auf Disk' },
+]
+
+// ─── New Rule Modal ──────────────────────────────────────────────────────────
+
+function NewRuleModal({
+  onClose,
+  onCreate,
+}: {
+  onClose: () => void
+  onCreate: (name: string, ruleType: string) => void
+}) {
+  const [name, setName] = useState('')
+  const [ruleType, setRuleType] = useState('language_filter')
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div
+        className="rounded-xl p-6 w-96 space-y-4"
+        style={{ background: 'var(--bg-surface)', border: '1px solid var(--border)' }}
+      >
+        <h3 className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
+          Neue Cleanup-Regel
+        </h3>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Regelname"
+          className="w-full px-3 py-2 rounded-lg text-sm focus:outline-none"
+          style={{
+            background: 'var(--bg-primary)',
+            border: '1px solid var(--border)',
+            color: 'var(--text-primary)',
+          }}
+        />
+        <div className="space-y-2">
+          {RULE_TYPES.map((rt) => (
+            <label
+              key={rt.value}
+              className="flex items-start gap-3 p-3 rounded-lg cursor-pointer"
+              style={{
+                background: ruleType === rt.value ? 'var(--accent-bg)' : 'var(--bg-primary)',
+                border: `1px solid ${ruleType === rt.value ? 'var(--accent)' : 'var(--border)'}`,
+              }}
+            >
+              <input
+                type="radio"
+                name="ruleType"
+                value={rt.value}
+                checked={ruleType === rt.value}
+                onChange={() => setRuleType(rt.value)}
+                className="mt-0.5"
+              />
+              <div>
+                <div className="text-xs font-semibold" style={{ color: 'var(--text-primary)' }}>
+                  {rt.label}
+                </div>
+                <div className="text-[11px]" style={{ color: 'var(--text-muted)' }}>
+                  {rt.desc}
+                </div>
+              </div>
+            </label>
+          ))}
+        </div>
+        <div className="flex gap-2 justify-end">
+          <button
+            onClick={onClose}
+            className="px-3 py-1.5 rounded text-xs"
+            style={{ color: 'var(--text-muted)' }}
+          >
+            Abbrechen
+          </button>
+          <button
+            onClick={() => {
+              if (name.trim()) onCreate(name.trim(), ruleType)
+            }}
+            disabled={!name.trim()}
+            className="px-4 py-1.5 rounded text-xs font-medium text-white disabled:opacity-50"
+            style={{ background: 'var(--accent)' }}
+          >
+            Erstellen
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ─── History Section ─────────────────────────────────────────────────────────
+
+function HistorySection() {
+  const { t } = useTranslation('settings')
+  const [page, setPage] = useState(1)
+  const { data: historyData } = useCleanupHistory(page)
+  const entries = historyData?.entries ?? []
+  const total = historyData?.total ?? 0
+
+  if (entries.length === 0) return null
+
+  return (
+    <div
+      className="rounded-xl overflow-hidden"
+      style={{ background: 'var(--bg-surface)', border: '1px solid var(--border)' }}
+    >
+      <div className="px-4 py-3" style={{ borderBottom: '1px solid var(--border)' }}>
+        <span className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
+          {t('cleanup.history.title', 'Cleanup History')}
+        </span>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full text-xs">
+          <thead>
+            <tr style={{ borderBottom: '1px solid var(--border)' }}>
+              {['Datum', 'Aktion', 'Verarbeitet', 'Gelöscht', 'Freigegeben'].map((h) => (
+                <th
+                  key={h}
+                  className="py-2 px-3 text-left font-medium"
+                  style={{ color: 'var(--text-muted)' }}
+                >
+                  {h}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {entries.map((entry) => (
+              <tr key={entry.id} style={{ borderBottom: '1px solid var(--border)' }}>
+                <td className="py-2 px-3" style={{ color: 'var(--text-secondary)' }}>
+                  {new Date(entry.performed_at).toLocaleString('de-DE')}
+                </td>
+                <td className="py-2 px-3">
+                  <span
+                    className="px-1.5 py-0.5 rounded text-[10px] font-medium"
+                    style={{ background: 'var(--accent-bg)', color: 'var(--accent)' }}
+                  >
+                    {entry.action_type}
+                  </span>
+                </td>
+                <td
+                  className="py-2 px-3 tabular-nums"
+                  style={{ fontFamily: 'var(--font-mono)', color: 'var(--text-secondary)' }}
+                >
+                  {entry.files_processed}
+                </td>
+                <td
+                  className="py-2 px-3 tabular-nums"
+                  style={{ fontFamily: 'var(--font-mono)', color: 'var(--error)' }}
+                >
+                  {entry.files_deleted}
+                </td>
+                <td
+                  className="py-2 px-3 tabular-nums"
+                  style={{ fontFamily: 'var(--font-mono)', color: 'var(--success)' }}
+                >
+                  {formatBytes(entry.bytes_freed)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {total > 50 && (
+        <div className="flex items-center justify-center gap-2 p-3">
+          <button
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+            disabled={page <= 1}
+            className="px-2 py-1 rounded text-xs disabled:opacity-40"
+            style={{ border: '1px solid var(--border)', color: 'var(--text-muted)' }}
+          >
+            Zurück
+          </button>
+          <span className="text-xs" style={{ color: 'var(--text-muted)' }}>
+            {page} / {Math.ceil(total / 50)}
+          </span>
+          <button
+            onClick={() => setPage((p) => p + 1)}
+            disabled={page >= Math.ceil(total / 50)}
+            className="px-2 py-1 rounded text-xs disabled:opacity-40"
+            style={{ border: '1px solid var(--border)', color: 'var(--text-muted)' }}
+          >
+            Weiter
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─── Main Page ───────────────────────────────────────────────────────────────
+
+export function CleanupSettings() {
+  const { t } = useTranslation('settings')
+  const { data: rules = [], isLoading } = useCleanupRules()
+  const { data: stats } = useCleanupStats()
+  const createRule = useCreateCleanupRule()
+  const updateRule = useUpdateCleanupRule()
+  const deleteRule = useDeleteCleanupRule()
+  const runRule = useRunCleanupRule()
+  const rulePreview = useRulePreview()
+  const startScan = useStartCleanupScan()
+  const [isScanning, setIsScanning] = useState(false)
+  const scanStatus = useCleanupScanStatus(isScanning)
+  const { data: duplicatesData, refetch: refetchDuplicates } = useDuplicates()
+  const deleteDuplicates = useDeleteDuplicates()
+  const cleanupPreview = useCleanupPreview()
+
+  const [selectedId, setSelectedId] = useState<number | null>(null)
+  const [showNewModal, setShowNewModal] = useState(false)
+  const [previewResult, setPreviewResult] = useState<Record<string, number> | null>(null)
+  const [dedupPreviewData, setDedupPreviewData] = useState<CleanupPreviewData | null>(null)
+  const [pendingDeleteSelections, setPendingDeleteSelections] = useState<
+    { keep: string; delete: string[] }[] | null
+  >(null)
+
+  const selectedRule = rules.find((r: CleanupRule) => r.id === selectedId) ?? null
+
+  // Auto-select first rule when rules load
+  useEffect(() => {
+    if (rules.length > 0 && selectedId === null) setSelectedId(rules[0].id)
+  }, [rules, selectedId])
+
+  // Stop scan polling when scan completes
+  useEffect(() => {
+    if (scanStatus.data?.status === 'idle' && isScanning) {
+      setIsScanning(false)
+      void refetchDuplicates()
+    }
+  }, [scanStatus.data, isScanning, refetchDuplicates])
+
+  const handleCreate = useCallback(
+    (name: string, ruleType: string) => {
+      createRule.mutate(
+        {
+          name,
+          rule_type: ruleType as CleanupRule['rule_type'],
+          config_json: {},
+          enabled: true,
+          schedule: 'manual',
+        },
+        {
+          onSuccess: (rule: CleanupRule) => {
+            setSelectedId(rule.id)
+            setShowNewModal(false)
+          },
+          onError: () => toast('Fehler beim Erstellen der Regel', 'error'),
+        },
+      )
+    },
+    [createRule],
+  )
+
+  const handleUpdate = useCallback(
+    (patch: Partial<CleanupRule>) => {
+      if (!selectedId) return
+      updateRule.mutate(
+        { id: selectedId, data: patch },
+        { onError: () => toast('Fehler beim Speichern', 'error') },
+      )
+    },
+    [selectedId, updateRule],
+  )
+
+  const handleDelete = useCallback(() => {
+    if (!selectedId) return
+    deleteRule.mutate(selectedId, {
+      onSuccess: () => {
+        setSelectedId(null)
+        toast('Regel gelöscht')
+      },
+      onError: () => toast('Fehler beim Löschen', 'error'),
+    })
+  }, [selectedId, deleteRule])
+
+  const handleRun = useCallback(() => {
+    if (!selectedId) return
+    runRule.mutate(selectedId, {
+      onSuccess: () => toast('Regel erfolgreich ausgeführt'),
+      onError: () => toast('Fehler beim Ausführen', 'error'),
+    })
+  }, [selectedId, runRule])
+
+  const handlePreview = useCallback(() => {
+    if (!selectedId) return
+    rulePreview.mutate(selectedId, {
+      onSuccess: (data: { preview: Record<string, number> }) => setPreviewResult(data.preview),
+      onError: () => toast('Vorschau fehlgeschlagen', 'error'),
+    })
+  }, [selectedId, rulePreview])
+
+  const handleStartScan = useCallback(() => {
+    startScan.mutate(undefined, {
+      onSuccess: () => setIsScanning(true),
+      onError: () => toast('Scan fehlgeschlagen', 'error'),
+    })
+  }, [startScan])
+
+  const handleDeleteDuplicates = useCallback(
+    (selections: { keep: string; delete: string[] }[]) => {
+      setPendingDeleteSelections(selections)
+      cleanupPreview.mutate(undefined, {
+        onSuccess: (data: CleanupPreviewData) => setDedupPreviewData(data),
+        onError: () => {
+          deleteDuplicates.mutate(selections, {
+            onSuccess: (result: { deleted: number; bytes_freed: number }) => {
+              toast(
+                `${result.deleted} Dateien gelöscht, ${formatBytes(result.bytes_freed)} freigegeben`,
+              )
+              setPendingDeleteSelections(null)
+            },
+            onError: () => toast('Fehler beim Löschen', 'error'),
+          })
+        },
+      })
+    },
+    [cleanupPreview, deleteDuplicates],
+  )
+
+  const handleConfirmDedupDelete = useCallback(() => {
+    if (!pendingDeleteSelections) return
+    deleteDuplicates.mutate(pendingDeleteSelections, {
+      onSuccess: (result: { deleted: number; bytes_freed: number }) => {
+        toast(
+          `${result.deleted} Dateien gelöscht, ${formatBytes(result.bytes_freed)} freigegeben`,
+        )
+        setPendingDeleteSelections(null)
+        setDedupPreviewData(null)
+      },
+      onError: () => toast('Fehler beim Löschen', 'error'),
+    })
+  }, [pendingDeleteSelections, deleteDuplicates])
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <Loader2 size={28} className="animate-spin" style={{ color: 'var(--accent)' }} />
+      </div>
+    )
+  }
+
+  const groups = duplicatesData?.groups ?? []
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Page header */}
+      <div className="px-6 py-5" style={{ borderBottom: '1px solid var(--border)' }}>
+        <PageHeader
+          title={t('cleanup.page.title', 'Cleanup Rules')}
+          subtitle={t(
+            'cleanup.page.subtitle',
+            'Automatisierte Bereinigung von Sidecar-Dateien und Datenbankeinträgen',
+          )}
+        />
+      </div>
+
+      <div className="flex flex-1 overflow-hidden">
+        {/* Sidebar */}
+        <RuleSidebar
+          rules={rules}
+          selectedId={selectedId}
+          onSelect={(id) => {
+            setSelectedId(id)
+            setPreviewResult(null)
+          }}
+          onNew={() => setShowNewModal(true)}
+        />
+
+        {/* Main content */}
+        <div className="flex-1 overflow-y-auto p-6 space-y-5">
+          {/* Disk space */}
+          {stats && <DiskSpaceWidget stats={stats} />}
+
+          {/* Rule detail or empty state */}
+          {selectedRule ? (
+            <RuleDetail
+              rule={selectedRule}
+              previewResult={previewResult}
+              isRunning={runRule.isPending}
+              isPreviewing={rulePreview.isPending}
+              onRun={handleRun}
+              onPreview={handlePreview}
+              onDelete={handleDelete}
+              onUpdate={handleUpdate}
+            />
+          ) : (
+            <div
+              className="rounded-xl p-12 text-center text-sm"
+              style={{
+                background: 'var(--bg-surface)',
+                border: '1px solid var(--border)',
+                color: 'var(--text-muted)',
+              }}
+            >
+              Wähle eine Regel aus der Sidebar oder erstelle eine neue.
+            </div>
+          )}
+
+          {/* Deduplication section */}
+          <div
+            className="rounded-xl overflow-hidden"
+            style={{ background: 'var(--bg-surface)', border: '1px solid var(--border)' }}
+          >
+            <div
+              className="flex items-center justify-between px-4 py-3"
+              style={{ borderBottom: '1px solid var(--border)' }}
+            >
+              <span className="text-sm font-semibold" style={{ color: 'var(--text-primary)' }}>
+                {t('cleanup.dedup.title', 'Deduplication')}
+              </span>
+              <button
+                onClick={handleStartScan}
+                disabled={isScanning || startScan.isPending}
+                className="flex items-center gap-1.5 px-3 py-1.5 rounded text-xs font-medium text-white disabled:opacity-50"
+                style={{ background: 'var(--accent)' }}
+              >
+                {isScanning ? <Loader2 size={12} className="animate-spin" /> : null}
+                {isScanning
+                  ? 'Scannt...'
+                  : t('cleanup.dedup.scanButton', 'Scan for Duplicates')}
+              </button>
+            </div>
+            <div className="p-4">
+              {dedupPreviewData ? (
+                <CleanupPreview
+                  preview={dedupPreviewData}
+                  onConfirm={handleConfirmDedupDelete}
+                  onCancel={() => {
+                    setDedupPreviewData(null)
+                    setPendingDeleteSelections(null)
+                  }}
+                  isConfirming={deleteDuplicates.isPending}
+                />
+              ) : groups.length > 0 ? (
+                <DedupGroupList
+                  groups={groups}
+                  onDelete={handleDeleteDuplicates}
+                  isDeleting={deleteDuplicates.isPending}
+                />
+              ) : (
+                <div
+                  className="text-sm text-center py-4"
+                  style={{ color: 'var(--text-muted)' }}
+                >
+                  {t('cleanup.dedup.noResults', 'No duplicates found. Run a scan to check.')}
+                </div>
+              )}
+            </div>
+          </div>
+
+          <HistorySection />
+        </div>
+      </div>
+
+      {showNewModal && (
+        <NewRuleModal onClose={() => setShowNewModal(false)} onCreate={handleCreate} />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/Settings/SubtitlesSettings.tsx
+++ b/frontend/src/pages/Settings/SubtitlesSettings.tsx
@@ -11,7 +11,7 @@
  */
 import { lazy, Suspense } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Star, FileType, Trash2, Film, Users, Heart, Tag, Filter, Sliders } from 'lucide-react'
+import { Star, FileType, Film, Users, Heart, Tag, Filter, Sliders } from 'lucide-react'
 import { SettingsDetailLayout } from '@/components/settings/SettingsDetailLayout'
 import { SettingsSection } from '@/components/settings/SettingsSection'
 import { FormGroup } from '@/components/settings/FormGroup'
@@ -32,10 +32,6 @@ const LanguageProfilesTab = lazy(() =>
 const SubtitleToolsTab = lazy(() =>
   import('./AdvancedTab').then((m) => ({ default: m.SubtitleToolsTab })),
 )
-const CleanupTab = lazy(() =>
-  import('./CleanupTab').then((m) => ({ default: m.CleanupTab })),
-)
-
 function SectionSkeleton() {
   return (
     <div data-testid="section-skeleton" className="animate-pulse space-y-3 py-2">
@@ -475,24 +471,6 @@ export function SubtitlesSettings() {
           <div data-testid="format-tools-content">
             <Suspense fallback={<SectionSkeleton />}>
               <SubtitleToolsTab />
-            </Suspense>
-          </div>
-        </SettingsSection>
-      </div>
-
-      {/* 3. Cleanup */}
-      <div data-testid="section-cleanup">
-        <SettingsSection
-          title={t('settings.subtitles.cleanup.title', 'Cleanup')}
-          description={t(
-            'settings.subtitles.cleanup.description',
-            'Remove duplicate and orphaned subtitle files from your library.',
-          )}
-          icon={<Trash2 size={16} style={{ color: 'var(--accent)' }} />}
-        >
-          <div data-testid="cleanup-content">
-            <Suspense fallback={<SectionSkeleton />}>
-              <CleanupTab />
             </Suspense>
           </div>
         </SettingsSection>

--- a/frontend/src/pages/Settings/__tests__/CleanupSettings.test.tsx
+++ b/frontend/src/pages/Settings/__tests__/CleanupSettings.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+vi.mock('@/hooks/useSystemApi', () => ({
+  useCleanupRules: () => ({ data: [], isLoading: false }),
+  useCreateCleanupRule: () => ({ mutate: vi.fn(), isPending: false }),
+  useUpdateCleanupRule: () => ({ mutate: vi.fn() }),
+  useDeleteCleanupRule: () => ({ mutate: vi.fn() }),
+  useRunCleanupRule: () => ({ mutate: vi.fn(), isPending: false }),
+  useRulePreview: () => ({ mutate: vi.fn(), isPending: false }),
+  useCleanupStats: () => ({ data: null, isLoading: false }),
+  useStartCleanupScan: () => ({ mutate: vi.fn(), isPending: false }),
+  useCleanupScanStatus: () => ({ data: null }),
+  useDuplicates: () => ({ data: null, refetch: vi.fn() }),
+  useDeleteDuplicates: () => ({ mutate: vi.fn(), isPending: false }),
+  useOrphanedScan: () => ({ mutate: vi.fn(), isPending: false }),
+  useOrphanedFiles: () => ({ data: null, refetch: vi.fn() }),
+  useDeleteOrphaned: () => ({ mutate: vi.fn(), isPending: false }),
+  useCleanupHistory: () => ({ data: null }),
+  useCleanupPreview: () => ({ mutate: vi.fn() }),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (_k: string, fb: string) => fb ?? _k }),
+}))
+
+function wrap(ui: React.ReactElement) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>)
+}
+
+describe('CleanupSettings', () => {
+  it('renders the page heading', async () => {
+    const { CleanupSettings } = await import('../CleanupSettings')
+    wrap(<CleanupSettings />)
+    expect(screen.getByText(/Cleanup Rules/i)).toBeTruthy()
+  })
+
+  it('shows empty state when no rules exist', async () => {
+    const { CleanupSettings } = await import('../CleanupSettings')
+    wrap(<CleanupSettings />)
+    expect(screen.getByText(/Noch keine Regeln/i)).toBeTruthy()
+  })
+
+  it('shows "+ Neu" button in sidebar', async () => {
+    const { CleanupSettings } = await import('../CleanupSettings')
+    wrap(<CleanupSettings />)
+    expect(screen.getByText('Neu')).toBeTruthy()
+  })
+})

--- a/frontend/src/pages/Settings/__tests__/SubtitlesSettings.test.tsx
+++ b/frontend/src/pages/Settings/__tests__/SubtitlesSettings.test.tsx
@@ -3,8 +3,8 @@
  *
  * Covers:
  * - Renders the page via SettingsDetailLayout
- * - All 6 sections are present (data-testid attributes)
- * - Sections 4-6 (Embedded Extraction, Language Profiles, Fansub Preferences)
+ * - All 8 sections are present (data-testid attributes)
+ * - Sections 3-5 (Embedded Extraction, Language Profiles, Fansub Preferences)
  *   use the `advanced` prop and are collapsed by default
  * - Expanding an advanced section via toggle reveals its content
  */
@@ -26,10 +26,6 @@ vi.mock('@/pages/Settings/AdvancedTab', () => ({
     <div data-testid="mock-language-profiles-tab">Language Profiles Tab</div>
   ),
   SubtitleToolsTab: () => <div data-testid="mock-subtitle-tools-tab">Subtitle Tools Tab</div>,
-}))
-
-vi.mock('@/pages/Settings/CleanupTab', () => ({
-  CleanupTab: () => <div data-testid="mock-cleanup-tab">Cleanup Tab</div>,
 }))
 
 const mockMutate = vi.fn()
@@ -128,11 +124,6 @@ describe('SubtitlesSettings', () => {
     expect(screen.getByTestId('section-format-tools')).toBeInTheDocument()
   })
 
-  it('renders the Cleanup section', () => {
-    renderPage()
-    expect(screen.getByTestId('section-cleanup')).toBeInTheDocument()
-  })
-
   it('renders the Embedded Extraction section', () => {
     renderPage()
     expect(screen.getByTestId('section-embedded-extraction')).toBeInTheDocument()
@@ -162,13 +153,6 @@ describe('SubtitlesSettings', () => {
     const wrapper = screen.getByTestId('section-format-tools')
     const title = wrapper.querySelector('[data-testid="settings-section-title"]')
     expect(title).toHaveTextContent('Format & Tools')
-  })
-
-  it('shows "Cleanup" section title', () => {
-    renderPage()
-    const wrapper = screen.getByTestId('section-cleanup')
-    const title = wrapper.querySelector('[data-testid="settings-section-title"]')
-    expect(title).toHaveTextContent('Cleanup')
   })
 
   it('shows "Embedded Extraction" section title', () => {
@@ -233,14 +217,6 @@ describe('SubtitlesSettings', () => {
   it('Format & Tools section does not have an advanced toggle', () => {
     renderPage()
     const wrapper = screen.getByTestId('section-format-tools')
-    expect(
-      wrapper.querySelector('[data-testid="settings-section-advanced-toggle"]'),
-    ).toBeNull()
-  })
-
-  it('Cleanup section does not have an advanced toggle', () => {
-    renderPage()
-    const wrapper = screen.getByTestId('section-cleanup')
     expect(
       wrapper.querySelector('[data-testid="settings-section-advanced-toggle"]'),
     ).toBeNull()
@@ -344,10 +320,10 @@ describe('SubtitlesSettings', () => {
 
   // ── All sections exist ────────────────────────────────────────────────────
 
-  it('renders exactly 9 settings sections', () => {
+  it('renders exactly 8 settings sections', () => {
     renderPage()
     const sections = screen.getAllByTestId('settings-section')
-    expect(sections).toHaveLength(9)
+    expect(sections).toHaveLength(8)
   })
 })
 

--- a/frontend/src/pages/Settings/index.tsx
+++ b/frontend/src/pages/Settings/index.tsx
@@ -58,6 +58,9 @@ const HooksPage = lazy(() =>
 const WebhooksPage = lazy(() =>
   import('./WebhooksPage').then((m) => ({ default: m.WebhooksPage })),
 )
+const CleanupSettings = lazy(() =>
+  import('./CleanupSettings').then((m) => ({ default: m.CleanupSettings })),
+)
 
 export function SettingsPage() {
   return (
@@ -74,6 +77,7 @@ export function SettingsPage() {
         <Route path="notifications" element={<NotificationsSettings />} />
         <Route path="system" element={<SystemSettings />} />
         <Route path="about" element={<AboutSettings />} />
+        <Route path="cleanup" element={<Suspense fallback={<FormSkeleton />}><CleanupSettings /></Suspense>} />
         <Route path="hooks" element={<HooksPage />} />
         <Route path="webhooks" element={<WebhooksPage />} />
       </Routes>

--- a/frontend/src/types/system.ts
+++ b/frontend/src/types/system.ts
@@ -371,9 +371,10 @@ export interface DuplicateGroup {
 export interface CleanupRule {
   id: number
   name: string
-  rule_type: 'dedup' | 'orphaned' | 'old_backups'
+  rule_type: 'dedup' | 'orphaned' | 'old_backups' | 'language_filter' | 'format_upgrade' | 'orphan_files' | 'orphan_db'
   config_json: Record<string, unknown>
   enabled: boolean
+  schedule: 'manual' | 'daily' | 'weekly' | 'after_scan'
   last_run_at: string | null
   created_at: string
 }


### PR DESCRIPTION
## Summary

- Replaces embedded `CleanupTab` in SubtitlesSettings with a dedicated first-class **Cleanup** tile in the Settings grid (`/settings/cleanup`)
- Implements 4 rule types: **Language Filter**, **Format Upgrade**, **Orphan Files**, **Orphan DB** — each with dry-run preview
- Adds `schedule` column to `cleanup_rules` (manual / daily / weekly / after_scan) with Alembic migration
- Full sidebar + detail layout: rule list, type-specific config sections (language tag picker, format card selector, schedule chip picker), last-run bar, history table
- NFO files (`.nfo`) hardcoded as excluded from all cleanup executors

## Changes

**Backend:**
- `db/migrations/versions/f0e1d2c3b4a5_add_schedule_to_cleanup_rules.py` — Alembic migration (batch_alter_table for SQLite compat)
- `db/models/cleanup.py` — `schedule` field added to `CleanupRule`
- `db/repositories/cleanup.py` — `_rule_to_dict`, `create_rule`/`update_rule`/`get_rules` support schedule
- `db/repositories/subtitles.py` — `get_all_subtitle_paths()` and `delete_by_path()` for orphan_db executor
- `services/cleanup_executors.py` — 4 new executor functions (language_filter, format_upgrade, orphan_files, orphan_db)
- `routes/cleanup.py` — dispatches to new executors; new `POST /rules/<id>/preview` endpoint
- `cleanup_scheduler.py` — dispatches all 7 rule types including the 4 new ones
- `tests/test_cleanup_executors.py` — 5 tests, 84% executor coverage

**Frontend:**
- `types/system.ts` — Extended `CleanupRule` interface with schedule + new rule types
- `api/system/tasks.ts` + `hooks/useSystemApi.ts` — `previewCleanupRule` + `useRulePreview` hook
- `components/cleanup/LanguageFilterConfig.tsx` — tag-style language picker
- `components/cleanup/FormatUpgradeConfig.tsx` — 3-card format selector
- `components/cleanup/SchedulePicker.tsx` — chip selector for schedule
- `components/cleanup/RuleSidebar.tsx` — 260px sidebar with rule cards
- `components/cleanup/RuleDetail.tsx` — detail panel with header, last-run bar, config sections, preview
- `pages/Settings/CleanupSettings.tsx` — full page: NewRuleModal + HistorySection + main layout
- `pages/Settings/__tests__/CleanupSettings.test.tsx` — 3 smoke tests
- `pages/Settings/SettingsGrid.tsx` — Cleanup tile added
- `pages/Settings/index.tsx` — `/settings/cleanup` route wired
- `pages/Settings/SubtitlesSettings.tsx` — CleanupTab removed

## Test plan

- [ ] Backend: 1477 passed, 3 skipped (standard ignores)
- [ ] Frontend: 825 passed (72 test files)
- [ ] ruff: All checks passed, 451 files formatted
- [ ] ESLint: 0 errors, 11 warnings (all pre-existing)
- [ ] TypeScript: no errors
- [ ] Navigate to Settings → verify Cleanup tile appears in grid
- [ ] Create a Language Filter rule, add languages, save, run preview
- [ ] Create a Format Upgrade rule, select preference, run immediately
- [ ] Create Orphan Files + Orphan DB rules with schedule = after_scan
- [ ] Verify NFO files never appear in preview/delete results
- [ ] Verify CleanupTab no longer visible in Subtitles settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)