### PR TITLE
Add Shoko Server integration (AniDB matching + rescan)

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,20 @@ Point Sublarr at your media folder in *Settings → Library Sources*. It will wa
 2. Enter your server URL and API key
 3. Sublarr will trigger a library refresh after each subtitle download
 
+### Shoko Server (anime — AniDB matching)
+
+1. *Sublarr → Settings → Connections → Add Media Server → Shoko Server*
+2. Enter your Shoko URL (default port `8111`) and an API key — or a username/password
+3. (Optional) Set a *Path Mapping* (`from:to`) if Sublarr and Shoko mount the media under different roots
+
+What it does:
+- **Authoritative AniDB matching** — Shoko already knows the exact AniDB anime, episode
+  and absolute-episode number for every file it manages, so Sublarr uses that instead of
+  guessing via titles. This directly improves Jimaku (AniDB-ID-based) results and fixes
+  alternate episode ordering. An explicit Sonarr `anidb_id` custom field still wins.
+- **Rescan after download** — like Jellyfin/Emby, Shoko is told to rescan the file after
+  a subtitle is written so it picks up the new external subtitle.
+
 ### Ollama (Local LLM — translation beta)
 
 > ⚠️ Translation quality is variable. Only enable if you need it.

--- a/backend/config.py
+++ b/backend/config.py
@@ -36,6 +36,7 @@ from config_singleton import get_settings, reload_settings  # noqa: E402, F401
 from config_instances import (  # noqa: E402, F401
     get_media_server_instances,
     get_radarr_instances,
+    get_shoko_config,
     get_sonarr_instances,
     is_standalone_mode,
 )

--- a/backend/config_instances.py
+++ b/backend/config_instances.py
@@ -148,15 +148,39 @@ def get_media_server_instances() -> list[dict]:
     return []
 
 
+# Memoized result of get_shoko_config(). Shoko is entirely optional: when no
+# Shoko instance is configured this stays None, so the per-query enricher hook
+# becomes a cheap dict/None check with zero DB reads for users who don't run
+# Shoko. Cleared by invalidate_shoko_config_cache(), which the media-server
+# manager's invalidate hook calls whenever media_servers_json changes.
+_UNSET = object()
+_shoko_config_cache = _UNSET
+
+
+def invalidate_shoko_config_cache() -> None:
+    """Drop the memoized Shoko config so the next lookup re-reads config."""
+    global _shoko_config_cache
+    _shoko_config_cache = _UNSET
+
+
 def get_shoko_config() -> dict | None:
-    """Return the first enabled Shoko instance config, or None.
+    """Return the first enabled Shoko instance config, or None (memoized).
 
     Shoko is configured as a ``shoko``-typed entry in the shared
     ``media_servers_json`` blob (same store the media-server manager uses for
     the rescan role), so the enricher/library-sync code and the media-server
     rescan share a single source of truth. Returns a dict with at least
     ``url`` plus ``api_key``/``username``/``password`` when configured.
+
+    The result is cached (including the common ``None`` — "no Shoko" — case) and
+    only recomputed after ``invalidate_shoko_config_cache()``; the media-server
+    manager clears it on every media_servers_json write.
     """
+    global _shoko_config_cache
+    if _shoko_config_cache is not _UNSET:
+        return _shoko_config_cache
+
+    result = None
     for entry in get_media_server_instances():
         if not isinstance(entry, dict):
             continue
@@ -165,5 +189,8 @@ def get_shoko_config() -> dict | None:
         if not entry.get("enabled", True):
             continue
         if entry.get("url"):
-            return entry
-    return None
+            result = entry
+            break
+
+    _shoko_config_cache = result
+    return result

--- a/backend/config_instances.py
+++ b/backend/config_instances.py
@@ -146,3 +146,24 @@ def get_media_server_instances() -> list[dict]:
         return migrated
 
     return []
+
+
+def get_shoko_config() -> dict | None:
+    """Return the first enabled Shoko instance config, or None.
+
+    Shoko is configured as a ``shoko``-typed entry in the shared
+    ``media_servers_json`` blob (same store the media-server manager uses for
+    the rescan role), so the enricher/library-sync code and the media-server
+    rescan share a single source of truth. Returns a dict with at least
+    ``url`` plus ``api_key``/``username``/``password`` when configured.
+    """
+    for entry in get_media_server_instances():
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("type") != "shoko":
+            continue
+        if not entry.get("enabled", True):
+            continue
+        if entry.get("url"):
+            return entry
+    return None

--- a/backend/mediaserver/__init__.py
+++ b/backend/mediaserver/__init__.py
@@ -291,6 +291,14 @@ def invalidate_media_server_manager() -> None:
     """Destroy the singleton instance (for testing or config reload)."""
     global _manager
     _manager = None
+    # Shoko shares media_servers_json; drop its memoized config too so the
+    # wanted-search enricher re-reads it after any media-server change.
+    try:
+        from config_instances import invalidate_shoko_config_cache
+
+        invalidate_shoko_config_cache()
+    except Exception:  # noqa: BLE001 — cache invalidation is best-effort
+        pass
 
 
 def _register_builtin_servers(manager: MediaServerManager) -> None:

--- a/backend/mediaserver/__init__.py
+++ b/backend/mediaserver/__init__.py
@@ -311,3 +311,8 @@ def _register_builtin_servers(manager: MediaServerManager) -> None:
     from mediaserver.kodi import KodiServer
 
     manager.register_server_type(KodiServer)
+
+    # Shoko: uses stdlib requests (always available)
+    from mediaserver.shoko import ShokoServer
+
+    manager.register_server_type(ShokoServer)

--- a/backend/mediaserver/shoko.py
+++ b/backend/mediaserver/shoko.py
@@ -1,0 +1,137 @@
+"""Shoko Server media-server backend.
+
+Shoko is an AniDB-backed anime collection manager. As a *media server* in
+Sublarr's sense it plays the same role as Jellyfin/Plex/Kodi: after Sublarr
+writes a subtitle next to a video, we tell Shoko to rescan that file so it
+picks up the new external subtitle.
+
+The heavy lifting lives in ``metadata.shoko_client.ShokoClient`` — this class
+is a thin MediaServer ABC adapter over it, so the same config powers both the
+rescan role here and the authoritative AniDB lookups in the wanted-search
+enricher chain.
+"""
+
+import logging
+
+from mediaserver.base import MediaServer, RefreshResult
+
+logger = logging.getLogger(__name__)
+
+
+class ShokoServer(MediaServer):
+    """Shoko Server v3 backend (rescan-after-download)."""
+
+    name = "shoko"
+    display_name = "Shoko Server"
+    config_fields = [
+        {
+            "key": "url",
+            "label": "Server URL",
+            "type": "text",
+            "required": True,
+            "default": "http://localhost:8111",
+            "help": "Shoko Server URL (e.g. http://192.168.1.100:8111)",
+        },
+        {
+            "key": "api_key",
+            "label": "API Key",
+            "type": "password",
+            "required": False,
+            "default": "",
+            "help": "Persistent Shoko API key. Leave blank to use username/password instead.",
+        },
+        {
+            "key": "username",
+            "label": "Username",
+            "type": "text",
+            "required": False,
+            "default": "",
+            "help": "Shoko username (only needed when no API key is set)",
+        },
+        {
+            "key": "password",
+            "label": "Password",
+            "type": "password",
+            "required": False,
+            "default": "",
+            "help": "Shoko password (only needed when no API key is set)",
+        },
+        {
+            "key": "path_mapping",
+            "label": "Path Mapping",
+            "type": "text",
+            "required": False,
+            "default": "",
+            "help": "from_path:to_path if Sublarr and Shoko see the media under "
+            "different roots (e.g. /media:/data). Leave blank if the paths match.",
+        },
+    ]
+
+    def __init__(self, **config):
+        super().__init__(**config)
+        self.url = str(config.get("url", "http://localhost:8111")).rstrip("/")
+        self.api_key = config.get("api_key", "")
+        self.username = config.get("username", "")
+        self.password = config.get("password", "")
+
+    def _client(self):
+        from metadata.shoko_client import ShokoClient
+
+        return ShokoClient(
+            url=self.url,
+            api_key=self.api_key,
+            username=self.username,
+            password=self.password,
+        )
+
+    def health_check(self) -> tuple[bool, str]:
+        return self._client().health_check()
+
+    def refresh_item(self, file_path: str, item_type: str = "") -> RefreshResult:
+        """Rescan the Shoko file matching ``file_path``.
+
+        Falls back to a full import-folder scan when the file is unknown to
+        Shoko (e.g. path-mapping mismatch or not yet imported).
+        """
+        mapped_path = self.apply_path_mapping(file_path)
+        server_name = self.config.get("name", self.display_name)
+        try:
+            client = self._client()
+            if client.rescan_file_by_path(mapped_path):
+                type_str = f" ({item_type})" if item_type else ""
+                logger.info("Triggered Shoko rescan for %s%s", mapped_path, type_str)
+                return RefreshResult(
+                    success=True,
+                    message=f"Rescanned {mapped_path}{type_str}",
+                    server_name=server_name,
+                )
+            logger.info("File not found in Shoko, falling back to library scan: %s", mapped_path)
+            return self.refresh_library()
+        except Exception as e:  # noqa: BLE001 — refresh is best-effort
+            return RefreshResult(
+                success=False,
+                message=f"Shoko rescan failed: {e}",
+                server_name=server_name,
+            )
+
+    def refresh_library(self) -> RefreshResult:
+        server_name = self.config.get("name", self.display_name)
+        try:
+            if self._client().refresh_library():
+                logger.info("Triggered Shoko import-folder scan")
+                return RefreshResult(
+                    success=True,
+                    message="Import-folder scan triggered on Shoko",
+                    server_name=server_name,
+                )
+        except Exception as e:  # noqa: BLE001
+            return RefreshResult(
+                success=False,
+                message=f"Shoko library scan failed: {e}",
+                server_name=server_name,
+            )
+        return RefreshResult(
+            success=False,
+            message="Failed to trigger import-folder scan on Shoko",
+            server_name=server_name,
+        )

--- a/backend/metadata/shoko_client.py
+++ b/backend/metadata/shoko_client.py
@@ -1,0 +1,331 @@
+"""Shoko Server v3 REST API client.
+
+Shoko is an AniDB-backed anime collection manager. Because Shoko already
+matches every physical file to its exact AniDB anime + AniDB episode (and
+therefore the AniDB absolute-episode number), it is an *authoritative*
+source for the IDs Sublarr otherwise has to guess via the fuzzy AniDB
+resolution chain in ``anidb_mapper`` / ``metadata_enrichers``.
+
+This client is deliberately thin and follows the same shape as the other
+metadata/media-server clients in the codebase (see ``metadata/tvdb_client.py``
+and ``mediaserver/jellyfin.py``): a ``requests.Session`` with per-request
+retry/429 handling, private ``_get``/``_post`` helpers that return ``None``
+on failure instead of raising, and typed public methods.
+
+Auth: Shoko v3 accepts an ``apikey`` — either supplied directly (a persistent
+API key) or obtained via ``POST /api/auth`` with user/pass/device. The key is
+sent as the ``apikey`` header on every request.
+
+Endpoints used (Shoko Server v3):
+    POST /api/auth                                  -> {"apikey": "..."}
+    GET  /api/v3/Init/Status                        -> server state (no auth)
+    GET  /api/v3/File/PathEndsWith?path=&include=XRefs
+    GET  /api/v3/Series/{id}                        -> IDs.AniDB
+    GET  /api/v3/Episode/{id}                       -> IDs.AniDB + AniDB.EpisodeNumber
+    POST /api/v3/File/{id}/Rescan
+    GET  /api/v3/ImportFolder/{id}/Scan
+
+License: GPL-3.0
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from dataclasses import dataclass
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+REQUEST_TIMEOUT = 15
+MAX_RETRIES = 2
+BACKOFF_BASE = 2
+
+
+@dataclass
+class ShokoFileIDs:
+    """Authoritative AniDB identifiers Shoko holds for a physical file."""
+
+    file_id: int | None = None
+    anidb_anime_id: int | None = None
+    anidb_episode_id: int | None = None
+    # AniDB numbers episodes 1..N within each anime entry, so for a "Normal"
+    # episode this number is the AniDB absolute-order number Sublarr wants.
+    absolute_episode: int | None = None
+
+
+class ShokoClient:
+    """Minimal client for the Shoko Server v3 REST API."""
+
+    def __init__(
+        self,
+        url: str,
+        api_key: str = "",
+        username: str = "",
+        password: str = "",
+    ):
+        self.url = (url or "").rstrip("/")
+        self._api_key = api_key or ""
+        self._username = username or ""
+        self._password = password or ""
+        self.session = requests.Session()
+        self.session.headers["Accept"] = "application/json"
+        if self._api_key:
+            self.session.headers["apikey"] = self._api_key
+
+    # ------------------------------------------------------------------
+    # Auth
+    # ------------------------------------------------------------------
+    def _ensure_auth(self) -> bool:
+        """Ensure an apikey is set, logging in with user/pass if needed.
+
+        Returns True when an apikey is available on the session.
+        """
+        if self._api_key:
+            return True
+        if not (self._username and self._password):
+            return False
+        try:
+            resp = self.session.post(
+                f"{self.url}/api/auth",
+                json={
+                    "user": self._username,
+                    "pass": self._password,
+                    "device": "Sublarr",
+                },
+                timeout=REQUEST_TIMEOUT,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            key = data.get("apikey") if isinstance(data, dict) else None
+            if key:
+                self._api_key = key
+                self.session.headers["apikey"] = key
+                return True
+        except Exception as e:  # noqa: BLE001 — auth failure is non-fatal
+            logger.warning("Shoko auth failed at %s: %s", self.url, e)
+        return False
+
+    # ------------------------------------------------------------------
+    # HTTP helpers (return None on failure, never raise)
+    # ------------------------------------------------------------------
+    def _request(self, method: str, path: str, params=None, timeout=REQUEST_TIMEOUT):
+        url = f"{self.url}{path}"
+        for attempt in range(1, MAX_RETRIES + 1):
+            try:
+                resp = self.session.request(method, url, params=params, timeout=timeout)
+                if resp.status_code == 429:
+                    retry_after = resp.headers.get("Retry-After")
+                    try:
+                        wait_seconds = int(retry_after) if retry_after else 60
+                    except ValueError:
+                        wait_seconds = 60
+                    logger.warning(
+                        "Shoko %s %s rate limited (attempt %d), waiting %ds",
+                        method,
+                        path,
+                        attempt,
+                        wait_seconds,
+                    )
+                    if attempt < MAX_RETRIES:
+                        time.sleep(wait_seconds)
+                        continue
+                    return None
+                resp.raise_for_status()
+                if not resp.content:
+                    return {}
+                return resp.json()
+            except requests.ConnectionError as e:
+                logger.warning("Shoko %s %s failed (attempt %d): %s", method, path, attempt, e)
+            except requests.Timeout:
+                logger.warning("Shoko %s %s timed out (attempt %d)", method, path, attempt)
+            except Exception as e:  # noqa: BLE001 — bubble up as None
+                logger.error("Shoko unexpected error on %s %s: %s", method, path, e)
+                return None
+            if attempt < MAX_RETRIES:
+                time.sleep(BACKOFF_BASE * attempt)
+        return None
+
+    def _get(self, path, params=None, timeout=REQUEST_TIMEOUT):
+        return self._request("GET", path, params=params, timeout=timeout)
+
+    def _post(self, path, params=None, timeout=REQUEST_TIMEOUT):
+        return self._request("POST", path, params=params, timeout=timeout)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def health_check(self) -> tuple[bool, str]:
+        """Check that Shoko is reachable (and, if secured, that auth works).
+
+        ``/api/v3/Init/Status`` needs no auth, so it verifies reachability.
+        A subsequent authenticated call confirms the apikey when credentials
+        are configured.
+        """
+        status = self._get("/api/v3/Init/Status")
+        if status is None:
+            return False, f"Cannot connect to Shoko at {self.url}"
+
+        state = ""
+        if isinstance(status, dict):
+            state = status.get("State", "") or status.get("state", "")
+
+        # Confirm auth when we have (or can obtain) an apikey.
+        if self._api_key or (self._username and self._password):
+            if not self._ensure_auth():
+                return False, "Shoko reachable but authentication failed"
+            # /api/v3/Dashboard requires a valid apikey — cheap auth probe.
+            if self._get("/api/v3/Dashboard") is None:
+                return False, "Shoko reachable but apikey rejected"
+
+        suffix = f" ({state})" if state else ""
+        return True, f"Connected to Shoko at {self.url}{suffix}"
+
+    def get_file_ids_by_path(self, file_path: str) -> ShokoFileIDs | None:
+        """Resolve a physical file to its authoritative AniDB IDs.
+
+        Looks the file up by the tail of its path (``PathEndsWith`` matches on
+        a path suffix, so it is robust to differing mount roots between Shoko
+        and Sublarr). Returns ``None`` when the file is unknown to Shoko or
+        Shoko is unreachable.
+        """
+        if not file_path:
+            return None
+        if not self._ensure_auth() and (self._username or self._password):
+            # Credentials were given but login failed — treat as unavailable.
+            return None
+
+        # Match on filename + parent dir: specific enough to avoid collisions,
+        # short enough to survive path-root differences.
+        basename = os.path.basename(file_path)
+        parent = os.path.basename(os.path.dirname(file_path))
+        needle = f"{parent}/{basename}" if parent else basename
+
+        files = self._get(
+            "/api/v3/File/PathEndsWith",
+            params={"path": needle, "include": "XRefs", "limit": 1},
+        )
+        if not files:
+            # Retry with just the filename in case the parent dir differs.
+            files = self._get(
+                "/api/v3/File/PathEndsWith",
+                params={"path": basename, "include": "XRefs", "limit": 1},
+            )
+        if not files or not isinstance(files, list):
+            return None
+
+        file_obj = files[0]
+        ids = ShokoFileIDs(file_id=_as_int(file_obj.get("ID")))
+        xref = _first_cross_reference(file_obj)
+        if xref is None:
+            return ids if ids.file_id else None
+
+        ids.anidb_anime_id = _extract_anidb_anime_id(xref)
+        ids.anidb_episode_id = _extract_anidb_episode_id(xref)
+
+        # The AniDB episode number (== absolute order for Normal episodes) is
+        # not always inlined in the file xref; fetch it from the episode when
+        # we have a Shoko episode id to resolve it from.
+        shoko_episode_id = _extract_shoko_episode_id(xref)
+        if shoko_episode_id:
+            ids.absolute_episode = self._get_anidb_episode_number(shoko_episode_id)
+
+        return ids
+
+    def _get_anidb_episode_number(self, shoko_episode_id: int) -> int | None:
+        """Return the AniDB episode number for a Shoko episode id (Normal type only)."""
+        ep = self._get(f"/api/v3/Episode/{shoko_episode_id}")
+        if not isinstance(ep, dict):
+            return None
+        anidb = ep.get("AniDB")
+        if not isinstance(anidb, dict):
+            return None
+        # Only "Normal" episodes carry a meaningful absolute number; specials,
+        # OPs/EDs, trailers etc. are numbered in their own AniDB namespace.
+        ep_type = str(anidb.get("Type", "") or "").lower()
+        if ep_type and ep_type != "normal":
+            return None
+        return _as_int(anidb.get("EpisodeNumber"))
+
+    def rescan_file_by_path(self, file_path: str) -> bool:
+        """Trigger a rescan of the file at ``file_path`` so Shoko re-reads sidecars."""
+        ids = self.get_file_ids_by_path(file_path)
+        if not ids or not ids.file_id:
+            return False
+        result = self._post(f"/api/v3/File/{ids.file_id}/Rescan")
+        return result is not None
+
+    def refresh_library(self) -> bool:
+        """Trigger a scan of every import folder (fallback when a file is unknown)."""
+        if not self._ensure_auth() and (self._username or self._password):
+            return False
+        folders = self._get("/api/v3/ImportFolder")
+        if not isinstance(folders, list) or not folders:
+            return False
+        ok = False
+        for folder in folders:
+            folder_id = _as_int(folder.get("ID"))
+            if folder_id and self._get(f"/api/v3/ImportFolder/{folder_id}/Scan") is not None:
+                ok = True
+        return ok
+
+
+# ---------------------------------------------------------------------------
+# Cross-reference parsing helpers
+#
+# The exact nesting of a File's cross-references has shifted across Shoko
+# releases, so these read defensively: they accept both a flat shape
+# (``AnidbAnimeID`` / ``AnidbEpisodeID`` integers) and the nested
+# ``SeriesID`` / ``EpisodeIDs`` objects that expose an ``AniDB`` field.
+# ---------------------------------------------------------------------------
+def _as_int(value) -> int | None:
+    try:
+        if value is None:
+            return None
+        ivalue = int(value)
+        return ivalue if ivalue > 0 else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _first_cross_reference(file_obj: dict) -> dict | None:
+    if not isinstance(file_obj, dict):
+        return None
+    xrefs = file_obj.get("SeriesIDs")
+    if isinstance(xrefs, list) and xrefs and isinstance(xrefs[0], dict):
+        return xrefs[0]
+    return None
+
+
+def _extract_anidb_anime_id(xref: dict) -> int | None:
+    # Flat shape (ReleaseCrossReference): {"AnidbAnimeID": 123, ...}
+    flat = _as_int(xref.get("AnidbAnimeID"))
+    if flat:
+        return flat
+    # Nested shape: {"SeriesID": {"AniDB": 123, "ID": <shoko>}}
+    series_id = xref.get("SeriesID")
+    if isinstance(series_id, dict):
+        return _as_int(series_id.get("AniDB"))
+    # Some builds expose SeriesID as the plain AniDB int.
+    return _as_int(series_id)
+
+
+def _extract_anidb_episode_id(xref: dict) -> int | None:
+    # Flat shape
+    flat = _as_int(xref.get("AnidbEpisodeID"))
+    if flat:
+        return flat
+    # Nested shape: {"EpisodeIDs": [{"AniDB": 456, "ID": <shoko>}]}
+    episode_ids = xref.get("EpisodeIDs")
+    if isinstance(episode_ids, list) and episode_ids and isinstance(episode_ids[0], dict):
+        return _as_int(episode_ids[0].get("AniDB"))
+    return None
+
+
+def _extract_shoko_episode_id(xref: dict) -> int | None:
+    episode_ids = xref.get("EpisodeIDs")
+    if isinstance(episode_ids, list) and episode_ids and isinstance(episode_ids[0], dict):
+        return _as_int(episode_ids[0].get("ID"))
+    return None

--- a/backend/tests/test_shoko_integration.py
+++ b/backend/tests/test_shoko_integration.py
@@ -239,6 +239,79 @@ class TestShokoServer:
 
 
 # ---------------------------------------------------------------------------
+# get_shoko_config — optionality: cached, and None when Shoko isn't configured
+# ---------------------------------------------------------------------------
+class TestShokoConfigOptional:
+    def test_none_when_no_shoko_instance(self):
+        import config_instances
+
+        config_instances.invalidate_shoko_config_cache()
+        with patch(
+            "config_instances.get_media_server_instances",
+            return_value=[{"type": "jellyfin", "name": "JF", "url": "http://jf:8096"}],
+        ):
+            assert config_instances.get_shoko_config() is None
+        config_instances.invalidate_shoko_config_cache()
+
+    def test_returns_enabled_shoko_instance(self):
+        import config_instances
+
+        config_instances.invalidate_shoko_config_cache()
+        shoko = {"type": "shoko", "name": "S", "enabled": True, "url": "http://shoko:8111"}
+        with patch("config_instances.get_media_server_instances", return_value=[shoko]):
+            assert config_instances.get_shoko_config() == shoko
+        config_instances.invalidate_shoko_config_cache()
+
+    def test_disabled_shoko_instance_ignored(self):
+        import config_instances
+
+        config_instances.invalidate_shoko_config_cache()
+        shoko = {"type": "shoko", "name": "S", "enabled": False, "url": "http://shoko:8111"}
+        with patch("config_instances.get_media_server_instances", return_value=[shoko]):
+            assert config_instances.get_shoko_config() is None
+        config_instances.invalidate_shoko_config_cache()
+
+    def test_result_is_cached_no_repeat_db_reads(self):
+        import config_instances
+
+        config_instances.invalidate_shoko_config_cache()
+        mock = MagicMock(return_value=[])
+        with patch("config_instances.get_media_server_instances", mock):
+            config_instances.get_shoko_config()
+            config_instances.get_shoko_config()
+            config_instances.get_shoko_config()
+        # Cached after the first call -> config read exactly once.
+        assert mock.call_count == 1
+        config_instances.invalidate_shoko_config_cache()
+
+    def test_invalidation_forces_recompute(self):
+        import config_instances
+
+        config_instances.invalidate_shoko_config_cache()
+        mock = MagicMock(return_value=[])
+        with patch("config_instances.get_media_server_instances", mock):
+            config_instances.get_shoko_config()
+            config_instances.invalidate_shoko_config_cache()
+            config_instances.get_shoko_config()
+        assert mock.call_count == 2
+        config_instances.invalidate_shoko_config_cache()
+
+    def test_media_server_invalidate_clears_shoko_cache(self):
+        """The manager's invalidate hook must also drop the memoized Shoko config."""
+        import config_instances
+        from mediaserver import invalidate_media_server_manager
+
+        config_instances.invalidate_shoko_config_cache()
+        mock = MagicMock(return_value=[])
+        with patch("config_instances.get_media_server_instances", mock):
+            config_instances.get_shoko_config()
+            invalidate_media_server_manager()  # simulates a media-server config change
+            config_instances.get_shoko_config()
+        assert mock.call_count == 2
+        config_instances.invalidate_shoko_config_cache()
+
+
+# ---------------------------------------------------------------------------
 # Enricher — Tier-0 Shoko AniDB resolution
 # ---------------------------------------------------------------------------
 class TestShokoEnricher:

--- a/backend/tests/test_shoko_integration.py
+++ b/backend/tests/test_shoko_integration.py
@@ -1,0 +1,325 @@
+"""Tests for the Shoko Server integration.
+
+Covers the ShokoClient parser, the ShokoServer media-server backend
+(rescan-after-download), and the authoritative Tier-0 AniDB lookup in the
+wanted-search enricher chain.
+
+Run:
+    pytest tests/test_shoko_integration.py -v
+"""
+
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# ShokoClient — cross-reference parsing
+# ---------------------------------------------------------------------------
+class TestShokoClientParsing:
+    def _client(self):
+        from metadata.shoko_client import ShokoClient
+
+        return ShokoClient(url="http://shoko:8111", api_key="key123")
+
+    def test_get_file_ids_nested_shape(self):
+        client = self._client()
+        file_obj = {
+            "ID": 42,
+            "SeriesIDs": [
+                {
+                    "SeriesID": {"ID": 7, "AniDB": 6789},
+                    "EpisodeIDs": [{"ID": 15, "AniDB": 112233}],
+                }
+            ],
+        }
+        client._get = MagicMock(
+            side_effect=lambda path, params=None, **kw: (
+                [file_obj]
+                if path == "/api/v3/File/PathEndsWith"
+                else {"AniDB": {"Type": "Normal", "EpisodeNumber": 5}}
+            )
+        )
+
+        ids = client.get_file_ids_by_path("/anime/Show/Show - 05.mkv")
+
+        assert ids is not None
+        assert ids.file_id == 42
+        assert ids.anidb_anime_id == 6789
+        assert ids.anidb_episode_id == 112233
+        assert ids.absolute_episode == 5
+
+    def test_get_file_ids_flat_shape(self):
+        client = self._client()
+        file_obj = {
+            "ID": 1,
+            "SeriesIDs": [{"AnidbAnimeID": 555, "AnidbEpisodeID": 999}],
+        }
+        client._get = MagicMock(return_value=[file_obj])
+
+        ids = client.get_file_ids_by_path("/anime/x.mkv")
+
+        assert ids.anidb_anime_id == 555
+        assert ids.anidb_episode_id == 999
+        # No Shoko episode ID in flat shape -> no absolute lookup attempted.
+        assert ids.absolute_episode is None
+
+    def test_get_file_ids_unknown_file_returns_none(self):
+        client = self._client()
+        client._get = MagicMock(return_value=[])
+
+        assert client.get_file_ids_by_path("/anime/missing.mkv") is None
+
+    def test_get_file_ids_empty_path_returns_none(self):
+        client = self._client()
+        assert client.get_file_ids_by_path("") is None
+
+    def test_special_episode_has_no_absolute_number(self):
+        client = self._client()
+        file_obj = {
+            "ID": 3,
+            "SeriesIDs": [{"SeriesID": {"AniDB": 1}, "EpisodeIDs": [{"ID": 9, "AniDB": 2}]}],
+        }
+        client._get = MagicMock(
+            side_effect=lambda path, params=None, **kw: (
+                [file_obj]
+                if path == "/api/v3/File/PathEndsWith"
+                else {"AniDB": {"Type": "Special", "EpisodeNumber": 3}}
+            )
+        )
+
+        ids = client.get_file_ids_by_path("/anime/Show/Special.mkv")
+
+        assert ids.anidb_anime_id == 1
+        assert ids.absolute_episode is None  # specials excluded
+
+    def test_rescan_file_by_path(self):
+        client = self._client()
+        client.get_file_ids_by_path = MagicMock(return_value=_ids(file_id=42, anime=1, episode=2))
+        client._post = MagicMock(return_value={})
+
+        assert client.rescan_file_by_path("/anime/x.mkv") is True
+        client._post.assert_called_once_with("/api/v3/File/42/Rescan")
+
+    def test_rescan_file_unknown_returns_false(self):
+        client = self._client()
+        client.get_file_ids_by_path = MagicMock(return_value=None)
+
+        assert client.rescan_file_by_path("/anime/x.mkv") is False
+
+    def test_refresh_library_scans_all_folders(self):
+        client = self._client()
+        calls = []
+
+        def fake_get(path, params=None, **kw):
+            calls.append(path)
+            if path == "/api/v3/ImportFolder":
+                return [{"ID": 1}, {"ID": 2}]
+            return {}
+
+        client._get = MagicMock(side_effect=fake_get)
+
+        assert client.refresh_library() is True
+        assert "/api/v3/ImportFolder/1/Scan" in calls
+        assert "/api/v3/ImportFolder/2/Scan" in calls
+
+
+# ---------------------------------------------------------------------------
+# ShokoClient — auth + health
+# ---------------------------------------------------------------------------
+class TestShokoClientAuth:
+    def test_api_key_sets_header(self):
+        from metadata.shoko_client import ShokoClient
+
+        client = ShokoClient(url="http://shoko:8111", api_key="abc")
+        assert client.session.headers.get("apikey") == "abc"
+        assert client._ensure_auth() is True
+
+    def test_ensure_auth_without_credentials_is_false(self):
+        from metadata.shoko_client import ShokoClient
+
+        client = ShokoClient(url="http://shoko:8111")
+        assert client._ensure_auth() is False
+
+    def test_ensure_auth_logs_in_with_user_pass(self):
+        from metadata.shoko_client import ShokoClient
+
+        client = ShokoClient(url="http://shoko:8111", username="u", password="p")
+        resp = MagicMock()
+        resp.json.return_value = {"apikey": "fresh-key"}
+        resp.raise_for_status.return_value = None
+        with patch.object(client.session, "post", return_value=resp) as post:
+            assert client._ensure_auth() is True
+        assert client.session.headers.get("apikey") == "fresh-key"
+        assert post.call_args.args[0] == "http://shoko:8111/api/auth"
+
+    def test_health_check_unreachable(self):
+        from metadata.shoko_client import ShokoClient
+
+        client = ShokoClient(url="http://shoko:8111", api_key="abc")
+        client._get = MagicMock(return_value=None)
+
+        ok, msg = client.health_check()
+        assert ok is False
+        assert "Cannot connect" in msg
+
+    def test_health_check_ok(self):
+        from metadata.shoko_client import ShokoClient
+
+        client = ShokoClient(url="http://shoko:8111", api_key="abc")
+        client._get = MagicMock(
+            side_effect=lambda path, params=None, **kw: (
+                {"State": "Started"} if "Init/Status" in path else {"ok": True}
+            )
+        )
+
+        ok, msg = client.health_check()
+        assert ok is True
+        assert "Connected to Shoko" in msg
+
+
+# ---------------------------------------------------------------------------
+# ShokoServer media-server backend
+# ---------------------------------------------------------------------------
+class TestShokoServer:
+    def test_registered_in_manager(self):
+        from mediaserver import get_media_server_manager, invalidate_media_server_manager
+
+        invalidate_media_server_manager()
+        manager = get_media_server_manager()
+        names = {t["name"] for t in manager.get_all_server_types()}
+        assert "shoko" in names
+
+    def test_refresh_item_success(self):
+        from mediaserver.shoko import ShokoServer
+
+        server = ShokoServer(url="http://shoko:8111", api_key="k", name="My Shoko")
+        fake_client = MagicMock()
+        fake_client.rescan_file_by_path.return_value = True
+        server._client = MagicMock(return_value=fake_client)
+
+        result = server.refresh_item("/media/anime/ep.mkv", "episode")
+
+        assert result.success is True
+        fake_client.rescan_file_by_path.assert_called_once_with("/media/anime/ep.mkv")
+
+    def test_refresh_item_falls_back_to_library(self):
+        from mediaserver.shoko import ShokoServer
+
+        server = ShokoServer(url="http://shoko:8111", api_key="k")
+        fake_client = MagicMock()
+        fake_client.rescan_file_by_path.return_value = False
+        fake_client.refresh_library.return_value = True
+        server._client = MagicMock(return_value=fake_client)
+
+        result = server.refresh_item("/media/anime/ep.mkv")
+
+        assert result.success is True
+        fake_client.refresh_library.assert_called_once()
+
+    def test_refresh_item_applies_path_mapping(self):
+        from mediaserver.shoko import ShokoServer
+
+        server = ShokoServer(url="http://shoko:8111", api_key="k", path_mapping="/media:/data")
+        fake_client = MagicMock()
+        fake_client.rescan_file_by_path.return_value = True
+        server._client = MagicMock(return_value=fake_client)
+
+        server.refresh_item("/media/anime/ep.mkv")
+
+        fake_client.rescan_file_by_path.assert_called_once_with("/data/anime/ep.mkv")
+
+    def test_health_check_delegates_to_client(self):
+        from mediaserver.shoko import ShokoServer
+
+        server = ShokoServer(url="http://shoko:8111", api_key="k")
+        fake_client = MagicMock()
+        fake_client.health_check.return_value = (True, "ok")
+        server._client = MagicMock(return_value=fake_client)
+
+        assert server.health_check() == (True, "ok")
+
+
+# ---------------------------------------------------------------------------
+# Enricher — Tier-0 Shoko AniDB resolution
+# ---------------------------------------------------------------------------
+class TestShokoEnricher:
+    def _query(self, file_path="/anime/Show/Show - 05.mkv"):
+        from providers.base import VideoQuery
+
+        return VideoQuery(file_path=file_path)
+
+    def test_noop_when_no_shoko_config(self):
+        from wanted_search.metadata_enrichers import _resolve_anidb_from_shoko
+
+        query = self._query()
+        with patch("config.get_shoko_config", return_value=None):
+            assert _resolve_anidb_from_shoko(query) is False
+        assert query.anidb_id is None
+
+    def test_noop_when_no_file_path(self):
+        from wanted_search.metadata_enrichers import _resolve_anidb_from_shoko
+
+        query = self._query(file_path="")
+        assert _resolve_anidb_from_shoko(query) is False
+
+    def test_sets_ids_from_shoko(self):
+        from wanted_search.metadata_enrichers import _resolve_anidb_from_shoko
+
+        query = self._query()
+        fake_client = MagicMock()
+        fake_client.get_file_ids_by_path.return_value = _ids(
+            file_id=42, anime=6789, episode=112233, absolute=5
+        )
+        with (
+            patch("config.get_shoko_config", return_value={"url": "http://shoko:8111"}),
+            patch("metadata.shoko_client.ShokoClient", return_value=fake_client),
+        ):
+            assert _resolve_anidb_from_shoko(query) is True
+
+        assert query.anidb_id == 6789
+        assert query.anidb_episode_id == 112233
+        assert query.absolute_episode == 5
+
+    def test_returns_false_when_file_unknown_to_shoko(self):
+        from wanted_search.metadata_enrichers import _resolve_anidb_from_shoko
+
+        query = self._query()
+        fake_client = MagicMock()
+        fake_client.get_file_ids_by_path.return_value = None
+        with (
+            patch("config.get_shoko_config", return_value={"url": "http://shoko:8111"}),
+            patch("metadata.shoko_client.ShokoClient", return_value=fake_client),
+        ):
+            assert _resolve_anidb_from_shoko(query) is False
+        assert query.anidb_id is None
+
+    def test_shoko_wins_as_tier0_in_standalone_chain(self):
+        """When Shoko resolves, the fuzzy cache/AniList/title tiers are skipped."""
+        from providers.base import VideoQuery
+        from wanted_search.metadata_enrichers import _resolve_anidb_id_for_standalone
+
+        query = VideoQuery(file_path="/anime/x.mkv", tvdb_id=100, anilist_id=200)
+        fake_client = MagicMock()
+        fake_client.get_file_ids_by_path.return_value = _ids(file_id=1, anime=333, episode=444)
+        with (
+            patch("config.get_shoko_config", return_value={"url": "http://shoko:8111"}),
+            patch("metadata.shoko_client.ShokoClient", return_value=fake_client),
+            patch("db.cache.get_anidb_mapping") as cache_lookup,
+        ):
+            _resolve_anidb_id_for_standalone(query, {"id": 1})
+
+        assert query.anidb_id == 333
+        cache_lookup.assert_not_called()  # fuzzy chain never reached
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+def _ids(file_id=None, anime=None, episode=None, absolute=None):
+    from metadata.shoko_client import ShokoFileIDs
+
+    return ShokoFileIDs(
+        file_id=file_id,
+        anidb_anime_id=anime,
+        anidb_episode_id=episode,
+        absolute_episode=absolute,
+    )

--- a/backend/wanted_search/metadata.py
+++ b/backend/wanted_search/metadata.py
@@ -134,6 +134,7 @@ from wanted_search.metadata_enrichers import (  # noqa: F401 — re-exported for
     _enrich_from_standalone_series,
     _enrich_release_metadata,
     _resolve_anidb_absolute_episode,
+    _resolve_anidb_from_shoko,
     _resolve_anidb_id_for_standalone,
     _validate_minimum_query_data,
 )
@@ -171,6 +172,13 @@ def build_query_from_wanted(wanted_item: dict) -> VideoQuery:
 
     if not metadata_available:
         _enrich_from_filename(query, wanted_item)
+
+    # Authoritative Shoko file→AniDB lookup for anime episodes. Fills the gap
+    # for the Sonarr/filename paths (the standalone path already tries Shoko as
+    # Tier 0 in its own chain). Only runs when no AniDB ID is set yet, so an
+    # explicit Sonarr custom-field tag still wins.
+    if wanted_item["item_type"] == "episode" and not query.anidb_id:
+        _resolve_anidb_from_shoko(query)
 
     _resolve_anidb_absolute_episode(query, wanted_item)
     _enrich_release_metadata(query, wanted_item)

--- a/backend/wanted_search/metadata_enrichers.py
+++ b/backend/wanted_search/metadata_enrichers.py
@@ -62,9 +62,60 @@ def _enrich_from_sonarr(query: VideoQuery, wanted_item: dict) -> bool:
         return False
 
 
+def _resolve_anidb_from_shoko(query: VideoQuery) -> bool:
+    """Tier 0: set AniDB IDs from Shoko's authoritative file→AniDB mapping.
+
+    Shoko already matches every physical file to its exact AniDB anime,
+    AniDB episode and (for Normal episodes) absolute-episode number, so when
+    a Shoko instance is configured this short-circuits the fuzzy resolution
+    chain below. No-op (returns False) when Shoko is disabled/unreachable or
+    the file is unknown to Shoko.
+    """
+    if not query.file_path:
+        return False
+    try:
+        from config import get_shoko_config
+
+        shoko_cfg = get_shoko_config()
+        if not shoko_cfg:
+            return False
+
+        from metadata.shoko_client import ShokoClient
+
+        client = ShokoClient(
+            url=shoko_cfg.get("url", ""),
+            api_key=shoko_cfg.get("api_key", ""),
+            username=shoko_cfg.get("username", ""),
+            password=shoko_cfg.get("password", ""),
+        )
+        ids = client.get_file_ids_by_path(query.file_path)
+        if not ids or not ids.anidb_anime_id:
+            return False
+
+        query.anidb_id = ids.anidb_anime_id
+        if ids.anidb_episode_id:
+            query.anidb_episode_id = ids.anidb_episode_id
+        if ids.absolute_episode is not None and query.absolute_episode is None:
+            query.absolute_episode = ids.absolute_episode
+        logger.debug(
+            "Resolved AniDB ID %d (ep %s, abs %s) from Shoko for %s",
+            ids.anidb_anime_id,
+            ids.anidb_episode_id,
+            ids.absolute_episode,
+            query.file_path,
+        )
+        return True
+    except Exception as _e:  # noqa: BLE001 — Shoko lookup is best-effort
+        logger.debug("Shoko AniDB resolution failed for %s: %s", query.file_path, _e)
+        return False
+
+
 def _resolve_anidb_id_for_standalone(query: VideoQuery, wanted_item: dict) -> None:
-    """Try to set ``query.anidb_id`` using cache → AniList → title search → title dump."""
+    """Try to set ``query.anidb_id`` using Shoko → cache → AniList → title search → title dump."""
     if query.anidb_id:
+        return
+    # Tier 0: authoritative Shoko file→AniDB mapping (short-circuits the rest).
+    if _resolve_anidb_from_shoko(query):
         return
     try:
         # Tier 1: TVDB→AniDB cache
@@ -261,6 +312,10 @@ def _enrich_from_filename(query: VideoQuery, wanted_item: dict) -> None:
 
 def _resolve_anidb_absolute_episode(query: VideoQuery, wanted_item: dict) -> None:
     """Set query.absolute_episode from the AniDB mapping when absolute_order is enabled."""
+    # Shoko (or another authoritative source) may already have set the absolute
+    # episode; its per-file AniDB number beats the TVDB→AniDB range mapping.
+    if query.absolute_episode is not None:
+        return
     if not (
         wanted_item["item_type"] == "episode"
         and query.tvdb_id is not None


### PR DESCRIPTION
Adds an optional Shoko Server integration built on the existing MediaServer
ABC and wanted-search enricher chain — no DB migration, no frontend changes.

- metadata/shoko_client.py: thin Shoko v3 REST client (apikey/user-pass auth,
  file→AniDB lookup by path, rescan, import-folder scan). Cross-reference
  parsing is defensive across Shoko release shapes.
- mediaserver/shoko.py: ShokoServer MediaServer backend for rescan-after-
  download; registered in the manager so it appears in the data-driven
  Media Servers UI and flows through notify_media_servers automatically.
- wanted_search: _resolve_anidb_from_shoko as an authoritative Tier-0 AniDB
  source (file → AniDB anime/episode/absolute), short-circuiting the fuzzy
  title/AniList chain and the TVDB→absolute mapping. An explicit Sonarr
  anidb_id tag still wins.
- config_instances.get_shoko_config(): single config source (a shoko-typed
  entry in media_servers_json) shared by the rescan and matching roles.
- tests + README integration note.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01W1GvJLk9WsZ4QnjqB4XSrg