### PR TITLE
fix(auth): login looped back to /login — API-key gate now accepts UI session

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -14,7 +14,7 @@ import threading
 import time
 from collections import defaultdict
 
-from flask import jsonify, request
+from flask import jsonify, request, session
 
 from config import get_settings
 
@@ -180,6 +180,26 @@ def init_auth(app):
         # Skip auth for standalone poster endpoints — posters are public metadata
         # (is_safe_path() in the route prevents directory traversal)
         if re.match(r"^/api/v1/standalone/(series|movies)/\d+/poster$", path):
+            return None
+
+        # An authenticated UI session satisfies the API gate. ui_auth.py's
+        # contract is "API routes accept either a valid UI session OR an
+        # X-Api-Key header", but this hook used to enforce the key
+        # unconditionally: a browser that had just logged in (session cookie
+        # set, no key in localStorage yet) got 401 on every request, and the
+        # frontend's 401 interceptor bounced it back to /login in an endless
+        # loop. A session is only free when UI auth is disabled — and in that
+        # configuration /auth/bootstrap already hands out the key to any LAN
+        # client by design, so this adds no exposure beyond that.
+        if session.get("ui_authenticated"):
+            return None
+
+        # Same contract for reverse-proxy header auth (Authelia/authentik SSO):
+        # a request vouched for by the trusted proxy must not be rejected for
+        # lacking an X-Api-Key. Fails closed on any misconfiguration.
+        from proxy_auth import request_has_valid_proxy_auth
+
+        if request_has_valid_proxy_auth():
             return None
 
         ip = request.remote_addr or "unknown"

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -124,3 +124,69 @@ def test_ip_allowlist_empty_allows_all():
     with patch("auth.get_settings", return_value=settings_mock), app.test_client() as client:
         resp = client.get("/api/v1/health")
         assert resp.status_code != 403
+
+
+def _protected_app():
+    """Flask app with init_auth and a protected /api/v1 route + session support."""
+    app = Flask(__name__)
+    app.config["SECRET_KEY"] = "test-secret"
+
+    @app.route("/api/v1/protected")
+    def protected():
+        return {"status": "ok"}
+
+    init_auth(app)
+    return app
+
+
+def _settings(api_key="server-key", allowed_ip_ranges=""):
+    settings_mock = MagicMock()
+    settings_mock.api_key = api_key
+    settings_mock.allowed_ip_ranges = allowed_ip_ranges
+    settings_mock.max_login_attempts = 20
+    return settings_mock
+
+
+def test_ui_session_satisfies_api_key_gate():
+    """A logged-in UI session must pass the API gate without an X-Api-Key.
+
+    Regression test for the 1.6.0 login loop: the SPA logs in (session cookie
+    set) but has no key in localStorage yet; every API call got 401 and the
+    frontend's 401 interceptor bounced back to /login forever.
+    """
+    app = _protected_app()
+    with patch("auth.get_settings", return_value=_settings()), app.test_client() as client:
+        with client.session_transaction() as sess:
+            sess["ui_authenticated"] = True
+        resp = client.get("/api/v1/protected")
+        assert resp.status_code == 200
+
+
+def test_no_session_no_key_still_401():
+    """Without a session and without a key the gate must still reject."""
+    app = _protected_app()
+    with patch("auth.get_settings", return_value=_settings()), app.test_client() as client:
+        resp = client.get("/api/v1/protected")
+        assert resp.status_code == 401
+
+
+def test_unauthenticated_session_cookie_does_not_bypass():
+    """A session cookie without the ui_authenticated flag must not pass."""
+    app = _protected_app()
+    with patch("auth.get_settings", return_value=_settings()), app.test_client() as client:
+        with client.session_transaction() as sess:
+            sess["some_other_flag"] = True
+        resp = client.get("/api/v1/protected")
+        assert resp.status_code == 401
+
+
+def test_valid_proxy_auth_satisfies_api_key_gate():
+    """A trusted-proxy-authenticated request must pass without an X-Api-Key."""
+    app = _protected_app()
+    with (
+        patch("auth.get_settings", return_value=_settings()),
+        patch("proxy_auth.request_has_valid_proxy_auth", return_value=True),
+        app.test_client() as client,
+    ):
+        resp = client.get("/api/v1/protected")
+        assert resp.status_code == 200

--- a/frontend/src/api/core.test.ts
+++ b/frontend/src/api/core.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import axios from 'axios'
-import { bootstrapApiKey } from './core'
+import { api, bootstrapApiKey } from './core'
 
 vi.mock('axios', async () => {
   const actual = await vi.importActual<typeof import('axios')>('axios')
@@ -94,5 +94,33 @@ describe('bootstrapApiKey', () => {
 
     expect(axios.post).not.toHaveBeenCalled()
     expect(localStorage.getItem('sublarr_api_key')).toBe('fetched-key')
+  })
+})
+
+describe('401 response interceptor', () => {
+  // The interceptor is registered on the `api` instance at module load;
+  // invoke its rejection handler directly to simulate a failed response.
+  const rejected = (api.interceptors.response as unknown as {
+    handlers: Array<{ rejected: (error: unknown) => Promise<unknown> }>
+  }).handlers[0].rejected
+
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('clears a stale stored key on 401 so the next load re-bootstraps', async () => {
+    localStorage.setItem('sublarr_api_key', 'stale-key')
+    await expect(
+      rejected({ response: { status: 401 }, config: { url: '/wanted' } })
+    ).rejects.toBeTruthy()
+    expect(localStorage.getItem('sublarr_api_key')).toBeNull()
+  })
+
+  it('keeps the stored key on 401 from auth endpoints (wrong password)', async () => {
+    localStorage.setItem('sublarr_api_key', 'valid-key')
+    await expect(
+      rejected({ response: { status: 401 }, config: { url: '/auth/login' } })
+    ).rejects.toBeTruthy()
+    expect(localStorage.getItem('sublarr_api_key')).toBe('valid-key')
   })
 })

--- a/frontend/src/api/core.ts
+++ b/frontend/src/api/core.ts
@@ -103,6 +103,11 @@ api.interceptors.response.use(
     }
 
     if (error.response?.status === 401 && !error.config.url?.includes('/auth/')) {
+      // A 401 despite a stored key means the key is stale (e.g. the backend
+      // regenerated it). Drop it so bootstrapApiKey() fetches a fresh one on
+      // the reload — otherwise its early-return keeps re-sending the dead key
+      // and the app loops between /login and the dashboard forever.
+      localStorage.removeItem('sublarr_api_key')
       window.location.href = '/login'
     }
     return Promise.reject(error)


### PR DESCRIPTION
The check_api_key before_request hook enforced X-Api-Key unconditionally,
although ui_auth.py's documented contract is "API routes accept either a
valid UI session OR an X-Api-Key header". Since the API key is
auto-generated on first start, every remote browser depends on the
localStorage key fetched via /auth/bootstrap — which is only handed out
AFTER a session exists. A fresh browser (or one holding a stale key after
the server-side key changed) therefore logged in successfully (200 +
session cookie, /auth/status authenticated:true) but got 401 on every
subsequent API call, and the axios 401 interceptor hard-redirected back
to /login in an endless loop, with the dashboard flashing briefly.

- backend: an authenticated UI session (and a valid trusted-proxy SSO
  request) now satisfies the API-key gate. No new exposure: a session is
  only obtainable without a password when UI auth is disabled, and in
  that configuration /auth/bootstrap already hands the key to any LAN
  client by design.
- frontend: the 401 interceptor drops a stored (stale) API key before
  redirecting, so the next page load re-bootstraps a fresh key instead
  of re-sending the dead one forever.

Reported via Discord #bug-report against 1.6.0 (login loop in Firefox).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019fmiZCQqzkK27y7vJPP8Ym