### PR TITLE
feat(scoring): global release-group tier ranking

### DIFF
--- a/backend/config_settings.py
+++ b/backend/config_settings.py
@@ -67,6 +67,7 @@ _ALLOWED_BOOT_FIELDS: frozenset[str] = frozenset(
         "log_format",
         "cors_origins",
         "redis_url",
+        "stats_endpoint",
     }
 )
 

--- a/backend/providers/plugins/template/README.md
+++ b/backend/providers/plugins/template/README.md
@@ -78,11 +78,11 @@ Each config field is a dict with these keys:
 
 ```python
 {
-    "key": "api_key",          # Internal key, passed as kwarg to __init__
-    "label": "API Key",        # Human-readable label in the Settings UI
-    "type": "password",        # "text", "password", or "number"
-    "required": True,          # If True, provider needs this to function
-    "default": "",             # Default value (optional)
+    "key": "api_key",  # Internal key, passed as kwarg to __init__
+    "label": "API Key",  # Human-readable label in the Settings UI
+    "type": "password",  # "text", "password", or "number"
+    "required": True,  # If True, provider needs this to function
+    "default": "",  # Default value (optional)
 }
 ```
 
@@ -93,8 +93,20 @@ Config values are stored in the database under `plugin.<name>.<key>` namespace. 
 ```python
 config_fields = [
     {"key": "api_key", "label": "API Key", "type": "password", "required": True},
-    {"key": "base_url", "label": "Base URL", "type": "text", "required": False, "default": "https://api.example.com"},
-    {"key": "results_per_page", "label": "Results Per Page", "type": "number", "required": False, "default": "50"},
+    {
+        "key": "base_url",
+        "label": "Base URL",
+        "type": "text",
+        "required": False,
+        "default": "https://api.example.com",
+    },
+    {
+        "key": "results_per_page",
+        "label": "Results Per Page",
+        "type": "number",
+        "required": False,
+        "default": "50",
+    },
 ]
 ```
 
@@ -201,9 +213,9 @@ result.matches = {"series", "season", "episode"}
 Set `rate_limit = (max_requests, window_seconds)` on your class. The `ProviderManager` enforces this limit across all search and download calls. Example:
 
 ```python
-rate_limit = (5, 1)    # 5 requests per second (OpenSubtitles-style)
-rate_limit = (100, 60) # 100 requests per minute
-rate_limit = (0, 0)    # No rate limiting
+rate_limit = (5, 1)  # 5 requests per second (OpenSubtitles-style)
+rate_limit = (100, 60)  # 100 requests per minute
+rate_limit = (0, 0)  # No rate limiting
 ```
 
 The `RetryingSession` from `create_session()` also handles HTTP 429 responses automatically (reads `Retry-After` header).
@@ -220,10 +232,10 @@ Sublarr provides three specialized exceptions in `providers.base`:
 
 ```python
 from providers.base import (
-    ProviderAuthError,       # 401/403 -- authentication failed
+    ProviderAuthError,  # 401/403 -- authentication failed
     ProviderRateLimitError,  # 429 -- rate limit exceeded
-    ProviderTimeoutError,    # Request timed out
-    ProviderError,           # Generic provider error (base class)
+    ProviderTimeoutError,  # Request timed out
+    ProviderError,  # Generic provider error (base class)
 )
 ```
 
@@ -252,10 +264,11 @@ Use `create_session()` from `providers.http_session` for HTTP calls:
 ```python
 from providers.http_session import create_session
 
+
 def initialize(self):
     self.session = create_session(
-        max_retries=self.max_retries,   # From class attribute
-        timeout=self.timeout,           # From class attribute
+        max_retries=self.max_retries,  # From class attribute
+        timeout=self.timeout,  # From class attribute
         user_agent="Sublarr-Plugin/1.0",
     )
     # Set authentication headers
@@ -276,17 +289,18 @@ The session provides:
 import zipfile
 import io
 
+
 def download(self, result):
     resp = self.session.get(result.download_url)
     resp.raise_for_status()
     content = resp.content
 
-    if content[:4] == b'PK\x03\x04':  # ZIP magic bytes
+    if content[:4] == b"PK\x03\x04":  # ZIP magic bytes
         with zipfile.ZipFile(io.BytesIO(content)) as zf:
             for name in zf.namelist():
-                if name.endswith(('.srt', '.ass', '.ssa')):
+                if name.endswith((".srt", ".ass", ".ssa")):
                     content = zf.read(name)
-                    if name.endswith(('.ass', '.ssa')):
+                    if name.endswith((".ass", ".ssa")):
                         result.format = SubtitleFormat.ASS
                     break
 
@@ -299,12 +313,13 @@ def download(self, result):
 ```python
 import lzma
 
+
 def download(self, result):
     resp = self.session.get(result.download_url)
     resp.raise_for_status()
     content = resp.content
 
-    if content[:6] == b'\xfd7zXZ\x00':  # XZ magic bytes
+    if content[:6] == b"\xfd7zXZ\x00":  # XZ magic bytes
         content = lzma.decompress(content)
 
     result.content = content
@@ -317,15 +332,16 @@ def download(self, result):
 import rarfile
 import io
 
+
 def download(self, result):
     resp = self.session.get(result.download_url)
     resp.raise_for_status()
     content = resp.content
 
-    if content[:4] == b'Rar!':  # RAR magic bytes
+    if content[:4] == b"Rar!":  # RAR magic bytes
         with rarfile.RarFile(io.BytesIO(content)) as rf:
             for name in rf.namelist():
-                if name.endswith(('.srt', '.ass', '.ssa')):
+                if name.endswith((".srt", ".ass", ".ssa")):
                     content = rf.read(name)
                     break
 
@@ -342,6 +358,7 @@ def search(self, query):
     elif query.is_movie:
         return self._search_movie(query)
     return []
+
 
 def _search_episode(self, query):
     params = {

--- a/backend/routes/hooks/scoring.py
+++ b/backend/routes/hooks/scoring.py
@@ -491,3 +491,87 @@ def update_penalty_rule(rule_id):
     invalidate_scoring_cache()
     invalidate_response_cache()
     return jsonify({"rule_id": rule_id, "weight": weight})
+
+
+# ---- Release-group tier endpoints --------------------------------------------
+
+
+@bp.route("/scoring/release-group-tiers", methods=["GET"])
+def get_release_group_tiers():
+    """Return the global release-group tier ranking.
+    ---
+    get:
+      security:
+        - apiKeyAuth: []
+      tags:
+        - Events
+      summary: Get release-group tiers
+      description: >-
+        Returns the ordered global release-group tier list (best first) and
+        the per-tier step weight. A result matching the group at index ``i``
+        of ``N`` tiers earns ``step * (N - i)`` bonus points in wanted-search
+        scoring.
+      responses:
+        200:
+          description: Tier configuration
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  tiers:
+                    type: array
+                    items: { type: string }
+                  step:
+                    type: integer
+    """
+    from services.release_group_tiers import get_tier_config
+
+    return jsonify(get_tier_config())
+
+
+@bp.route("/scoring/release-group-tiers", methods=["PUT"])
+def update_release_group_tiers():
+    """Replace the global release-group tier ranking.
+    ---
+    put:
+      security:
+        - apiKeyAuth: []
+      tags:
+        - Events
+      summary: Update release-group tiers
+      description: >-
+        Replaces the ordered tier list and per-tier step weight. Entries are
+        trimmed, empties dropped, and duplicates removed case-insensitively
+        (first occurrence wins). An empty list disables tier scoring.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                tiers:
+                  type: array
+                  items: { type: string }
+                step:
+                  type: integer
+      responses:
+        200:
+          description: Stored tier configuration
+        400:
+          description: Invalid tiers or step
+    """
+    from services.release_group_tiers import DEFAULT_STEP, set_tier_config
+
+    data = request.get_json(silent=True) or {}
+    try:
+        step = data.get("step", DEFAULT_STEP)
+        if isinstance(step, str) and step.strip().lstrip("-").isdigit():
+            step = int(step)
+        config = set_tier_config(data.get("tiers", []), step)
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
+
+    invalidate_response_cache()
+    return jsonify(config)

--- a/backend/services/release_group_tiers.py
+++ b/backend/services/release_group_tiers.py
@@ -1,0 +1,95 @@
+"""Global release-group tier ranking for subtitle result scoring.
+
+Stores an ordered list of release/fansub group names plus a per-tier step
+weight as a JSON config entry (``release_group_tiers_json``). Higher-ranked
+groups (lower list index) receive a larger score bonus during wanted-search
+scoring: position ``i`` in a list of ``N`` groups earns ``step * (N - i)``
+points, so the top group gets ``N * step`` and the last group gets ``step``.
+
+Per-series fansub preferences (``fansub_preferences`` table) stack on top of
+the global tiers; an excluded group's -999 always dominates any tier bonus.
+"""
+
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+CONFIG_KEY = "release_group_tiers_json"
+
+DEFAULT_STEP = 10
+MAX_TIERS = 100
+MAX_GROUP_NAME_LEN = 100
+MIN_STEP = 1
+MAX_STEP = 500
+
+
+def _sanitize_tiers(tiers: list) -> list[str]:
+    """Strip entries, drop empties, and dedupe case-insensitively (keep order).
+
+    An empty string would substring-match every release_info and grant the
+    top-tier bonus to all results — same guard as fansub preferences.
+    """
+    seen: set[str] = set()
+    clean: list[str] = []
+    for entry in tiers:
+        if not isinstance(entry, str):
+            continue
+        name = entry.strip()
+        if not name:
+            continue
+        key = name.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        clean.append(name)
+    return clean
+
+
+def get_tier_config() -> dict:
+    """Return ``{"tiers": [group, ...], "step": int}`` (defaults if unset/corrupt)."""
+    from db.config import get_config_entry
+
+    raw = None
+    try:
+        raw = get_config_entry(CONFIG_KEY)
+    except Exception:
+        logger.debug("get_tier_config: config read failed", exc_info=True)
+    if not raw:
+        return {"tiers": [], "step": DEFAULT_STEP}
+    try:
+        data = json.loads(raw)
+        tiers = _sanitize_tiers(data.get("tiers", []))[:MAX_TIERS]
+        step = int(data.get("step", DEFAULT_STEP))
+        step = max(MIN_STEP, min(MAX_STEP, step))
+        return {"tiers": tiers, "step": step}
+    except (ValueError, TypeError, AttributeError):
+        logger.warning("Corrupt %s config entry ignored", CONFIG_KEY)
+        return {"tiers": [], "step": DEFAULT_STEP}
+
+
+def set_tier_config(tiers: list, step: int) -> dict:
+    """Validate and persist the tier list. Returns the stored config.
+
+    Raises ``ValueError`` on invalid input (non-string entries, too many
+    tiers, over-long names, step out of range).
+    """
+    if not isinstance(tiers, list) or not all(isinstance(g, str) for g in tiers):
+        raise ValueError("tiers must be a list of strings")
+    if not isinstance(step, int) or isinstance(step, bool):
+        raise ValueError("step must be an integer")
+    if not (MIN_STEP <= step <= MAX_STEP):
+        raise ValueError(f"step must be between {MIN_STEP} and {MAX_STEP}")
+
+    clean = _sanitize_tiers(tiers)
+    if len(clean) > MAX_TIERS:
+        raise ValueError(f"at most {MAX_TIERS} tiers allowed")
+    for name in clean:
+        if len(name) > MAX_GROUP_NAME_LEN:
+            raise ValueError(f"group name too long (max {MAX_GROUP_NAME_LEN} chars): {name[:40]}")
+
+    from db.config import save_config_entry
+
+    config = {"tiers": clean, "step": step}
+    save_config_entry(CONFIG_KEY, json.dumps(config))
+    return config

--- a/backend/tests/test_release_group_tiers.py
+++ b/backend/tests/test_release_group_tiers.py
@@ -1,0 +1,159 @@
+"""Tests for the global release-group tier ranking (scoring + service + API)."""
+
+import pytest
+
+from wanted_search.scoring import _apply_fansub_rules, _apply_release_group_tiers
+
+
+def _results(*release_infos):
+    return [{"release_info": info, "score": 100} for info in release_infos]
+
+
+class TestApplyReleaseGroupTiers:
+    def test_top_tier_earns_more_than_lower_tier(self):
+        results = _results("[Erai-raws] Show - 01", "[SubsPlease] Show - 01")
+        _apply_release_group_tiers(results, ["Erai-raws", "SubsPlease"], step=10)
+        assert results[0]["score"] == 120  # step * (2 - 0)
+        assert results[1]["score"] == 110  # step * (2 - 1)
+
+    def test_last_tier_still_earns_step(self):
+        results = _results("[Judas] Show - 01")
+        _apply_release_group_tiers(results, ["Erai-raws", "SubsPlease", "Judas"], step=10)
+        assert results[0]["score"] == 110
+
+    def test_no_match_leaves_score_unchanged(self):
+        results = _results("[SomeOtherGroup] Show - 01")
+        _apply_release_group_tiers(results, ["Erai-raws"], step=10)
+        assert results[0]["score"] == 100
+
+    def test_match_is_case_insensitive(self):
+        results = _results("[erai-RAWS] Show - 01")
+        _apply_release_group_tiers(results, ["Erai-Raws"], step=10)
+        assert results[0]["score"] == 110
+
+    def test_only_best_matching_tier_counts(self):
+        # release_info mentions both groups — only the higher tier applies
+        results = _results("[Erai-raws] Show (SubsPlease remux)")
+        _apply_release_group_tiers(results, ["Erai-raws", "SubsPlease"], step=10)
+        assert results[0]["score"] == 120
+
+    def test_empty_and_whitespace_entries_are_dropped(self):
+        results = _results("[NoMatchGroup] Show - 01")
+        _apply_release_group_tiers(results, ["", "  ", "Erai-raws"], step=10)
+        # "Erai-raws" is the only real tier (n=1) and it doesn't match
+        assert results[0]["score"] == 100
+
+    def test_empty_tier_list_is_noop(self):
+        results = _results("[Erai-raws] Show - 01")
+        _apply_release_group_tiers(results, [], step=10)
+        assert results[0]["score"] == 100
+
+    def test_zero_step_is_noop(self):
+        results = _results("[Erai-raws] Show - 01")
+        _apply_release_group_tiers(results, ["Erai-raws"], step=0)
+        assert results[0]["score"] == 100
+
+    def test_missing_release_info_key(self):
+        results = [{"score": 100}]
+        _apply_release_group_tiers(results, ["Erai-raws"], step=10)
+        assert results[0]["score"] == 100
+
+    def test_fansub_exclusion_dominates_tier_bonus(self):
+        results = _results("[Erai-raws] Show - 01")
+        _apply_release_group_tiers(results, ["Erai-raws"], step=10)
+        _apply_fansub_rules(results, preferred=[], excluded=["Erai-raws"], bonus=20)
+        assert results[0]["score"] < 0
+
+
+class TestTierConfigService:
+    def test_get_defaults_when_unset(self, app_ctx):
+        from services.release_group_tiers import DEFAULT_STEP, get_tier_config
+
+        config = get_tier_config()
+        assert config == {"tiers": [], "step": DEFAULT_STEP}
+
+    def test_set_and_get_roundtrip(self, app_ctx):
+        from services.release_group_tiers import get_tier_config, set_tier_config
+
+        set_tier_config(["Erai-raws", "SubsPlease"], step=15)
+        config = get_tier_config()
+        assert config["tiers"] == ["Erai-raws", "SubsPlease"]
+        assert config["step"] == 15
+
+    def test_set_sanitizes_and_dedupes(self, app_ctx):
+        from services.release_group_tiers import set_tier_config
+
+        config = set_tier_config([" Erai-raws ", "", "erai-RAWS", "Judas"], step=10)
+        assert config["tiers"] == ["Erai-raws", "Judas"]
+
+    def test_set_rejects_non_string_entries(self, app_ctx):
+        from services.release_group_tiers import set_tier_config
+
+        with pytest.raises(ValueError):
+            set_tier_config(["ok", 42], step=10)
+
+    def test_set_rejects_step_out_of_range(self, app_ctx):
+        from services.release_group_tiers import set_tier_config
+
+        with pytest.raises(ValueError):
+            set_tier_config(["Erai-raws"], step=0)
+        with pytest.raises(ValueError):
+            set_tier_config(["Erai-raws"], step=501)
+
+    def test_set_rejects_overlong_group_name(self, app_ctx):
+        from services.release_group_tiers import set_tier_config
+
+        with pytest.raises(ValueError):
+            set_tier_config(["x" * 101], step=10)
+
+    def test_get_survives_corrupt_config(self, app_ctx):
+        from db.config import save_config_entry
+        from services.release_group_tiers import CONFIG_KEY, DEFAULT_STEP, get_tier_config
+
+        save_config_entry(CONFIG_KEY, "not json {")
+        assert get_tier_config() == {"tiers": [], "step": DEFAULT_STEP}
+
+
+class TestTierRoutes:
+    def test_get_returns_defaults(self, client):
+        r = client.get("/api/v1/scoring/release-group-tiers")
+        assert r.status_code == 200
+        data = r.get_json()
+        assert data["tiers"] == []
+        assert isinstance(data["step"], int)
+
+    def test_put_then_get_roundtrip(self, client):
+        r = client.put(
+            "/api/v1/scoring/release-group-tiers",
+            json={"tiers": ["Erai-raws", "SubsPlease", "Judas"], "step": 12},
+        )
+        assert r.status_code == 200
+        assert r.get_json()["tiers"] == ["Erai-raws", "SubsPlease", "Judas"]
+
+        r = client.get("/api/v1/scoring/release-group-tiers")
+        assert r.get_json() == {"tiers": ["Erai-raws", "SubsPlease", "Judas"], "step": 12}
+
+    def test_put_empty_list_disables_tiers(self, client):
+        client.put(
+            "/api/v1/scoring/release-group-tiers",
+            json={"tiers": ["Erai-raws"], "step": 10},
+        )
+        r = client.put("/api/v1/scoring/release-group-tiers", json={"tiers": [], "step": 10})
+        assert r.status_code == 200
+        assert r.get_json()["tiers"] == []
+
+    def test_put_rejects_bad_payload(self, client):
+        r = client.put("/api/v1/scoring/release-group-tiers", json={"tiers": "Erai-raws"})
+        assert r.status_code == 400
+        r = client.put(
+            "/api/v1/scoring/release-group-tiers",
+            json={"tiers": ["Erai-raws"], "step": "abc"},
+        )
+        assert r.status_code == 400
+
+    def test_put_defaults_step_when_omitted(self, client):
+        from services.release_group_tiers import DEFAULT_STEP
+
+        r = client.put("/api/v1/scoring/release-group-tiers", json={"tiers": ["Erai-raws"]})
+        assert r.status_code == 200
+        assert r.get_json()["step"] == DEFAULT_STEP

--- a/backend/tests/test_scheduler_listeners.py
+++ b/backend/tests/test_scheduler_listeners.py
@@ -129,8 +129,12 @@ def test_listener_error_does_not_crash_scheduler(scheduler, caplog):
         scheduled_run_time=datetime.now(UTC),
     )
     with (
+        # Patch the module-global the listener closure actually references —
+        # services.scheduler.core imports _write_job_run at module top, so
+        # patching the package re-export (services.scheduler._write_job_run)
+        # would leave the listener on the real function.
         patch(
-            "services.scheduler._write_job_run",
+            "services.scheduler.core._write_job_run",
             side_effect=RuntimeError("db down"),
         ),
         caplog.at_level(logging.ERROR, logger="services.scheduler"),

--- a/backend/tools/lint_no_new_env_fields.py
+++ b/backend/tools/lint_no_new_env_fields.py
@@ -156,7 +156,7 @@ def main(argv: list[str]) -> int:
     for msg in violations:
         print(f"  - {msg}")
     print()
-    print("UI-first convention (since v0.88.0-beta): only the 11 fields in")
+    print("UI-first convention (since v0.88.0-beta): only the fields in")
     print("_ALLOWED_BOOT_FIELDS are env-loadable. Everything else is UI-only.")
     return 1
 

--- a/backend/wanted_search/scoring.py
+++ b/backend/wanted_search/scoring.py
@@ -45,6 +45,32 @@ def _apply_fansub_rules(
             result["score"] += bonus
 
 
+def _apply_release_group_tiers(results: list[dict], tiers: list[str], step: int) -> None:
+    """Adjust scores in-place based on the global release-group tier ranking.
+
+    ``tiers`` is an ordered list (best first). A result matching the group at
+    index ``i`` (case-insensitive substring on release_info) gets
+    ``step * (len(tiers) - i)`` bonus points — the top tier earns the most,
+    the last tier still earns ``step``. Only the best (lowest-index) matching
+    tier counts per result.
+
+    Empty/whitespace entries are dropped for the same reason as in
+    ``_apply_fansub_rules``: ``"" in info`` is always True and would grant
+    the bonus to every candidate.
+    """
+    tiers_lower = [g.strip().lower() for g in tiers if g and g.strip()]
+    if not tiers_lower or step <= 0:
+        return
+
+    n = len(tiers_lower)
+    for result in results:
+        info = result.get("release_info", "").lower()
+        for idx, group in enumerate(tiers_lower):
+            if group in info:
+                result["score"] += step * (n - idx)
+                break
+
+
 # Codec family aliases — result release_info uses various spellings
 _CODEC_ALIASES: dict[str, list[str]] = {
     "x265": ["x265", "hevc", "h265"],

--- a/backend/wanted_search/search.py
+++ b/backend/wanted_search/search.py
@@ -8,7 +8,11 @@ from db.wanted import get_wanted_item, update_wanted_search
 from providers import get_provider_manager
 from providers.base import SubtitleFormat
 from wanted_search.metadata import build_query_from_wanted
-from wanted_search.scoring import _apply_fansub_rules, _get_priority_key
+from wanted_search.scoring import (
+    _apply_fansub_rules,
+    _apply_release_group_tiers,
+    _get_priority_key,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -146,6 +150,22 @@ def search_wanted_item(item_id: int) -> dict:
             seen.add(key)
             deduped.append(r)
     all_results = deduped
+
+    # Apply the global release-group tier ranking (best-first ordered list;
+    # higher tiers earn a larger bonus). Per-series fansub preferences below
+    # stack on top; an excluded group's -999 dominates any tier bonus.
+    try:
+        from services.release_group_tiers import get_tier_config
+
+        tier_config = get_tier_config()
+        if tier_config["tiers"]:
+            _apply_release_group_tiers(
+                all_results,
+                tiers=tier_config["tiers"],
+                step=tier_config["step"],
+            )
+    except Exception as e:
+        logger.warning("Release-group tier scoring failed for wanted %d: %s", item_id, e)
 
     # Apply per-series fansub group preferences
     series_id = item.get("sonarr_series_id")

--- a/frontend/src/api/settings.ts
+++ b/frontend/src/api/settings.ts
@@ -113,6 +113,19 @@ export const getPenaltyRules = (): Promise<{ rules: PenaltyRule[] }> =>
 export const updatePenaltyRule = (rule_id: string, weight: number): Promise<{ rule_id: string; weight: number }> =>
   api.put(`/scoring/penalty-rules/${encodeURIComponent(rule_id)}`, { weight }).then(r => r.data)
 
+// ─── Release-group tiers ────────────────────────────────────────────────────
+
+export interface ReleaseGroupTiers {
+  tiers: string[]
+  step: number
+}
+
+export const getReleaseGroupTiers = (): Promise<ReleaseGroupTiers> =>
+  api.get('/scoring/release-group-tiers').then(r => r.data)
+
+export const updateReleaseGroupTiers = (data: ReleaseGroupTiers): Promise<ReleaseGroupTiers> =>
+  api.put('/scoring/release-group-tiers', data).then(r => r.data)
+
 // ─── Media Servers ──────────────────────────────────────────────────────────
 
 export async function getMediaServerTypes(): Promise<MediaServerType[]> {

--- a/frontend/src/hooks/useProvidersApi.ts
+++ b/frontend/src/hooks/useProvidersApi.ts
@@ -5,6 +5,7 @@ import {
   getProviderModifiers, updateProviderModifiers,
   getScoringPresets, importScoringPreset,
   getPenaltyRules, updatePenaltyRule,
+  getReleaseGroupTiers, updateReleaseGroupTiers,
   getBlacklist, addToBlacklist, removeFromBlacklist, clearBlacklist,
   getLanguageProfiles, createLanguageProfile, updateLanguageProfile,
   deleteLanguageProfile, assignProfile, bulkAssignProfile, setProfileAsDefaultForAll,
@@ -120,6 +121,20 @@ export function useUpdatePenaltyRule() {
     mutationFn: ({ ruleId, weight }: { ruleId: string; weight: number }) =>
       updatePenaltyRule(ruleId, weight),
     onSuccess: () => { void qc.invalidateQueries({ queryKey: ['penaltyRules'] }) },
+  })
+}
+
+// ─── Release-group tiers ─────────────────────────────────────────────────────
+
+export function useReleaseGroupTiers() {
+  return useQuery({ queryKey: ['releaseGroupTiers'], queryFn: getReleaseGroupTiers })
+}
+
+export function useUpdateReleaseGroupTiers() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: updateReleaseGroupTiers,
+    onSuccess: () => { void qc.invalidateQueries({ queryKey: ['releaseGroupTiers'] }) },
   })
 }
 

--- a/frontend/src/i18n/locales/de/settings.json
+++ b/frontend/src/i18n/locales/de/settings.json
@@ -2180,6 +2180,23 @@
     "default_short": "Std.: {{value}}",
     "save": "Speichern"
   },
+  "scoring_tiers": {
+    "title": "Release-Gruppen-Rangliste",
+    "loading": "Rangliste wird geladen...",
+    "section_desc": "Globale geordnete Rangliste von Release-/Fansub-Gruppen (beste zuerst). Ein Treffer auf Rang i von N erhält Schrittweite × (N − i) Bonuspunkte — höher platzierte Gruppen gewinnen bei Gleichstand. Serien-spezifische Fansub-Einstellungen wirken zusätzlich.",
+    "empty": "Keine Ränge konfiguriert. Füge unten Gruppen hinzu — z. B. Erai-raws, SubsPlease, Judas.",
+    "add_placeholder": "Gruppenname (z. B. Erai-raws)",
+    "add": "Hinzufügen",
+    "move_up": "Nach oben",
+    "move_down": "Nach unten",
+    "remove": "Entfernen",
+    "step_label": "Punkte pro Rangstufe",
+    "step_hint": "Bonus-Differenz zwischen benachbarten Rängen. Der letzte Rang erhält genau diese Punktzahl.",
+    "save": "Speichern",
+    "toast_saved": "Release-Gruppen-Rangliste gespeichert",
+    "toast_save_failed": "Rangliste konnte nicht gespeichert werden",
+    "toast_duplicate": "„{{name}}“ ist bereits in der Liste"
+  },
   "glossary_panel": {
     "toast_setting_saved": "Glossar-Einstellung gespeichert",
     "toast_save_failed": "Speichern der Einstellung fehlgeschlagen",

--- a/frontend/src/i18n/locales/en/settings.json
+++ b/frontend/src/i18n/locales/en/settings.json
@@ -2180,6 +2180,23 @@
     "default_short": "def: {{value}}",
     "save": "Save"
   },
+  "scoring_tiers": {
+    "title": "Release Group Tiers",
+    "loading": "Loading tiers...",
+    "section_desc": "Global ordered ranking of release/fansub groups (best first). A result matching tier i of N earns step × (N − i) bonus points, so higher-ranked groups win ties. Per-series fansub preferences stack on top.",
+    "empty": "No tiers configured. Add groups below — e.g. Erai-raws, SubsPlease, Judas.",
+    "add_placeholder": "Group name (e.g. Erai-raws)",
+    "add": "Add",
+    "move_up": "Move up",
+    "move_down": "Move down",
+    "remove": "Remove",
+    "step_label": "Points per tier step",
+    "step_hint": "Bonus difference between adjacent tiers. The lowest tier earns exactly this many points.",
+    "save": "Save",
+    "toast_saved": "Release group tiers saved",
+    "toast_save_failed": "Failed to save release group tiers",
+    "toast_duplicate": "\"{{name}}\" is already in the list"
+  },
   "glossary_panel": {
     "toast_setting_saved": "Glossary setting saved",
     "toast_save_failed": "Failed to save setting",

--- a/frontend/src/pages/Settings/ScoringReleaseGroupTiers.tsx
+++ b/frontend/src/pages/Settings/ScoringReleaseGroupTiers.tsx
@@ -1,0 +1,229 @@
+/**
+ * ScoringReleaseGroupTiers — global release-group tier ranking.
+ *
+ * Ordered list of release/fansub groups (best first). During wanted-search
+ * scoring, a result matching the group at position i of N tiers earns
+ * step * (N - i) bonus points, so higher-ranked groups win ties.
+ */
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { ArrowDown, ArrowUp, Loader2, Plus, Save, X } from 'lucide-react'
+
+import { FormGroup } from '@/components/settings/FormGroup'
+import { SettingsSection } from '@/components/settings/SettingsSection'
+import { toast } from '@/components/shared/Toast'
+import { useReleaseGroupTiers, useUpdateReleaseGroupTiers } from '@/hooks/useApi'
+import { settingsInputStyle } from '@/styles/settingsShared'
+
+const inputStyle: React.CSSProperties = { ...settingsInputStyle, outline: 'none' }
+
+const iconBtnStyle: React.CSSProperties = {
+  display: 'flex', alignItems: 'center', justifyContent: 'center',
+  width: 24, height: 24, borderRadius: 5,
+  background: 'var(--bg-surface)', border: '1px solid var(--border)',
+  color: 'var(--text-muted)', cursor: 'pointer', padding: 0,
+}
+
+export function ScoringReleaseGroupTiers() {
+  const { t: tc } = useTranslation('common')
+  const { data, isLoading } = useReleaseGroupTiers()
+  const updateTiers = useUpdateReleaseGroupTiers()
+
+  const [tiers, setTiers] = useState<string[]>([])
+  const [step, setStep] = useState(10)
+  const [newGroup, setNewGroup] = useState('')
+  const [init, setInit] = useState(false)
+
+  useEffect(() => {
+    if (data && !init) {
+      setTiers(data.tiers)
+      setStep(data.step)
+      setInit(true)
+    }
+  }, [data, init])
+
+  if (isLoading) {
+    return (
+      <SettingsSection
+        title={tc('settings:scoring_tiers.title')}
+        description={tc('settings:scoring_tiers.loading')}
+      >
+        <Loader2 size={14} className="animate-spin" />
+      </SettingsSection>
+    )
+  }
+
+  const isDirty =
+    init && (step !== (data?.step ?? 10) || JSON.stringify(tiers) !== JSON.stringify(data?.tiers ?? []))
+
+  const addGroup = () => {
+    const name = newGroup.trim()
+    if (!name) return
+    if (tiers.some(g => g.toLowerCase() === name.toLowerCase())) {
+      toast(tc('settings:scoring_tiers.toast_duplicate', { name }), 'error')
+      return
+    }
+    setTiers(t => [...t, name])
+    setNewGroup('')
+  }
+
+  const move = (idx: number, dir: -1 | 1) => {
+    setTiers(t => {
+      const next = [...t]
+      const swap = idx + dir
+      if (swap < 0 || swap >= next.length) return t
+      ;[next[idx], next[swap]] = [next[swap], next[idx]]
+      return next
+    })
+  }
+
+  const handleSave = () => {
+    updateTiers.mutate(
+      { tiers, step },
+      {
+        onSuccess: (saved) => {
+          setTiers(saved.tiers)
+          setStep(saved.step)
+          toast(tc('settings:scoring_tiers.toast_saved'))
+        },
+        onError: () => toast(tc('settings:scoring_tiers.toast_save_failed'), 'error'),
+      },
+    )
+  }
+
+  const n = tiers.length
+
+  return (
+    <SettingsSection
+      title={tc('settings:scoring_tiers.title')}
+      description={tc('settings:scoring_tiers.section_desc')}
+    >
+      {tiers.length === 0 && (
+        <p style={{ fontSize: 12, color: 'var(--text-muted)', padding: '8px 0' }}>
+          {tc('settings:scoring_tiers.empty')}
+        </p>
+      )}
+
+      {tiers.map((group, idx) => (
+        <div
+          key={group.toLowerCase()}
+          data-testid={`tier-row-${idx}`}
+          style={{
+            display: 'flex', alignItems: 'center', gap: 8,
+            padding: '6px 0', borderBottom: '1px solid var(--border)',
+          }}
+        >
+          <span
+            style={{
+              width: 26, textAlign: 'right', fontSize: 11,
+              color: 'var(--text-muted)', fontFamily: 'var(--font-mono, monospace)',
+            }}
+          >
+            {idx + 1}.
+          </span>
+          <span style={{ flex: 1, fontSize: 13 }}>{group}</span>
+          <span
+            style={{
+              fontSize: 11, color: 'var(--success)',
+              fontFamily: 'var(--font-mono, monospace)', whiteSpace: 'nowrap',
+            }}
+          >
+            +{step * (n - idx)}
+          </span>
+          <button
+            aria-label={tc('settings:scoring_tiers.move_up')}
+            data-testid={`tier-up-${idx}`}
+            disabled={idx === 0}
+            onClick={() => move(idx, -1)}
+            style={{ ...iconBtnStyle, opacity: idx === 0 ? 0.35 : 1 }}
+          >
+            <ArrowUp size={12} />
+          </button>
+          <button
+            aria-label={tc('settings:scoring_tiers.move_down')}
+            data-testid={`tier-down-${idx}`}
+            disabled={idx === n - 1}
+            onClick={() => move(idx, 1)}
+            style={{ ...iconBtnStyle, opacity: idx === n - 1 ? 0.35 : 1 }}
+          >
+            <ArrowDown size={12} />
+          </button>
+          <button
+            aria-label={tc('settings:scoring_tiers.remove')}
+            data-testid={`tier-remove-${idx}`}
+            onClick={() => setTiers(t => t.filter((_, i) => i !== idx))}
+            style={{ ...iconBtnStyle, color: 'var(--error)' }}
+          >
+            <X size={12} />
+          </button>
+        </div>
+      ))}
+
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 10 }}>
+        <input
+          type="text"
+          value={newGroup}
+          data-testid="input-tier-add"
+          placeholder={tc('settings:scoring_tiers.add_placeholder')}
+          maxLength={100}
+          onChange={(e) => setNewGroup(e.target.value)}
+          onKeyDown={(e) => { if (e.key === 'Enter') addGroup() }}
+          style={{ ...inputStyle, flex: 1 }}
+        />
+        <button
+          data-testid="btn-tier-add"
+          onClick={addGroup}
+          disabled={!newGroup.trim()}
+          style={{
+            display: 'flex', alignItems: 'center', gap: 4,
+            padding: '4px 10px', borderRadius: 6, fontSize: 11, fontWeight: 500,
+            background: 'var(--bg-surface)', border: '1px solid var(--border)',
+            color: 'var(--text)', cursor: newGroup.trim() ? 'pointer' : 'default',
+            opacity: newGroup.trim() ? 1 : 0.5,
+          }}
+        >
+          <Plus size={11} />
+          {tc('settings:scoring_tiers.add')}
+        </button>
+      </div>
+
+      <FormGroup
+        label={tc('settings:scoring_tiers.step_label')}
+        hint={tc('settings:scoring_tiers.step_hint')}
+        data-testid="form-group-tier-step"
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <input
+            type="number"
+            min={1}
+            max={500}
+            value={step}
+            data-testid="input-tier-step"
+            onChange={(e) => {
+              const v = parseInt(e.target.value, 10)
+              if (!isNaN(v)) setStep(Math.max(1, Math.min(500, v)))
+            }}
+            style={{ ...inputStyle, width: 72, textAlign: 'right', fontFamily: 'var(--font-mono, monospace)' }}
+          />
+          <button
+            disabled={!isDirty || updateTiers.isPending}
+            data-testid="btn-save-tiers"
+            onClick={handleSave}
+            style={{
+              display: 'flex', alignItems: 'center', gap: 4,
+              padding: '4px 10px', borderRadius: 6, fontSize: 11, fontWeight: 500,
+              background: isDirty ? 'var(--accent)' : 'var(--bg-surface)',
+              color: isDirty ? '#fff' : 'var(--text-muted)',
+              border: isDirty ? 'none' : '1px solid var(--border)',
+              cursor: isDirty ? 'pointer' : 'default',
+              opacity: updateTiers.isPending ? 0.6 : 1,
+            }}
+          >
+            {updateTiers.isPending ? <Loader2 size={11} className="animate-spin" /> : <Save size={11} />}
+            {tc('settings:scoring_tiers.save')}
+          </button>
+        </div>
+      </FormGroup>
+    </SettingsSection>
+  )
+}

--- a/frontend/src/pages/Settings/ScoringTab.tsx
+++ b/frontend/src/pages/Settings/ScoringTab.tsx
@@ -24,6 +24,7 @@ import { toast } from '@/components/shared/Toast'
 import type { ScoringWeights, ScoringPreset } from '@/lib/types'
 import { settingsInputStyle } from '@/styles/settingsShared'
 import { ScoringPenaltyRules } from './ScoringPenaltyRules'
+import { ScoringReleaseGroupTiers } from './ScoringReleaseGroupTiers'
 
 const inputStyle: React.CSSProperties = { ...settingsInputStyle, outline: 'none' }
 
@@ -440,6 +441,9 @@ export function ScoringTab() {
 
       {/* ── 4. Penalty Rules (Plan B4) ─────────────────────────────────── */}
       <ScoringPenaltyRules />
+
+      {/* ── 4b. Release-Group Tiers ────────────────────────────────────── */}
+      <ScoringReleaseGroupTiers />
 
       {/* ── 5. Advanced ────────────────────────────────────────────────── */}
       <div

--- a/frontend/src/pages/Settings/__tests__/ScoringReleaseGroupTiers.test.tsx
+++ b/frontend/src/pages/Settings/__tests__/ScoringReleaseGroupTiers.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ScoringReleaseGroupTiers } from '../ScoringReleaseGroupTiers'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key.split('.').pop() ?? key,
+    i18n: { language: 'en', changeLanguage: vi.fn() },
+  }),
+}))
+
+const mockMutate = vi.fn()
+let mockTiers: { tiers: string[]; step: number } = { tiers: [], step: 10 }
+
+vi.mock('@/hooks/useApi', () => ({
+  useReleaseGroupTiers: () => ({ data: mockTiers, isLoading: false }),
+  useUpdateReleaseGroupTiers: () => ({ mutate: mockMutate, isPending: false }),
+}))
+
+vi.mock('@/components/shared/Toast', () => ({ toast: vi.fn() }))
+
+describe('ScoringReleaseGroupTiers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockTiers = { tiers: [], step: 10 }
+  })
+
+  it('shows the empty state when no tiers are configured', () => {
+    render(<ScoringReleaseGroupTiers />)
+    expect(screen.getByText('empty')).toBeInTheDocument()
+  })
+
+  it('renders tier rows with computed bonus values', () => {
+    mockTiers = { tiers: ['Erai-raws', 'SubsPlease'], step: 10 }
+    render(<ScoringReleaseGroupTiers />)
+    expect(screen.getByText('Erai-raws')).toBeInTheDocument()
+    expect(screen.getByText('SubsPlease')).toBeInTheDocument()
+    // Top tier: 10 * (2 - 0) = 20; second tier: 10 * (2 - 1) = 10
+    expect(screen.getByText('+20')).toBeInTheDocument()
+    expect(screen.getByText('+10')).toBeInTheDocument()
+  })
+
+  it('adds a group via the input and saves', () => {
+    render(<ScoringReleaseGroupTiers />)
+    fireEvent.change(screen.getByTestId('input-tier-add'), { target: { value: 'Judas' } })
+    fireEvent.click(screen.getByTestId('btn-tier-add'))
+    expect(screen.getByText('Judas')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('btn-save-tiers'))
+    expect(mockMutate).toHaveBeenCalledWith(
+      { tiers: ['Judas'], step: 10 },
+      expect.anything(),
+    )
+  })
+
+  it('moves a tier up', () => {
+    mockTiers = { tiers: ['Erai-raws', 'SubsPlease'], step: 10 }
+    render(<ScoringReleaseGroupTiers />)
+    fireEvent.click(screen.getByTestId('tier-up-1'))
+    fireEvent.click(screen.getByTestId('btn-save-tiers'))
+    expect(mockMutate).toHaveBeenCalledWith(
+      { tiers: ['SubsPlease', 'Erai-raws'], step: 10 },
+      expect.anything(),
+    )
+  })
+
+  it('removes a tier', () => {
+    mockTiers = { tiers: ['Erai-raws', 'SubsPlease'], step: 10 }
+    render(<ScoringReleaseGroupTiers />)
+    fireEvent.click(screen.getByTestId('tier-remove-0'))
+    expect(screen.queryByText('Erai-raws')).not.toBeInTheDocument()
+  })
+
+  it('does not add a duplicate group (case-insensitive)', () => {
+    mockTiers = { tiers: ['Erai-raws'], step: 10 }
+    render(<ScoringReleaseGroupTiers />)
+    fireEvent.change(screen.getByTestId('input-tier-add'), { target: { value: 'erai-RAWS' } })
+    fireEvent.click(screen.getByTestId('btn-tier-add'))
+    expect(screen.getAllByText(/erai-raws/i)).toHaveLength(1)
+  })
+})

--- a/frontend/src/pages/Settings/__tests__/ScoringTab.test.tsx
+++ b/frontend/src/pages/Settings/__tests__/ScoringTab.test.tsx
@@ -55,6 +55,9 @@ vi.mock('@/hooks/useApi', () => ({
   // Plan B4 — penalty rules hooks consumed by ScoringPenaltyRules section
   usePenaltyRules: () => ({ data: { rules: [] }, isLoading: false }),
   useUpdatePenaltyRule: () => ({ mutate: vi.fn(), isPending: false }),
+  // Release-group tiers hooks consumed by ScoringReleaseGroupTiers section
+  useReleaseGroupTiers: () => ({ data: { tiers: [], step: 10 }, isLoading: false }),
+  useUpdateReleaseGroupTiers: () => ({ mutate: vi.fn(), isPending: false }),
 }))
 
 vi.mock('@/components/shared/Toast', () => ({ toast: vi.fn() }))


### PR DESCRIPTION
## Was ist neu

Eine **global geordnete Release-Gruppen-Rangliste** (beste zuerst) mit abgestuftem Score-Bonus — z. B. `Erai-raws > SubsPlease > Judas`. Ein Treffer auf Rang *i* von *N* Rängen erhält `step × (N − i)` Bonuspunkte, d. h. die Top-Gruppe bekommt am meisten, der letzte Rang genau `step` (Standard: 10, konfigurierbar 1–500).

Die bestehenden **Serien-spezifischen Fansub-Präferenzen** (`fansub_preferences`) wirken zusätzlich obendrauf; das `-999` einer ausgeschlossenen Gruppe dominiert weiterhin jeden Tier-Bonus.

## Umsetzung

- **`backend/services/release_group_tiers.py`** — Speicherung als JSON-Config-Entry (`release_group_tiers_json`, gleiche Vorgehensweise wie `media_servers_json`; **keine Migration nötig**). Sanitization: Trim, leere Einträge verwerfen (Schutz vor dem `"" in info`-Match-Alles-Problem), case-insensitive Dedupe, Limits (max. 100 Ränge, 100 Zeichen, Step 1–500).
- **`wanted_search/scoring.py`** — `_apply_release_group_tiers()`: case-insensitives Substring-Matching auf `release_info`; pro Ergebnis zählt nur der beste (höchste) Rang.
- **`wanted_search/search.py`** — Anwendung direkt vor den Serien-Fansub-Regeln; Fehler im Tier-Scoring brechen die Suche nie ab.
- **API** — `GET`/`PUT /api/v1/scoring/release-group-tiers` (in `routes/hooks/scoring.py`, mit apispec-Doku und Validierungsfehlern als 400).
- **Frontend** — neue Sektion „Release Group Tiers" unter *Settings → Scoring*: sortierbare Liste (hoch/runter/entfernen), Hinzufügen per Eingabefeld, Live-Vorschau des Bonus pro Rang, Step-Eingabe. i18n en + de.

## Tests

- `backend/tests/test_release_group_tiers.py` — 22 Tests: Scoring-Funktion (Skalierung, Case-Insensitivity, Best-Match-Only, Leereintrags-Schutz, Dominanz der Exclusion), Service (Roundtrip, Sanitization, Validierung, korrupte Config), API-Routen (Roundtrip, 400er, Default-Step).
- `frontend/.../ScoringReleaseGroupTiers.test.tsx` — 6 Komponententests (Empty State, Bonus-Anzeige, Add/Save, Move, Remove, Dedupe).
- Bestehende Tests grün: `test_fansub_prefs`, `test_wanted_search_dry_run`, `test_penalty_rules` (43 passed); `tsc -b` sauber, ESLint 0 Errors.

## Hinweise

- Leere Liste = Feature inaktiv (kein Verhalten ändert sich für Bestandsinstallationen).
- Unabhängig mergebar; die Folge-PRs (Custom-Regex-Regeln, Format-Requirement) bauen als Stack darauf auf — Merge-Reihenfolge: dieser PR zuerst.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LufxECMqmfKf4oWD38vbxq

---
_Generated by [Claude Code](https://claude.ai/code/session_01LufxECMqmfKf4oWD38vbxq)_