### PR TITLE
feat(providers): generic Custom HTTP/JSON provider (customapi)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to Sublarr are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Custom HTTP/JSON provider (`customapi`).** Connect private subtitle
+  servers or adapt any REST API without writing a plugin: a small documented
+  search/download contract (see `docs/CUSTOM_PROVIDER_API.md`), configurable
+  auth header, response field mapping (dot-notation), extra query params, and
+  multiple independent instances via `customapi_instances_json` — each with
+  its own stats, health state, and circuit breaker. Pure configuration, no
+  third-party code execution.
+
 ## [1.9.4] - 2026-07-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ It follows the *arr-suite design philosophy: connect it to Sonarr/Radarr, set up
 
 ### 🔍 Subtitle Search & Download
 - **21 providers** — AnimeTosho, Jimaku, OpenSubtitles, SubDL, Subscene, Subf2m, Subsource, SubsDump, Addic7ed, BetaSeries, Titlovi, Titrari, TVSubtitles, Gestdown, Kitsunekko, Napisy24, Podnapisi, YIFY, Zimuku, LegendasDivX, TurkceAltyazi — plus embedded subtitle extraction
+- **Custom HTTP/JSON provider** — connect private subtitle servers or adapt any REST API via configuration (field mapping, multiple instances, no code required) — see [docs/CUSTOM_PROVIDER_API.md](docs/CUSTOM_PROVIDER_API.md)
 - **ASS-first scoring** — ASS/SSA gets +50 bonus over SRT; format, dialect, sync quality, and uploader reputation scored
 - **Smart deduplication** — avoids re-downloading identical files via SHA-256 hashing
 - **Machine translation detection** — flags OpenSubtitles mt/ai-tagged uploads with an orange badge

--- a/backend/config_settings.py
+++ b/backend/config_settings.py
@@ -260,6 +260,18 @@ class UISettings(BaseModel):
     subsdump_url: str = "http://192.168.178.195"
     subsdump_api_key: str = ""
 
+    # Custom HTTP/JSON provider (generic, user-configured REST endpoint —
+    # see docs/CUSTOM_PROVIDER_API.md for the contract)
+    customapi_base_url: str = ""
+    customapi_api_key: str = ""
+    customapi_api_key_header: str = "X-API-Key"
+    customapi_search_path: str = "/search"
+    customapi_download_path: str = "/download/{id}"
+    customapi_results_path: str = "results"
+    customapi_field_map: str = ""  # JSON object: SubtitleResult field -> response path
+    customapi_extra_params: str = ""  # JSON object: extra query params sent on search
+    customapi_instances_json: str = ""  # JSON array of additional instances
+
     # Sonarr (optional)
     sonarr_url: str = ""
     sonarr_api_key: str = ""

--- a/backend/providers/customapi.py
+++ b/backend/providers/customapi.py
@@ -1,0 +1,549 @@
+"""Custom HTTP/JSON provider — generic, user-configured REST subtitle source.
+
+Talks to any HTTP endpoint that returns subtitle search results as JSON:
+a private subtitle server implementing the Sublarr custom-provider contract
+(see docs/CUSTOM_PROVIDER_API.md), or an existing third-party API adapted
+via the ``results_path`` / ``field_map`` / ``extra_params`` settings.
+
+Additional independent instances (several private servers) are configured
+through ``customapi_instances_json`` — each entry is registered as its own
+provider named ``customapi-<name>`` with separate stats, circuit breaker,
+and rate limiting.
+
+No rate limiting by default: custom endpoints are typically self-hosted.
+License: GPL-3.0
+"""
+
+import json
+import logging
+import re
+import urllib.parse
+
+from archive_utils import extract_subtitles_from_zip
+from providers import _stream_download, register_provider
+from providers.base import (
+    ProviderAuthError,
+    ProviderError,
+    ProviderRateLimitError,
+    SubtitleFormat,
+    SubtitleProvider,
+    SubtitleResult,
+    VideoQuery,
+)
+from providers.http_session import create_session
+from security_utils import validate_download_url, validate_service_url
+
+logger = logging.getLogger(__name__)
+
+# Maps SubtitleResult fields -> path into each response item (dot-notation).
+# Overridable per instance via the ``field_map`` JSON config.
+DEFAULT_FIELD_MAP: dict[str, str] = {
+    "subtitle_id": "id",
+    "language": "language",
+    "download_url": "download_url",
+    "filename": "filename",
+    "format": "format",
+    "release_info": "release",
+    "hearing_impaired": "hearing_impaired",
+    "forced": "forced",
+    "matches": "matches",
+}
+
+_FORMAT_MAP = {
+    ".ass": SubtitleFormat.ASS,
+    ".ssa": SubtitleFormat.SSA,
+    ".srt": SubtitleFormat.SRT,
+    ".vtt": SubtitleFormat.VTT,
+}
+
+
+def _dot_get(obj, path: str):
+    """Walk ``obj`` along a dot-separated path ('data.results' / 'items.0.id').
+
+    Returns None when any segment is missing. An empty path returns ``obj``
+    unchanged (useful for top-level-array responses).
+    """
+    if not path:
+        return obj
+    cur = obj
+    for part in path.split("."):
+        if isinstance(cur, dict):
+            cur = cur.get(part)
+        elif isinstance(cur, list) and part.isdigit() and int(part) < len(cur):
+            cur = cur[int(part)]
+        else:
+            return None
+        if cur is None:
+            return None
+    return cur
+
+
+def _parse_json_object(raw, what: str) -> dict:
+    """Parse a config value that may be a JSON string or already a dict."""
+    if isinstance(raw, dict):
+        return raw
+    if not raw or not str(raw).strip():
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, TypeError) as e:
+        logger.warning("customapi: %s is not valid JSON, ignoring: %s", what, e)
+        return {}
+    if not isinstance(parsed, dict):
+        logger.warning("customapi: %s must be a JSON object, ignoring", what)
+        return {}
+    return parsed
+
+
+def _format_from_value(value, filename: str) -> SubtitleFormat:
+    """Resolve SubtitleFormat from an explicit item value, else the filename."""
+    if value:
+        try:
+            return SubtitleFormat(str(value).lower().lstrip("."))
+        except ValueError:
+            pass
+    ext = "." + filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
+    return _FORMAT_MAP.get(ext, SubtitleFormat.UNKNOWN)
+
+
+def _normalize_path(path: str, default: str) -> str:
+    path = (path or "").strip() or default
+    if not path.startswith("/"):
+        path = "/" + path
+    return path
+
+
+@register_provider
+class CustomApiProvider(SubtitleProvider):
+    """Generic user-configured HTTP/JSON subtitle provider.
+
+    Sends one GET request per search with the video's metadata as query
+    parameters and maps the JSON response onto SubtitleResult via a
+    configurable field map. Runs no third-party code — adapting an API is
+    pure configuration, which keeps this path safer than a Python plugin.
+    """
+
+    name = "customapi"
+    languages: set[str] = set()  # Determined by the configured endpoint
+
+    config_fields = [
+        {
+            "key": "customapi_base_url",
+            "label": "Base URL",
+            "type": "text",
+            "required": True,
+            "default": "",
+        },
+        {
+            "key": "customapi_api_key",
+            "label": "API Key",
+            "type": "password",
+            "required": False,
+            "default": "",
+        },
+        {
+            "key": "customapi_api_key_header",
+            "label": "API Key Header",
+            "type": "text",
+            "required": False,
+            "default": "X-API-Key",
+        },
+        {
+            "key": "customapi_search_path",
+            "label": "Search Path",
+            "type": "text",
+            "required": False,
+            "default": "/search",
+        },
+        {
+            "key": "customapi_download_path",
+            "label": "Download Path ({id} placeholder)",
+            "type": "text",
+            "required": False,
+            "default": "/download/{id}",
+        },
+        {
+            "key": "customapi_results_path",
+            "label": "Results Path (dot-notation into JSON)",
+            "type": "text",
+            "required": False,
+            "default": "results",
+        },
+        {
+            "key": "customapi_field_map",
+            "label": "Field Map (JSON, advanced)",
+            "type": "text",
+            "required": False,
+            "default": "",
+        },
+        {
+            "key": "customapi_extra_params",
+            "label": "Extra Query Params (JSON, advanced)",
+            "type": "text",
+            "required": False,
+            "default": "",
+        },
+        {
+            "key": "customapi_instances_json",
+            "label": "Extra Instances (JSON array, advanced)",
+            "type": "text",
+            "required": False,
+            "default": "",
+        },
+    ]
+
+    rate_limit = (0, 0)
+    timeout = 20
+    max_retries = 2
+
+    # Self-hosted endpoints: keep the provider-budget gate effectively open.
+    rate_limits = {"free": {"second": 10, "hour": 3600, "day": 50000}}
+
+    # Set by sync_instances() on dynamically registered instance subclasses.
+    _instance_config: dict | None = None
+
+    def __init__(self, **config):
+        super().__init__(**config)
+        self.session = None
+        self._base = ""
+        self._search_path = "/search"
+        self._download_path = "/download/{id}"
+        self._results_path = "results"
+        self._field_map: dict[str, str] = dict(DEFAULT_FIELD_MAP)
+        self._extra_params: dict = {}
+
+    def _effective_config(self) -> dict:
+        """Constructor kwargs merged with the per-instance config (if any)."""
+        cfg = dict(self.config)
+        inst = type(self)._instance_config
+        if inst:
+            for key, value in inst.items():
+                if key != "name":
+                    cfg[key] = value
+        return cfg
+
+    def initialize(self):
+        cfg = self._effective_config()
+
+        base_url = str(cfg.get("base_url") or "").strip().rstrip("/")
+        if not base_url:
+            logger.info("%s: no base URL configured, provider will be disabled", self.name)
+            return
+
+        url_ok, url_err = validate_service_url(base_url)
+        if not url_ok:
+            logger.error("%s: base URL rejected: %s", self.name, url_err)
+            return
+
+        self._base = base_url
+        self._search_path = _normalize_path(str(cfg.get("search_path") or ""), "/search")
+        self._download_path = _normalize_path(str(cfg.get("download_path") or ""), "/download/{id}")
+        results_path = cfg.get("results_path")
+        self._results_path = "results" if results_path is None else str(results_path).strip()
+        self._field_map = {
+            **DEFAULT_FIELD_MAP,
+            **{k: str(v) for k, v in _parse_json_object(cfg.get("field_map"), "field_map").items()},
+        }
+        self._extra_params = _parse_json_object(cfg.get("extra_params"), "extra_params")
+
+        self.session = create_session(timeout=self.timeout)
+        self.session.headers.update({"Accept": "application/json"})
+
+        api_key = str(cfg.get("api_key") or "").strip()
+        if api_key:
+            header = str(cfg.get("api_key_header") or "").strip() or "X-API-Key"
+            value = api_key
+            # Ergonomics: a bare token in an Authorization header almost
+            # certainly wants the Bearer scheme.
+            if header.lower() == "authorization" and " " not in api_key:
+                value = f"Bearer {api_key}"
+            self.session.headers[header] = value
+
+    def terminate(self):
+        if self.session:
+            self.session.close()
+            self.session = None
+
+    def health_check(self) -> tuple[bool, str]:
+        if not self._base:
+            return False, "Base URL not configured"
+        if not self.session:
+            return False, "Not initialized"
+        try:
+            resp = self.session.get(f"{self._base}/health", timeout=5)
+            if resp.status_code == 200:
+                return True, "OK"
+            if resp.status_code == 404:
+                # No /health endpoint — any non-server-error answer from the
+                # base URL counts as reachable.
+                resp = self.session.get(self._base, timeout=5)
+                if resp.status_code < 500:
+                    return True, "OK (no /health endpoint)"
+            if resp.status_code in (401, 403):
+                return False, "Authentication failed"
+            return False, f"HTTP {resp.status_code}"
+        except Exception as e:
+            return False, str(e)
+
+    # ─── Search ──────────────────────────────────────────────────────────
+
+    def _build_params(self, query: VideoQuery) -> dict:
+        params: dict = {}
+        if query.is_episode:
+            params["series_title"] = query.series_title or query.title
+            params["season"] = query.season
+            params["episode"] = query.episode
+        else:
+            params["title"] = query.title
+        if query.year:
+            params["year"] = query.year
+        if query.imdb_id:
+            params["imdb_id"] = query.imdb_id
+        if query.tmdb_id:
+            params["tmdb_id"] = query.tmdb_id
+        if query.tvdb_id:
+            params["tvdb_id"] = query.tvdb_id
+        if query.anilist_id:
+            params["anilist_id"] = query.anilist_id
+        if query.languages:
+            params["languages"] = ",".join(query.languages)
+        if query.file_hash:
+            params["file_hash"] = query.file_hash
+        if query.file_size:
+            params["file_size"] = query.file_size
+        if query.release_group:
+            params["release_group"] = query.release_group
+        if query.resolution:
+            params["resolution"] = query.resolution
+        if query.source:
+            params["source"] = query.source
+        for key, value in self._extra_params.items():
+            params[key] = value
+        return params
+
+    def _download_url_for_id(self, subtitle_id: str) -> str:
+        quoted = urllib.parse.quote(str(subtitle_id), safe="")
+        return self._base + self._download_path.replace("{id}", quoted)
+
+    def search(self, query: VideoQuery) -> list[SubtitleResult]:
+        if not self.session or not self._base:
+            return []
+
+        params = self._build_params(query)
+        try:
+            resp = self.session.get(
+                self._base + self._search_path, params=params, timeout=self.timeout
+            )
+        except Exception as e:
+            logger.warning("%s: search request failed: %s", self.name, e)
+            return []
+
+        if resp.status_code in (401, 403):
+            raise ProviderAuthError(f"{self.name}: authentication failed (HTTP {resp.status_code})")
+        if resp.status_code == 429:
+            retry_after = 60
+            try:
+                retry_after = int(resp.headers.get("Retry-After", "60"))
+            except ValueError:
+                pass
+            raise ProviderRateLimitError(
+                f"{self.name}: rate limited (HTTP 429)", retry_after=retry_after
+            )
+        if resp.status_code != 200:
+            logger.warning(
+                "%s: search failed: HTTP %d, response: %s",
+                self.name,
+                resp.status_code,
+                resp.text[:200],
+            )
+            return []
+
+        try:
+            data = resp.json()
+        except ValueError as e:
+            logger.warning("%s: search response is not JSON: %s", self.name, e)
+            return []
+
+        items = _dot_get(data, self._results_path)
+        if items is None and isinstance(data, list):
+            # Endpoint returns a top-level array — accept it even when a
+            # results_path is configured (default 'results' won't match).
+            items = data
+        if not isinstance(items, list):
+            logger.warning(
+                "%s: no result list at path %r in search response", self.name, self._results_path
+            )
+            return []
+
+        results: list[SubtitleResult] = []
+        fmap = self._field_map
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+
+            subtitle_id = _dot_get(item, fmap["subtitle_id"])
+            if subtitle_id is None or str(subtitle_id) == "":
+                continue
+            subtitle_id = str(subtitle_id)
+
+            download_url = str(_dot_get(item, fmap["download_url"]) or "")
+            if download_url and not download_url.startswith(("http://", "https://")):
+                download_url = self._base + "/" + download_url.lstrip("/")
+            if not download_url:
+                download_url = self._download_url_for_id(subtitle_id)
+
+            language = str(_dot_get(item, fmap["language"]) or "").lower()
+            if not language and len(query.languages) == 1:
+                language = query.languages[0]
+            if language and query.languages and language not in query.languages:
+                continue
+
+            filename = str(_dot_get(item, fmap["filename"]) or "")
+            raw_matches = _dot_get(item, fmap["matches"])
+            matches = (
+                {str(m) for m in raw_matches} if isinstance(raw_matches, (list, set)) else set()
+            )
+
+            results.append(
+                SubtitleResult(
+                    provider_name=self.name,
+                    subtitle_id=subtitle_id,
+                    language=language,
+                    format=_format_from_value(_dot_get(item, fmap["format"]), filename),
+                    filename=filename,
+                    download_url=download_url,
+                    release_info=str(_dot_get(item, fmap["release_info"]) or ""),
+                    hearing_impaired=bool(_dot_get(item, fmap["hearing_impaired"])),
+                    forced=bool(_dot_get(item, fmap["forced"])),
+                    matches=matches,
+                    provider_data={"item": item},
+                )
+            )
+
+        logger.info("%s: found %d results", self.name, len(results))
+        return results
+
+    # ─── Download ────────────────────────────────────────────────────────
+
+    def result_for_download(self, subtitle_id: str, language: str = "") -> SubtitleResult:
+        """Rebuild a downloadable result from a stored id via the download path."""
+        return SubtitleResult(
+            provider_name=self.name,
+            subtitle_id=subtitle_id,
+            language=language,
+            download_url=self._download_url_for_id(subtitle_id),
+        )
+
+    def download(self, result: SubtitleResult) -> bytes:
+        if not self.session:
+            raise ProviderError(f"{self.name}: not initialized")
+
+        url = result.download_url
+        if not url:
+            url = self._download_url_for_id(result.subtitle_id)
+
+        url_ok, url_err = validate_download_url(url, self.name)
+        if not url_ok:
+            raise ProviderError(f"{self.name}: download URL rejected: {url_err}")
+
+        try:
+            content = _stream_download(self.session, url, timeout=60, provider_name=self.name)
+        except Exception as e:
+            raise ProviderError(f"{self.name}: download failed: {e}") from e
+
+        # ZIP archives: extract the best subtitle file (prefer ASS/SSA).
+        if content[:4] == b"PK\x03\x04":
+            try:
+                files = extract_subtitles_from_zip(content)
+            except Exception as e:
+                raise ProviderError(f"{self.name}: failed to extract archive: {e}") from e
+            if not files:
+                raise ProviderError(f"{self.name}: no subtitle file found in archive")
+            files.sort(key=lambda f: 0 if f[0].lower().endswith((".ass", ".ssa")) else 1)
+            filename, content = files[0]
+            ext = "." + filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
+            result.format = _FORMAT_MAP.get(ext, SubtitleFormat.UNKNOWN)
+        elif result.format == SubtitleFormat.UNKNOWN and result.filename:
+            result.format = _format_from_value(None, result.filename)
+
+        result.content = content
+        logger.info("%s: downloaded %s (%d bytes)", self.name, result.subtitle_id, len(content))
+        return content
+
+
+# ─── Multi-instance support ──────────────────────────────────────────────
+
+
+def _slugify(name: str) -> str:
+    return re.sub(r"-+", "-", re.sub(r"[^a-z0-9]", "-", name.lower())).strip("-")
+
+
+def sync_instances() -> None:
+    """(Re)register provider classes for entries in ``customapi_instances_json``.
+
+    Called from ``import_builtin_providers()`` so every ProviderManager
+    (re)initialization picks up config changes: new instances are registered
+    as ``customapi-<name>``, removed ones are dropped from the registry.
+    Each instance gets its own stats, circuit breaker, and health state.
+    """
+    from providers.registry import _PROVIDER_CLASSES
+
+    raw = ""
+    try:
+        from config import get_settings
+
+        raw = getattr(get_settings(), "customapi_instances_json", "") or ""
+    except Exception as e:
+        logger.debug("customapi: settings unavailable, skipping instance sync: %s", e)
+
+    instances: list[dict] = []
+    if raw.strip():
+        try:
+            parsed = json.loads(raw)
+            if isinstance(parsed, list):
+                instances = [
+                    i for i in parsed if isinstance(i, dict) and i.get("name") and i.get("base_url")
+                ]
+                dropped = len(parsed) - len(instances)
+                if dropped:
+                    logger.warning(
+                        "customapi: %d instance entr%s missing 'name'/'base_url', skipped",
+                        dropped,
+                        "y is" if dropped == 1 else "ies are",
+                    )
+            else:
+                logger.warning("customapi: customapi_instances_json must be a JSON array")
+        except json.JSONDecodeError as e:
+            logger.warning("customapi: customapi_instances_json is not valid JSON: %s", e)
+
+    desired: dict[str, dict] = {}
+    for inst in instances:
+        slug = _slugify(str(inst["name"]))
+        if not slug:
+            continue
+        provider_name = f"customapi-{slug}"
+        if provider_name in desired:
+            logger.warning("customapi: duplicate instance name %r, skipping", inst["name"])
+            continue
+        desired[provider_name] = inst
+
+    # Drop registrations for instances that no longer exist in the config.
+    for existing in [n for n in _PROVIDER_CLASSES if n.startswith("customapi-")]:
+        if existing not in desired:
+            del _PROVIDER_CLASSES[existing]
+            logger.info("customapi: instance %s removed from registry", existing)
+
+    for provider_name, inst in desired.items():
+        cls = type(
+            f"CustomApiInstance_{provider_name.replace('-', '_')}",
+            (CustomApiProvider,),
+            {
+                "name": provider_name,
+                "config_fields": [],
+                "_instance_config": dict(inst),
+            },
+        )
+        # Assign directly (not register_provider) so config edits overwrite
+        # the previous registration instead of being skipped as a collision.
+        _PROVIDER_CLASSES[provider_name] = cls
+        logger.debug("customapi: registered instance %s", provider_name)

--- a/backend/providers/registry.py
+++ b/backend/providers/registry.py
@@ -17,6 +17,7 @@ PROVIDER_METADATA: dict[str, dict] = {
     "animetosho": {"rate_limit": (50, 30), "timeout": 10, "retries": 2},
     "subdl": {"rate_limit": (30, 10), "timeout": 10, "retries": 2},
     "subsdump": {"rate_limit": (0, 0), "timeout": 30, "retries": 2},
+    "customapi": {"rate_limit": (0, 0), "timeout": 20, "retries": 2},
 }
 
 import logging
@@ -54,6 +55,7 @@ _BUILTIN_PROVIDERS: tuple[str, ...] = (
     "animetosho",
     "subdl",
     "subsdump",
+    "customapi",
     "gestdown",
     "podnapisi",
     "kitsunekko",
@@ -90,6 +92,15 @@ def import_builtin_providers() -> None:
             importlib.import_module(f"providers.{name}")
         except ImportError as e:
             logger.debug("Provider %s not available: %s", name, e)
+
+    # Re-sync dynamically registered Custom API instances (customapi-<name>)
+    # so ProviderManager re-initialization picks up config changes.
+    try:
+        from providers.customapi import sync_instances
+
+        sync_instances()
+    except Exception as e:
+        logger.debug("Custom API instance sync skipped: %s", e)
 
 
 __all__ = [

--- a/backend/security_utils.py
+++ b/backend/security_utils.py
@@ -36,7 +36,13 @@ _LOCAL_PROVIDERS = {"embedded", "whisper"}
 
 # Providers that are self-hosted (operator chooses the URL).
 # Scheme must be http/https, but any hostname is accepted.
-_SELF_HOSTED_PROVIDERS = {"subsdump"}
+# The generic Custom HTTP/JSON provider ("customapi") and its dynamically
+# registered instances ("customapi-<name>") fall in this class too.
+_SELF_HOSTED_PROVIDERS = {"subsdump", "customapi"}
+
+
+def _is_self_hosted_provider(provider_name: str) -> bool:
+    return provider_name in _SELF_HOSTED_PROVIDERS or provider_name.startswith("customapi-")
 
 # Allowlists: a URL is accepted when netloc equals entry OR ends with ".<entry>".
 _PROVIDER_DOWNLOAD_DOMAINS: dict[str, set[str]] = {
@@ -72,7 +78,7 @@ def validate_download_url(url: str, provider_name: str) -> tuple[bool, str | Non
     if provider_name in _LOCAL_PROVIDERS:
         return True, None
 
-    if provider_name in _SELF_HOSTED_PROVIDERS:
+    if _is_self_hosted_provider(provider_name):
         if not url:
             return False, "Self-hosted provider download URL must not be empty"
         try:

--- a/backend/tests/test_customapi_provider.py
+++ b/backend/tests/test_customapi_provider.py
@@ -1,0 +1,410 @@
+"""Unit tests for the generic Custom HTTP/JSON provider (customapi)."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from providers.base import SubtitleFormat, VideoQuery
+from providers.customapi import (
+    CustomApiProvider,
+    _dot_get,
+    _slugify,
+    sync_instances,
+)
+
+
+def _make_provider(**config) -> CustomApiProvider:
+    """Provider with a mocked HTTP session, initialized via real initialize()."""
+    p = CustomApiProvider(**config)
+    with patch("providers.customapi.create_session") as mock_cs:
+        mock_cs.return_value = MagicMock()
+        p.initialize()
+    return p
+
+
+def _response(status_code=200, payload=None, headers=None, text=""):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = payload
+    resp.headers = headers or {}
+    resp.text = text
+    return resp
+
+
+class TestDotGet:
+    def test_empty_path_returns_object(self):
+        assert _dot_get([1, 2], "") == [1, 2]
+
+    def test_nested_dict(self):
+        assert _dot_get({"data": {"results": [1]}}, "data.results") == [1]
+
+    def test_list_index(self):
+        assert _dot_get({"pages": [{"items": ["x"]}]}, "pages.0.items") == ["x"]
+
+    def test_missing_segment_returns_none(self):
+        assert _dot_get({"a": {}}, "a.b.c") is None
+        assert _dot_get([1], "5") is None
+
+
+class TestInitialize:
+    def test_import_and_name(self):
+        p = CustomApiProvider()
+        assert p.name == "customapi"
+
+    def test_no_base_url_leaves_session_none(self):
+        p = CustomApiProvider()
+        p.initialize()
+        assert p.session is None
+
+    def test_invalid_base_url_rejected(self):
+        p = CustomApiProvider(base_url="file:///etc/passwd")
+        p.initialize()
+        assert p.session is None
+
+    def test_base_url_trailing_slash_stripped(self):
+        p = _make_provider(base_url="http://192.168.1.10:8080/")
+        assert p._base == "http://192.168.1.10:8080"
+        assert p.session is not None
+
+    def test_api_key_header_default(self):
+        p = _make_provider(base_url="http://192.168.1.10", api_key="secret")
+        p.session.headers.__setitem__.assert_any_call("X-API-Key", "secret")
+
+    def test_authorization_header_gets_bearer_prefix(self):
+        p = _make_provider(
+            base_url="http://192.168.1.10", api_key="tok123", api_key_header="Authorization"
+        )
+        p.session.headers.__setitem__.assert_any_call("Authorization", "Bearer tok123")
+
+    def test_authorization_header_with_scheme_kept_verbatim(self):
+        p = _make_provider(
+            base_url="http://192.168.1.10",
+            api_key="Basic abc==",
+            api_key_header="Authorization",
+        )
+        p.session.headers.__setitem__.assert_any_call("Authorization", "Basic abc==")
+
+    def test_invalid_field_map_json_falls_back_to_defaults(self):
+        p = _make_provider(base_url="http://192.168.1.10", field_map="{not json")
+        assert p._field_map["subtitle_id"] == "id"
+
+    def test_terminate_closes_session(self):
+        p = _make_provider(base_url="http://192.168.1.10")
+        session = p.session
+        p.terminate()
+        session.close.assert_called_once()
+        assert p.session is None
+
+
+class TestSearch:
+    def _query(self, **kwargs):
+        defaults = dict(
+            series_title="Test Show", season=1, episode=2, languages=["de"], imdb_id="tt123"
+        )
+        defaults.update(kwargs)
+        return VideoQuery(**defaults)
+
+    def test_search_returns_empty_without_session(self):
+        p = CustomApiProvider()
+        assert p.search(self._query()) == []
+
+    def test_default_contract_mapping(self):
+        p = _make_provider(base_url="http://192.168.1.10")
+        p.session.get.return_value = _response(
+            payload={
+                "results": [
+                    {
+                        "id": "42",
+                        "language": "de",
+                        "download_url": "http://192.168.1.10/files/42.ass",
+                        "filename": "ep2.ass",
+                        "release": "Group-1080p",
+                        "hearing_impaired": True,
+                        "forced": False,
+                        "matches": ["series", "season", "episode"],
+                    }
+                ]
+            }
+        )
+        results = p.search(self._query())
+        assert len(results) == 1
+        r = results[0]
+        assert r.provider_name == "customapi"
+        assert r.subtitle_id == "42"
+        assert r.language == "de"
+        assert r.download_url == "http://192.168.1.10/files/42.ass"
+        assert r.format == SubtitleFormat.ASS
+        assert r.release_info == "Group-1080p"
+        assert r.hearing_impaired is True
+        assert r.matches == {"series", "season", "episode"}
+
+    def test_search_params_include_query_metadata(self):
+        p = _make_provider(base_url="http://192.168.1.10", extra_params=json.dumps({"apikey": "x"}))
+        p.session.get.return_value = _response(payload={"results": []})
+        p.search(self._query())
+        args, kwargs = p.session.get.call_args
+        assert args[0] == "http://192.168.1.10/search"
+        params = kwargs["params"]
+        assert params["series_title"] == "Test Show"
+        assert params["season"] == 1
+        assert params["episode"] == 2
+        assert params["languages"] == "de"
+        assert params["imdb_id"] == "tt123"
+        assert params["apikey"] == "x"
+
+    def test_relative_download_url_resolved(self):
+        p = _make_provider(base_url="http://192.168.1.10")
+        p.session.get.return_value = _response(
+            payload={"results": [{"id": "1", "language": "de", "download_url": "files/1.srt"}]}
+        )
+        results = p.search(self._query())
+        assert results[0].download_url == "http://192.168.1.10/files/1.srt"
+
+    def test_missing_download_url_uses_download_path(self):
+        p = _make_provider(base_url="http://192.168.1.10")
+        p.session.get.return_value = _response(
+            payload={"results": [{"id": "a/b", "language": "de"}]}
+        )
+        results = p.search(self._query())
+        assert results[0].download_url == "http://192.168.1.10/download/a%2Fb"
+
+    def test_language_defaults_to_single_query_language(self):
+        p = _make_provider(base_url="http://192.168.1.10")
+        p.session.get.return_value = _response(payload={"results": [{"id": "1"}]})
+        results = p.search(self._query())
+        assert results[0].language == "de"
+
+    def test_mismatched_language_skipped(self):
+        p = _make_provider(base_url="http://192.168.1.10")
+        p.session.get.return_value = _response(payload={"results": [{"id": "1", "language": "fr"}]})
+        assert p.search(self._query()) == []
+
+    def test_top_level_array_response(self):
+        p = _make_provider(base_url="http://192.168.1.10")
+        p.session.get.return_value = _response(payload=[{"id": "1", "language": "de"}])
+        assert len(p.search(self._query())) == 1
+
+    def test_results_path_and_field_map_override(self):
+        p = _make_provider(
+            base_url="http://192.168.1.10",
+            results_path="data.subtitles",
+            field_map=json.dumps(
+                {"subtitle_id": "attributes.sid", "download_url": "attributes.file.url"}
+            ),
+        )
+        p.session.get.return_value = _response(
+            payload={
+                "data": {
+                    "subtitles": [
+                        {
+                            "attributes": {
+                                "sid": 7,
+                                "file": {"url": "http://192.168.1.10/d/7"},
+                            },
+                            "language": "de",
+                        }
+                    ]
+                }
+            }
+        )
+        results = p.search(self._query())
+        assert results[0].subtitle_id == "7"
+        assert results[0].download_url == "http://192.168.1.10/d/7"
+
+    def test_items_without_id_skipped(self):
+        p = _make_provider(base_url="http://192.168.1.10")
+        p.session.get.return_value = _response(
+            payload={"results": [{"language": "de"}, "not-a-dict"]}
+        )
+        assert p.search(self._query()) == []
+
+    def test_auth_error_raised(self):
+        from providers.base import ProviderAuthError
+
+        p = _make_provider(base_url="http://192.168.1.10")
+        p.session.get.return_value = _response(status_code=401)
+        with pytest.raises(ProviderAuthError):
+            p.search(self._query())
+
+    def test_rate_limit_raised_with_retry_after(self):
+        from providers.base import ProviderRateLimitError
+
+        p = _make_provider(base_url="http://192.168.1.10")
+        p.session.get.return_value = _response(status_code=429, headers={"Retry-After": "120"})
+        with pytest.raises(ProviderRateLimitError) as exc_info:
+            p.search(self._query())
+        assert exc_info.value.retry_after == 120
+
+    def test_server_error_returns_empty(self):
+        p = _make_provider(base_url="http://192.168.1.10")
+        p.session.get.return_value = _response(status_code=500, text="boom")
+        assert p.search(self._query()) == []
+
+    def test_network_error_returns_empty(self):
+        p = _make_provider(base_url="http://192.168.1.10")
+        p.session.get.side_effect = ConnectionError("refused")
+        assert p.search(self._query()) == []
+
+
+class TestDownload:
+    def test_download_raises_without_session(self):
+        from providers.base import ProviderError, SubtitleResult
+
+        p = CustomApiProvider()
+        r = SubtitleResult(provider_name="customapi", subtitle_id="1", language="de")
+        with pytest.raises(ProviderError):
+            p.download(r)
+
+    def test_download_rejects_bad_scheme(self):
+        from providers.base import ProviderError, SubtitleResult
+
+        p = _make_provider(base_url="http://192.168.1.10")
+        r = SubtitleResult(
+            provider_name="customapi",
+            subtitle_id="1",
+            language="de",
+            download_url="ftp://192.168.1.10/1.srt",
+        )
+        with pytest.raises(ProviderError, match="rejected"):
+            p.download(r)
+
+    def test_download_raw_subtitle(self):
+        from providers.base import SubtitleResult
+
+        p = _make_provider(base_url="http://192.168.1.10")
+        r = SubtitleResult(
+            provider_name="customapi",
+            subtitle_id="1",
+            language="de",
+            filename="x.srt",
+            download_url="http://192.168.1.10/d/1",
+        )
+        with patch("providers.customapi._stream_download", return_value=b"1\n00:00 sub"):
+            content = p.download(r)
+        assert content == b"1\n00:00 sub"
+        assert r.format == SubtitleFormat.SRT
+
+    def test_download_zip_prefers_ass(self):
+        import io
+        import zipfile
+
+        from providers.base import SubtitleResult
+
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("sub.srt", "srt content")
+            zf.writestr("sub.ass", "ass content")
+
+        p = _make_provider(base_url="http://192.168.1.10")
+        r = SubtitleResult(
+            provider_name="customapi",
+            subtitle_id="1",
+            language="de",
+            download_url="http://192.168.1.10/d/1",
+        )
+        with patch("providers.customapi._stream_download", return_value=buf.getvalue()):
+            content = p.download(r)
+        assert content == b"ass content"
+        assert r.format == SubtitleFormat.ASS
+
+    def test_result_for_download_builds_url(self):
+        p = _make_provider(base_url="http://192.168.1.10")
+        r = p.result_for_download("99", language="de")
+        assert r.download_url == "http://192.168.1.10/download/99"
+
+
+class TestHealthCheck:
+    def test_unconfigured(self):
+        p = CustomApiProvider()
+        healthy, msg = p.health_check()
+        assert not healthy
+
+    def test_health_endpoint_ok(self):
+        p = _make_provider(base_url="http://192.168.1.10")
+        p.session.get.return_value = _response(status_code=200, payload={"ok": True})
+        healthy, msg = p.health_check()
+        assert healthy
+
+    def test_missing_health_endpoint_falls_back_to_base(self):
+        p = _make_provider(base_url="http://192.168.1.10")
+        p.session.get.side_effect = [_response(status_code=404), _response(status_code=200)]
+        healthy, msg = p.health_check()
+        assert healthy
+
+    def test_auth_failure(self):
+        p = _make_provider(base_url="http://192.168.1.10")
+        p.session.get.return_value = _response(status_code=401)
+        healthy, msg = p.health_check()
+        assert not healthy
+        assert "Authentication" in msg
+
+
+class TestInstances:
+    def test_slugify(self):
+        assert _slugify("My Server #1") == "my-server-1"
+        assert _slugify("---") == ""
+
+    def _sync_with(self, raw_json: str):
+        settings = MagicMock()
+        settings.customapi_instances_json = raw_json
+        with patch("config.get_settings", return_value=settings):
+            sync_instances()
+
+    def test_sync_registers_and_removes_instances(self):
+        from providers.registry import _PROVIDER_CLASSES
+
+        try:
+            self._sync_with(
+                json.dumps(
+                    [
+                        {"name": "Home NAS", "base_url": "http://192.168.1.10:9000"},
+                        {"name": "no-url"},
+                    ]
+                )
+            )
+            assert "customapi-home-nas" in _PROVIDER_CLASSES
+            cls = _PROVIDER_CLASSES["customapi-home-nas"]
+            assert cls.name == "customapi-home-nas"
+            assert cls.config_fields == []
+
+            # Instance config drives initialize()
+            p = cls()
+            with patch("providers.customapi.create_session") as mock_cs:
+                mock_cs.return_value = MagicMock()
+                p.initialize()
+            assert p._base == "http://192.168.1.10:9000"
+
+            # Removing the instance from config drops the registration
+            self._sync_with("[]")
+            assert "customapi-home-nas" not in _PROVIDER_CLASSES
+        finally:
+            for name in [n for n in _PROVIDER_CLASSES if n.startswith("customapi-")]:
+                del _PROVIDER_CLASSES[name]
+
+    def test_sync_with_invalid_json_is_noop(self):
+        from providers.registry import _PROVIDER_CLASSES
+
+        before = set(_PROVIDER_CLASSES)
+        self._sync_with("{broken")
+        assert set(_PROVIDER_CLASSES) == before
+
+
+class TestDownloadUrlValidation:
+    def test_customapi_allows_arbitrary_private_host(self):
+        from security_utils import validate_download_url
+
+        ok, err = validate_download_url("http://192.168.1.10:9000/d/1", "customapi")
+        assert ok, err
+
+    def test_instance_names_allowed(self):
+        from security_utils import validate_download_url
+
+        ok, err = validate_download_url("http://10.0.0.5/d/1", "customapi-home-nas")
+        assert ok, err
+
+    def test_metadata_ip_blocked(self):
+        from security_utils import validate_download_url
+
+        ok, err = validate_download_url("http://169.254.169.254/latest", "customapi")
+        assert not ok

--- a/docs/CUSTOM_PROVIDER_API.md
+++ b/docs/CUSTOM_PROVIDER_API.md
@@ -1,0 +1,147 @@
+# Custom HTTP/JSON Provider
+
+The `customapi` provider turns any HTTP endpoint that returns JSON into a
+subtitle source — **without writing a plugin**. Point it at a private
+subtitle server that implements the small contract below, or adapt an
+existing third-party REST API using the mapping settings.
+
+Because it only sends configured HTTP requests and never executes
+third-party code, it is the safest way to integrate a custom source.
+For anything the mapping can't express (multi-step flows, login sessions,
+HTML scraping), write a [plugin](https://sublarr.de/docs/development/plugin-development/) instead.
+
+## Quick start (private server)
+
+1. Implement the three endpoints below on your server.
+2. In Sublarr: **Settings → Providers → customapi**, set the **Base URL**
+   (e.g. `http://192.168.1.10:9000`) and optionally an **API Key**.
+3. Done — results are scored, cached, rate-limited, and circuit-broken
+   exactly like every built-in provider.
+
+## The contract
+
+All endpoints are relative to the configured base URL. Paths are
+configurable (`Search Path`, `Download Path`); the defaults are shown.
+
+### `GET /search`
+
+Sublarr sends one request per search with the video's metadata as query
+parameters. All parameters are optional — use what you need:
+
+| Parameter | Example | Notes |
+|---|---|---|
+| `title` | `Inception` | Movies only |
+| `series_title` | `Frieren` | Episodes only |
+| `season` | `1` | Episodes only |
+| `episode` | `4` | Episodes only |
+| `year` | `2010` | |
+| `imdb_id` | `tt1375666` | |
+| `tmdb_id` | `27205` | |
+| `tvdb_id` | `424536` | |
+| `anilist_id` | `154587` | |
+| `languages` | `de,en` | Comma-separated ISO 639-1 codes |
+| `file_hash` | `8e245d9679d31e12` | OpenSubtitles-style hash |
+| `file_size` | `3841923072` | Bytes |
+| `release_group` | `SubsPlease` | |
+| `resolution` | `1080p` | |
+| `source` | `WEB-DL` | |
+
+Respond with `200` and:
+
+```json
+{
+  "results": [
+    {
+      "id": "abc123",
+      "language": "de",
+      "download_url": "/download/abc123",
+      "filename": "Frieren.S01E04.de.ass",
+      "format": "ass",
+      "release": "SubsPlease 1080p",
+      "hearing_impaired": false,
+      "forced": false,
+      "matches": ["series", "season", "episode", "release_group"]
+    }
+  ]
+}
+```
+
+Per-item fields:
+
+| Field | Required | Notes |
+|---|---|---|
+| `id` | ✅ | Unique subtitle id (string or number) |
+| `language` | recommended | ISO 639-1. Falls back to the (single) requested language; items whose language doesn't match the request are dropped |
+| `download_url` | — | Absolute or relative to the base URL. Omit it to have Sublarr use the download path (`/download/{id}`) |
+| `filename` | recommended | Used for format detection |
+| `format` | — | `ass` / `ssa` / `srt` / `vtt`; inferred from `filename` when omitted |
+| `release` | — | Release/version info shown in the UI |
+| `hearing_impaired` | — | Boolean |
+| `forced` | — | Boolean |
+| `matches` | — | Which query attributes this subtitle matches — this is what drives scoring. Valid values include `hash`, `series`, `title`, `year`, `season`, `episode`, `release_group`, `source`, `resolution`, `video_codec` |
+
+Auth failures should return `401`/`403`; rate limiting `429` (a
+`Retry-After` header is honored).
+
+### `GET /download/{id}`
+
+Returns the raw subtitle file (`.ass`/`.srt`/…) or a ZIP archive
+containing it (ASS/SSA is preferred when extracting).
+
+### `GET /health` *(optional)*
+
+Return `200` when healthy. Without this endpoint, any non-5xx response
+from the base URL counts as healthy.
+
+### Authentication
+
+If an API key is configured, it is sent on every request in the
+`X-API-Key` header (configurable). When the header is set to
+`Authorization` and the key contains no scheme, `Bearer ` is prefixed
+automatically.
+
+## Adapting an existing API
+
+Three settings map a foreign response shape onto the contract:
+
+- **Results Path** — dot-notation path to the result array inside the
+  response, e.g. `data.subtitles`. Leave empty for a top-level array.
+- **Field Map** (JSON) — maps Sublarr fields to per-item paths
+  (dot-notation supported):
+
+  ```json
+  {"subtitle_id": "attributes.sid", "download_url": "attributes.file.url", "release_info": "attributes.release"}
+  ```
+
+  Mappable fields: `subtitle_id`, `language`, `download_url`, `filename`,
+  `format`, `release_info`, `hearing_impaired`, `forced`, `matches`.
+- **Extra Query Params** (JSON) — static parameters added to every search
+  request, e.g. `{"apikey": "...", "type": "subtitle"}`.
+
+## Multiple instances
+
+Several independent servers can be configured via
+**Extra Instances (JSON array)** on the `customapi` provider:
+
+```json
+[
+  {"name": "Home NAS", "base_url": "http://192.168.1.10:9000", "api_key": "s3cret"},
+  {"name": "VPS Mirror", "base_url": "https://subs.example.org", "search_path": "/api/search"}
+]
+```
+
+Each entry is registered as its own provider named `customapi-<name>`
+(e.g. `customapi-home-nas`) with separate statistics, health state,
+circuit breaker, and priority. Instance entries accept the same keys as
+the main provider settings (without the `customapi_` prefix): `base_url`,
+`api_key`, `api_key_header`, `search_path`, `download_path`,
+`results_path`, `field_map` (object), `extra_params` (object).
+
+## Security notes
+
+- Only `http`/`https` URLs are accepted. Private LAN addresses are
+  allowed (that's the point), but cloud-metadata endpoints and link-local
+  addresses are always blocked.
+- Downloads are streamed with a 50 MB cap and validated as subtitle
+  content before being saved.
+- The API key is encrypted at rest like all other provider credentials.


### PR DESCRIPTION
Connect private subtitle servers or adapt any REST API through pure
configuration — no plugin code required:

- New built-in provider `customapi` with a small documented search/
  download contract (docs/CUSTOM_PROVIDER_API.md)
- Configurable auth header (X-API-Key default, automatic Bearer prefix
  for Authorization), search/download paths, results path (dot-notation)
- Field mapping (JSON) to adapt foreign response shapes onto
  SubtitleResult, plus static extra query params
- Multiple independent instances via customapi_instances_json — each
  registered as customapi-<name> with its own stats, circuit breaker,
  health state, and priority
- Self-hosted SSRF policy (any host allowed, metadata/link-local
  blocked), API key encrypted at rest, 50 MB streaming cap, ZIP
  extraction with ASS/SSA preference

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012bhJKRsgQmSrjow9wowrnb