### PR TITLE
feat(scoring): user-defined custom regex scoring rules

### DIFF
--- a/backend/db/migrations/versions/2026_07_30_1000-f8c9d0e1a2b3_add_custom_scoring_rules.py
+++ b/backend/db/migrations/versions/2026_07_30_1000-f8c9d0e1a2b3_add_custom_scoring_rules.py
@@ -1,0 +1,46 @@
+"""add custom_scoring_rules — user-defined regex scoring rules
+
+Sonarr-style release-profile conditions: each row holds a regex that is
+matched case-insensitively against a candidate's release_info during
+penalty-pipeline scoring; a hit adds the signed weight to the score.
+
+Guarded with has_table: the schema is also created straight from the models
+via create_all() (fresh installs, the test harness), so the migration must
+be a no-op when the table is already there.
+
+Revision ID: f8c9d0e1a2b3
+Revises: e7a1b2c3d4f5
+Create Date: 2026-07-30
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "f8c9d0e1a2b3"
+down_revision = "e7a1b2c3d4f5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if sa.inspect(bind).has_table("custom_scoring_rules"):
+        return
+
+    op.create_table(
+        "custom_scoring_rules",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("pattern", sa.Text(), nullable=False),
+        sa.Column("weight", sa.Integer(), nullable=False),
+        sa.Column("enabled", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if sa.inspect(bind).has_table("custom_scoring_rules"):
+        op.drop_table("custom_scoring_rules")

--- a/backend/db/models/__init__.py
+++ b/backend/db/models/__init__.py
@@ -44,6 +44,7 @@ from db.models.plugins import (
     MarketplaceCache,
 )
 from db.models.providers import (
+    CustomScoringRule,
     ProviderCache,
     ProviderScoreModifier,
     ProviderStats,
@@ -94,6 +95,7 @@ __all__ = [
     "ProviderStats",
     "ProviderScoreModifier",
     "ScoringWeights",
+    "CustomScoringRule",
     # translation
     "TranslationConfigHistory",
     "GlossaryEntry",

--- a/backend/db/models/providers.py
+++ b/backend/db/models/providers.py
@@ -5,7 +5,7 @@ All column types and defaults match the existing SCHEMA DDL in db/__init__.py ex
 
 from datetime import datetime
 
-from sqlalchemy import DateTime, Float, Index, Integer, Text, UniqueConstraint
+from sqlalchemy import Boolean, DateTime, Float, Index, Integer, Text, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 
 from extensions import db
@@ -105,10 +105,30 @@ class ScoringWeights(db.Model):
     __table_args__ = (UniqueConstraint("score_type", "weight_key"),)
 
 
+class CustomScoringRule(db.Model):
+    """User-defined regex scoring rule (Sonarr-style release profile condition).
+
+    ``pattern`` is matched case-insensitively against a candidate's
+    release_info during penalty-pipeline scoring; a hit adds the signed
+    ``weight`` to the candidate's score.
+    """
+
+    __tablename__ = "custom_scoring_rules"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    pattern: Mapped[str] = mapped_column(Text, nullable=False)
+    weight: Mapped[int] = mapped_column(Integer, nullable=False)
+    enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+
+
 __all__ = [
     "ProviderCache",
     "SubtitleDownload",
     "ProviderStats",
     "ProviderScoreModifier",
     "ScoringWeights",
+    "CustomScoringRule",
 ]

--- a/backend/db/repositories/custom_rules.py
+++ b/backend/db/repositories/custom_rules.py
@@ -1,0 +1,107 @@
+"""Repository for user-defined regex scoring rules."""
+
+import logging
+import re
+
+from db.models.providers import CustomScoringRule
+from db.repositories.base import BaseRepository
+
+logger = logging.getLogger(__name__)
+
+MAX_RULES = 200
+MAX_NAME_LEN = 100
+MAX_PATTERN_LEN = 500
+MIN_WEIGHT = -999
+MAX_WEIGHT = 999
+
+
+def validate_rule_fields(name: str, pattern: str, weight: int) -> None:
+    """Raise ``ValueError`` if any field is invalid (shared by create/update)."""
+    if not isinstance(name, str) or not name.strip():
+        raise ValueError("name must be a non-empty string")
+    if len(name.strip()) > MAX_NAME_LEN:
+        raise ValueError(f"name too long (max {MAX_NAME_LEN} chars)")
+    if not isinstance(pattern, str) or not pattern.strip():
+        raise ValueError("pattern must be a non-empty string")
+    if len(pattern) > MAX_PATTERN_LEN:
+        raise ValueError(f"pattern too long (max {MAX_PATTERN_LEN} chars)")
+    try:
+        re.compile(pattern, re.IGNORECASE)
+    except re.error as e:
+        raise ValueError(f"invalid regex: {e}") from e
+    if not isinstance(weight, int) or isinstance(weight, bool):
+        raise ValueError("weight must be an integer")
+    if not (MIN_WEIGHT <= weight <= MAX_WEIGHT):
+        raise ValueError(f"weight must be between {MIN_WEIGHT} and {MAX_WEIGHT}")
+
+
+class CustomScoringRuleRepository(BaseRepository):
+    """CRUD for custom regex scoring rules."""
+
+    def _to_dict(self, row: CustomScoringRule) -> dict:
+        return {
+            "id": row.id,
+            "name": row.name,
+            "pattern": row.pattern,
+            "weight": row.weight,
+            "enabled": bool(row.enabled),
+        }
+
+    def list_rules(self, enabled_only: bool = False) -> list[dict]:
+        """Return all rules ordered by id (creation order)."""
+        query = self.session.query(CustomScoringRule).order_by(CustomScoringRule.id)
+        if enabled_only:
+            query = query.filter(CustomScoringRule.enabled.is_(True))
+        return [self._to_dict(r) for r in query.all()]
+
+    def create_rule(self, name: str, pattern: str, weight: int, enabled: bool = True) -> dict:
+        """Validate and insert a rule. Raises ``ValueError`` on invalid input."""
+        validate_rule_fields(name, pattern, weight)
+        count = self.session.query(CustomScoringRule).count()
+        if count >= MAX_RULES:
+            raise ValueError(f"at most {MAX_RULES} custom rules allowed")
+        now = self._now()
+        row = CustomScoringRule(
+            name=name.strip(),
+            pattern=pattern,
+            weight=weight,
+            enabled=bool(enabled),
+            created_at=now,
+            updated_at=now,
+        )
+        self.session.add(row)
+        self._commit()
+        logger.debug("Custom scoring rule %d created: %s", row.id, row.name)
+        return self._to_dict(row)
+
+    def update_rule(
+        self,
+        rule_id: int,
+        name: str,
+        pattern: str,
+        weight: int,
+        enabled: bool,
+    ) -> dict | None:
+        """Full update of a rule. Returns None if the id is unknown."""
+        row = self.session.get(CustomScoringRule, rule_id)
+        if row is None:
+            return None
+        validate_rule_fields(name, pattern, weight)
+        row.name = name.strip()
+        row.pattern = pattern
+        row.weight = weight
+        row.enabled = bool(enabled)
+        row.updated_at = self._now()
+        self._commit()
+        logger.debug("Custom scoring rule %d updated", rule_id)
+        return self._to_dict(row)
+
+    def delete_rule(self, rule_id: int) -> bool:
+        """Delete a rule. Returns False if the id is unknown."""
+        row = self.session.get(CustomScoringRule, rule_id)
+        if row is None:
+            return False
+        self.session.delete(row)
+        self._commit()
+        logger.debug("Custom scoring rule %d deleted", rule_id)
+        return True

--- a/backend/routes/hooks/scoring.py
+++ b/backend/routes/hooks/scoring.py
@@ -575,3 +575,189 @@ def update_release_group_tiers():
 
     invalidate_response_cache()
     return jsonify(config)
+
+
+# ---- Custom regex scoring rule endpoints -------------------------------------
+
+
+@bp.route("/scoring/custom-rules", methods=["GET"])
+def list_custom_rules():
+    """Return all user-defined regex scoring rules.
+    ---
+    get:
+      security:
+        - apiKeyAuth: []
+      tags:
+        - Events
+      summary: List custom scoring rules
+      description: >-
+        Returns every user-defined regex rule. Enabled rules are matched
+        case-insensitively against a candidate's release_info during
+        penalty-pipeline scoring; a hit adds the signed weight.
+      responses:
+        200:
+          description: Custom rules list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  rules:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id: { type: integer }
+                        name: { type: string }
+                        pattern: { type: string }
+                        weight: { type: integer }
+                        enabled: { type: boolean }
+    """
+    from db.repositories.custom_rules import CustomScoringRuleRepository
+
+    return jsonify({"rules": CustomScoringRuleRepository().list_rules()})
+
+
+def _parse_custom_rule_payload(data: dict) -> tuple[str, str, int, bool]:
+    """Extract (name, pattern, weight, enabled) from a request body.
+
+    Raises ``ValueError`` for non-integer weight; field validation proper
+    happens in the repository.
+    """
+    name = data.get("name", "")
+    pattern = data.get("pattern", "")
+    weight = data.get("weight", 0)
+    if isinstance(weight, str) and weight.strip().lstrip("-").isdigit():
+        weight = int(weight)
+    enabled = bool(data.get("enabled", True))
+    return name, pattern, weight, enabled
+
+
+@bp.route("/scoring/custom-rules", methods=["POST"])
+def create_custom_rule():
+    """Create a custom regex scoring rule.
+    ---
+    post:
+      security:
+        - apiKeyAuth: []
+      tags:
+        - Events
+      summary: Create a custom scoring rule
+      description: >-
+        Validates the regex (must compile, max 500 chars) and weight
+        (-999..999) and inserts the rule. At most 200 rules are allowed.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name: { type: string }
+                pattern: { type: string }
+                weight: { type: integer }
+                enabled: { type: boolean }
+      responses:
+        200:
+          description: Created rule
+        400:
+          description: Invalid name, pattern, or weight
+    """
+    from db.repositories.custom_rules import CustomScoringRuleRepository
+    from wanted_search.penalty_rules import invalidate_custom_rules_cache
+
+    data = request.get_json(silent=True) or {}
+    try:
+        name, pattern, weight, enabled = _parse_custom_rule_payload(data)
+        rule = CustomScoringRuleRepository().create_rule(name, pattern, weight, enabled)
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
+
+    invalidate_custom_rules_cache()
+    invalidate_response_cache()
+    return jsonify(rule)
+
+
+@bp.route("/scoring/custom-rules/<int:rule_id>", methods=["PUT"])
+def update_custom_rule(rule_id: int):
+    """Update a custom regex scoring rule.
+    ---
+    put:
+      security:
+        - apiKeyAuth: []
+      tags:
+        - Events
+      summary: Update a custom scoring rule
+      parameters:
+        - in: path
+          name: rule_id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name: { type: string }
+                pattern: { type: string }
+                weight: { type: integer }
+                enabled: { type: boolean }
+      responses:
+        200:
+          description: Updated rule
+        400:
+          description: Invalid name, pattern, or weight
+        404:
+          description: Unknown rule id
+    """
+    from db.repositories.custom_rules import CustomScoringRuleRepository
+    from wanted_search.penalty_rules import invalidate_custom_rules_cache
+
+    data = request.get_json(silent=True) or {}
+    try:
+        name, pattern, weight, enabled = _parse_custom_rule_payload(data)
+        rule = CustomScoringRuleRepository().update_rule(rule_id, name, pattern, weight, enabled)
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
+    if rule is None:
+        return jsonify({"error": "unknown rule id", "id": rule_id}), 404
+
+    invalidate_custom_rules_cache()
+    invalidate_response_cache()
+    return jsonify(rule)
+
+
+@bp.route("/scoring/custom-rules/<int:rule_id>", methods=["DELETE"])
+def delete_custom_rule(rule_id: int):
+    """Delete a custom regex scoring rule.
+    ---
+    delete:
+      security:
+        - apiKeyAuth: []
+      tags:
+        - Events
+      summary: Delete a custom scoring rule
+      parameters:
+        - in: path
+          name: rule_id
+          required: true
+          schema:
+            type: integer
+      responses:
+        200:
+          description: Deleted
+        404:
+          description: Unknown rule id
+    """
+    from db.repositories.custom_rules import CustomScoringRuleRepository
+    from wanted_search.penalty_rules import invalidate_custom_rules_cache
+
+    if not CustomScoringRuleRepository().delete_rule(rule_id):
+        return jsonify({"error": "unknown rule id", "id": rule_id}), 404
+
+    invalidate_custom_rules_cache()
+    invalidate_response_cache()
+    return jsonify({"id": rule_id, "deleted": True})

--- a/backend/tests/test_custom_scoring_rules.py
+++ b/backend/tests/test_custom_scoring_rules.py
@@ -1,0 +1,221 @@
+"""Tests for user-defined regex scoring rules (repo + pipeline + API)."""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _fresh_custom_rules_cache():
+    """Custom-rule pipeline cache must not leak between tests."""
+    from wanted_search.penalty_rules import invalidate_custom_rules_cache
+
+    invalidate_custom_rules_cache()
+    yield
+    invalidate_custom_rules_cache()
+
+
+def _make_candidate(**kw):
+    from providers.base import SubtitleFormat, SubtitleResult
+
+    defaults = dict(
+        provider_name="test",
+        subtitle_id="1",
+        language="de",
+        format=SubtitleFormat.ASS,
+        release_info="[Erai-raws] Show - 01 [1080p][Multiple Subtitle]",
+    )
+    defaults.update(kw)
+    return SubtitleResult(**defaults)
+
+
+def _make_query(**kw):
+    from providers.base import VideoQuery
+
+    defaults = dict(file_path="/m/S01E01.mkv", series_title="X", season=1, episode=1)
+    defaults.update(kw)
+    return VideoQuery(**defaults)
+
+
+class TestCustomScoringRuleRepository:
+    def test_create_and_list_roundtrip(self, app_ctx):
+        from db.repositories.custom_rules import CustomScoringRuleRepository
+
+        repo = CustomScoringRuleRepository()
+        rule = repo.create_rule("Prefer dual audio", r"dual[ .-]?audio", 15)
+        assert rule["id"] > 0
+        assert rule["enabled"] is True
+
+        rules = repo.list_rules()
+        assert any(r["id"] == rule["id"] for r in rules)
+
+    def test_create_rejects_invalid_regex(self, app_ctx):
+        from db.repositories.custom_rules import CustomScoringRuleRepository
+
+        with pytest.raises(ValueError, match="invalid regex"):
+            CustomScoringRuleRepository().create_rule("bad", "[unclosed", 10)
+
+    def test_create_rejects_empty_name_and_pattern(self, app_ctx):
+        from db.repositories.custom_rules import CustomScoringRuleRepository
+
+        repo = CustomScoringRuleRepository()
+        with pytest.raises(ValueError):
+            repo.create_rule("  ", "x", 10)
+        with pytest.raises(ValueError):
+            repo.create_rule("ok", "", 10)
+
+    def test_create_rejects_weight_out_of_range(self, app_ctx):
+        from db.repositories.custom_rules import CustomScoringRuleRepository
+
+        with pytest.raises(ValueError):
+            CustomScoringRuleRepository().create_rule("x", "y", 1000)
+
+    def test_update_and_delete(self, app_ctx):
+        from db.repositories.custom_rules import CustomScoringRuleRepository
+
+        repo = CustomScoringRuleRepository()
+        rule = repo.create_rule("orig", "orig", 5)
+        updated = repo.update_rule(rule["id"], "renamed", "new", -20, False)
+        assert updated["name"] == "renamed"
+        assert updated["weight"] == -20
+        assert updated["enabled"] is False
+
+        assert repo.delete_rule(rule["id"]) is True
+        assert repo.delete_rule(rule["id"]) is False
+
+    def test_update_unknown_id_returns_none(self, app_ctx):
+        from db.repositories.custom_rules import CustomScoringRuleRepository
+
+        assert CustomScoringRuleRepository().update_rule(99999, "x", "y", 1, True) is None
+
+    def test_list_enabled_only_filters(self, app_ctx):
+        from db.repositories.custom_rules import CustomScoringRuleRepository
+
+        repo = CustomScoringRuleRepository()
+        on = repo.create_rule("on", "aaa", 5, enabled=True)
+        off = repo.create_rule("off", "bbb", 5, enabled=False)
+        enabled_ids = {r["id"] for r in repo.list_rules(enabled_only=True)}
+        assert on["id"] in enabled_ids
+        assert off["id"] not in enabled_ids
+
+
+class TestApplyCustomRegexRules:
+    def test_matching_rule_contributes_weight(self, app_ctx):
+        from db.repositories.custom_rules import CustomScoringRuleRepository
+        from wanted_search.penalty_rules import apply_custom_regex_rules
+
+        rule = CustomScoringRuleRepository().create_rule("erai", r"erai[- ]?raws", 25)
+        breakdown = apply_custom_regex_rules(_make_candidate(), _make_query())
+        assert breakdown.get(f"custom_{rule['id']}") == 25
+
+    def test_non_matching_rule_is_absent(self, app_ctx):
+        from db.repositories.custom_rules import CustomScoringRuleRepository
+        from wanted_search.penalty_rules import apply_custom_regex_rules
+
+        CustomScoringRuleRepository().create_rule("nope", r"commie", 25)
+        assert apply_custom_regex_rules(_make_candidate(), _make_query()) == {}
+
+    def test_disabled_rule_is_skipped(self, app_ctx):
+        from db.repositories.custom_rules import CustomScoringRuleRepository
+        from wanted_search.penalty_rules import apply_custom_regex_rules
+
+        CustomScoringRuleRepository().create_rule("off", r"erai", -50, enabled=False)
+        assert apply_custom_regex_rules(_make_candidate(), _make_query()) == {}
+
+    def test_match_is_case_insensitive(self, app_ctx):
+        from db.repositories.custom_rules import CustomScoringRuleRepository
+        from wanted_search.penalty_rules import apply_custom_regex_rules
+
+        rule = CustomScoringRuleRepository().create_rule("caps", r"MULTIPLE SUBTITLE", 5)
+        breakdown = apply_custom_regex_rules(_make_candidate(), _make_query())
+        assert f"custom_{rule['id']}" in breakdown
+
+    def test_negative_weight_penalty(self, app_ctx):
+        from db.repositories.custom_rules import CustomScoringRuleRepository
+        from wanted_search.penalty_rules import apply_custom_regex_rules
+
+        rule = CustomScoringRuleRepository().create_rule("no-1080", r"1080p", -30)
+        breakdown = apply_custom_regex_rules(_make_candidate(), _make_query())
+        assert breakdown[f"custom_{rule['id']}"] == -30
+
+    def test_empty_release_info_matches_nothing(self, app_ctx):
+        from db.repositories.custom_rules import CustomScoringRuleRepository
+        from wanted_search.penalty_rules import apply_custom_regex_rules
+
+        CustomScoringRuleRepository().create_rule("any", r".*", 5)
+        assert apply_custom_regex_rules(_make_candidate(release_info=""), _make_query()) == {}
+
+    def test_pipeline_includes_custom_entries(self, app_ctx):
+        from db.repositories.custom_rules import CustomScoringRuleRepository
+        from wanted_search.penalty_rules import apply_penalty_pipeline
+
+        rule = CustomScoringRuleRepository().create_rule("erai", r"erai", 25)
+        breakdown = apply_penalty_pipeline(_make_candidate(), _make_query())
+        assert breakdown.get(f"custom_{rule['id']}") == 25
+
+    def test_cache_invalidation_picks_up_new_rules(self, app_ctx):
+        from db.repositories.custom_rules import CustomScoringRuleRepository
+        from wanted_search.penalty_rules import (
+            apply_custom_regex_rules,
+            invalidate_custom_rules_cache,
+        )
+
+        # Prime the cache with no rules
+        assert apply_custom_regex_rules(_make_candidate(), _make_query()) == {}
+
+        rule = CustomScoringRuleRepository().create_rule("erai", r"erai", 25)
+        # Still cached-empty until invalidated
+        assert apply_custom_regex_rules(_make_candidate(), _make_query()) == {}
+
+        invalidate_custom_rules_cache()
+        breakdown = apply_custom_regex_rules(_make_candidate(), _make_query())
+        assert breakdown.get(f"custom_{rule['id']}") == 25
+
+
+class TestCustomRuleRoutes:
+    def test_list_initially_empty(self, client):
+        r = client.get("/api/v1/scoring/custom-rules")
+        assert r.status_code == 200
+        assert r.get_json() == {"rules": []}
+
+    def test_create_list_update_delete_lifecycle(self, client):
+        r = client.post(
+            "/api/v1/scoring/custom-rules",
+            json={"name": "Dual audio", "pattern": r"dual[ .-]?audio", "weight": 15},
+        )
+        assert r.status_code == 200
+        rule = r.get_json()
+        assert rule["enabled"] is True
+
+        r = client.get("/api/v1/scoring/custom-rules")
+        assert len(r.get_json()["rules"]) == 1
+
+        r = client.put(
+            f"/api/v1/scoring/custom-rules/{rule['id']}",
+            json={"name": "Dual audio", "pattern": r"dual", "weight": -5, "enabled": False},
+        )
+        assert r.status_code == 200
+        assert r.get_json()["weight"] == -5
+        assert r.get_json()["enabled"] is False
+
+        r = client.delete(f"/api/v1/scoring/custom-rules/{rule['id']}")
+        assert r.status_code == 200
+        r = client.get("/api/v1/scoring/custom-rules")
+        assert r.get_json() == {"rules": []}
+
+    def test_create_rejects_invalid_regex(self, client):
+        r = client.post(
+            "/api/v1/scoring/custom-rules",
+            json={"name": "bad", "pattern": "[unclosed", "weight": 10},
+        )
+        assert r.status_code == 400
+        assert "invalid regex" in r.get_json()["error"]
+
+    def test_update_unknown_id_404(self, client):
+        r = client.put(
+            "/api/v1/scoring/custom-rules/424242",
+            json={"name": "x", "pattern": "y", "weight": 1},
+        )
+        assert r.status_code == 404
+
+    def test_delete_unknown_id_404(self, client):
+        r = client.delete("/api/v1/scoring/custom-rules/424242")
+        assert r.status_code == 404

--- a/backend/wanted_search/penalty_rules.py
+++ b/backend/wanted_search/penalty_rules.py
@@ -133,6 +133,78 @@ _RULE_SUPERSEDES: dict[str, tuple[str, ...]] = {
 }
 
 
+# Custom regex rules — user-defined Sonarr-style release-profile conditions
+# stored in the ``custom_scoring_rules`` table. Compiled patterns are cached
+# with the same 60 s TTL as rule-weight overrides; the CRUD routes call
+# ``invalidate_custom_rules_cache()`` so edits apply immediately.
+#
+# Matching input is capped to bound worst-case regex backtracking on
+# adversarial provider strings.
+_CUSTOM_RULES_CACHE_TTL = 60  # seconds
+_MAX_MATCH_INPUT_LEN = 300
+_custom_rules_cache: dict = {"data": None, "expires": 0.0}
+_custom_rules_cache_lock = threading.Lock()
+
+
+def _get_cached_custom_rules() -> list[tuple[int, re.Pattern, int]]:
+    """Return enabled custom rules as ``[(id, compiled_pattern, weight)]``.
+
+    Falls back to an empty list on any DB error; rules whose pattern no
+    longer compiles (edited DB row, downgrade artifacts) are skipped.
+    """
+    with _custom_rules_cache_lock:
+        now = time.time()
+        cached = _custom_rules_cache["data"]
+        if cached is not None and now < _custom_rules_cache["expires"]:
+            return cached
+
+        compiled: list[tuple[int, re.Pattern, int]] = []
+        try:
+            from db.repositories.custom_rules import CustomScoringRuleRepository
+
+            for rule in CustomScoringRuleRepository().list_rules(enabled_only=True):
+                try:
+                    compiled.append(
+                        (rule["id"], re.compile(rule["pattern"], re.IGNORECASE), rule["weight"])
+                    )
+                except re.error:
+                    logger.warning(
+                        "Custom scoring rule %d has invalid pattern; skipped", rule["id"]
+                    )
+        except Exception:
+            logger.debug("Custom rule load failed", exc_info=True)
+
+        _custom_rules_cache["data"] = compiled
+        _custom_rules_cache["expires"] = now + _CUSTOM_RULES_CACHE_TTL
+        return compiled
+
+
+def invalidate_custom_rules_cache() -> None:
+    """Clear the custom-rule cache so the next pipeline call reloads from the DB."""
+    with _custom_rules_cache_lock:
+        _custom_rules_cache["data"] = None
+        _custom_rules_cache["expires"] = 0.0
+
+
+def apply_custom_regex_rules(candidate: SubtitleResult, query: VideoQuery) -> dict[str, int]:
+    """Apply user-defined regex rules to the candidate's release_info.
+
+    Returns ``{"custom_<id>": weight}`` entries for every matching enabled
+    rule. Pure function — does not mutate the candidate.
+    """
+    breakdown: dict[str, int] = {}
+    info = (candidate.release_info or "")[:_MAX_MATCH_INPUT_LEN]
+    if not info:
+        return breakdown
+    for rule_id, pattern, weight in _get_cached_custom_rules():
+        try:
+            if weight != 0 and pattern.search(info):
+                breakdown[f"custom_{rule_id}"] = int(weight)
+        except Exception as e:
+            logger.warning("Custom scoring rule %d raised: %s", rule_id, e)
+    return breakdown
+
+
 def apply_penalty_pipeline(
     candidate: SubtitleResult,
     query: VideoQuery,
@@ -152,6 +224,9 @@ def apply_penalty_pipeline(
     4. Call ``rule.weight(candidate, query)``. If the rule returned its
        own ``default_weight`` (the simple path), scale by the configured
        override; otherwise keep the dynamic value the rule computed.
+
+    User-defined custom regex rules (``custom_scoring_rules`` table) run
+    after the registry rules and contribute ``custom_<id>`` entries.
     """
     breakdown: dict[str, int] = {}
 
@@ -173,6 +248,8 @@ def apply_penalty_pipeline(
             breakdown[rule_cls.rule_id] = int(applied)
         except Exception as e:
             logger.warning("Penalty rule %s raised: %s", rule_cls.rule_id, e)
+
+    breakdown.update(apply_custom_regex_rules(candidate, query))
 
     return breakdown
 

--- a/frontend/src/api/settings.ts
+++ b/frontend/src/api/settings.ts
@@ -126,6 +126,30 @@ export const getReleaseGroupTiers = (): Promise<ReleaseGroupTiers> =>
 export const updateReleaseGroupTiers = (data: ReleaseGroupTiers): Promise<ReleaseGroupTiers> =>
   api.put('/scoring/release-group-tiers', data).then(r => r.data)
 
+// ─── Custom regex scoring rules ─────────────────────────────────────────────
+
+export interface CustomScoringRule {
+  id: number
+  name: string
+  pattern: string
+  weight: number
+  enabled: boolean
+}
+
+export type CustomScoringRuleInput = Omit<CustomScoringRule, 'id'>
+
+export const getCustomScoringRules = (): Promise<{ rules: CustomScoringRule[] }> =>
+  api.get('/scoring/custom-rules').then(r => r.data)
+
+export const createCustomScoringRule = (data: CustomScoringRuleInput): Promise<CustomScoringRule> =>
+  api.post('/scoring/custom-rules', data).then(r => r.data)
+
+export const updateCustomScoringRule = (id: number, data: CustomScoringRuleInput): Promise<CustomScoringRule> =>
+  api.put(`/scoring/custom-rules/${id}`, data).then(r => r.data)
+
+export const deleteCustomScoringRule = (id: number): Promise<{ id: number; deleted: boolean }> =>
+  api.delete(`/scoring/custom-rules/${id}`).then(r => r.data)
+
 // ─── Media Servers ──────────────────────────────────────────────────────────
 
 export async function getMediaServerTypes(): Promise<MediaServerType[]> {

--- a/frontend/src/hooks/useProvidersApi.ts
+++ b/frontend/src/hooks/useProvidersApi.ts
@@ -6,6 +6,7 @@ import {
   getScoringPresets, importScoringPreset,
   getPenaltyRules, updatePenaltyRule,
   getReleaseGroupTiers, updateReleaseGroupTiers,
+  getCustomScoringRules, createCustomScoringRule, updateCustomScoringRule, deleteCustomScoringRule,
   getBlacklist, addToBlacklist, removeFromBlacklist, clearBlacklist,
   getLanguageProfiles, createLanguageProfile, updateLanguageProfile,
   deleteLanguageProfile, assignProfile, bulkAssignProfile, setProfileAsDefaultForAll,
@@ -14,6 +15,7 @@ import {
   searchInteractive, searchInteractiveEpisode,
 } from '@/api/client'
 import type { LanguageProfile } from '@/lib/types'
+import type { CustomScoringRule } from '@/api/settings'
 
 // ─── Providers ───────────────────────────────────────────────────────────────
 
@@ -135,6 +137,36 @@ export function useUpdateReleaseGroupTiers() {
   return useMutation({
     mutationFn: updateReleaseGroupTiers,
     onSuccess: () => { void qc.invalidateQueries({ queryKey: ['releaseGroupTiers'] }) },
+  })
+}
+
+// ─── Custom regex scoring rules ──────────────────────────────────────────────
+
+export function useCustomScoringRules() {
+  return useQuery({ queryKey: ['customScoringRules'], queryFn: getCustomScoringRules })
+}
+
+export function useCreateCustomScoringRule() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: createCustomScoringRule,
+    onSuccess: () => { void qc.invalidateQueries({ queryKey: ['customScoringRules'] }) },
+  })
+}
+
+export function useUpdateCustomScoringRule() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, ...data }: CustomScoringRule) => updateCustomScoringRule(id, data),
+    onSuccess: () => { void qc.invalidateQueries({ queryKey: ['customScoringRules'] }) },
+  })
+}
+
+export function useDeleteCustomScoringRule() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: deleteCustomScoringRule,
+    onSuccess: () => { void qc.invalidateQueries({ queryKey: ['customScoringRules'] }) },
   })
 }
 

--- a/frontend/src/i18n/locales/de/settings.json
+++ b/frontend/src/i18n/locales/de/settings.json
@@ -2197,6 +2197,23 @@
     "toast_save_failed": "Rangliste konnte nicht gespeichert werden",
     "toast_duplicate": "„{{name}}“ ist bereits in der Liste"
   },
+  "scoring_custom": {
+    "title": "Eigene Regex-Regeln",
+    "loading": "Regeln werden geladen...",
+    "section_desc": "Eigene Scoring-Bedingungen im Sonarr-Stil: Der Regex jeder Regel wird (case-insensitiv) gegen die Release-Info eines Ergebnisses geprüft; ein Treffer addiert das Gewicht der Regel zum Score. Negative Gewichte bestrafen.",
+    "empty": "Noch keine eigenen Regeln. Füge unten eine hinzu — z. B. Muster \"dual[ .-]?audio\" mit Gewicht +15.",
+    "name_placeholder": "Regelname",
+    "pattern_placeholder": "Regex, z. B. dual[ .-]?audio",
+    "add": "Hinzufügen",
+    "toggle": "Regel aktivieren/deaktivieren",
+    "delete": "Regel löschen",
+    "hint": "Muster werden beim Speichern validiert (max. 500 Zeichen). Gewichtsbereich: -999 bis 999; -999 entfernt ein Ergebnis faktisch.",
+    "toast_created": "Eigene Regel erstellt",
+    "toast_create_failed": "Regel konnte nicht erstellt werden",
+    "toast_update_failed": "Regel konnte nicht aktualisiert werden",
+    "toast_deleted": "Regel \"{{name}}\" gelöscht",
+    "toast_delete_failed": "Regel konnte nicht gelöscht werden"
+  },
   "glossary_panel": {
     "toast_setting_saved": "Glossar-Einstellung gespeichert",
     "toast_save_failed": "Speichern der Einstellung fehlgeschlagen",

--- a/frontend/src/i18n/locales/en/settings.json
+++ b/frontend/src/i18n/locales/en/settings.json
@@ -2197,6 +2197,23 @@
     "toast_save_failed": "Failed to save release group tiers",
     "toast_duplicate": "\"{{name}}\" is already in the list"
   },
+  "scoring_custom": {
+    "title": "Custom Regex Rules",
+    "loading": "Loading rules...",
+    "section_desc": "Your own scoring conditions, Sonarr-style: each rule's regex is matched (case-insensitive) against a result's release info; a hit adds the rule's weight to the score. Negative weights penalize.",
+    "empty": "No custom rules yet. Add one below — e.g. pattern \"dual[ .-]?audio\" with weight +15.",
+    "name_placeholder": "Rule name",
+    "pattern_placeholder": "Regex, e.g. dual[ .-]?audio",
+    "add": "Add",
+    "toggle": "Enable/disable rule",
+    "delete": "Delete rule",
+    "hint": "Patterns are validated when saving (max 500 chars). Weight range: -999 to 999; -999 effectively removes a result.",
+    "toast_created": "Custom rule created",
+    "toast_create_failed": "Failed to create rule",
+    "toast_update_failed": "Failed to update rule",
+    "toast_deleted": "Rule \"{{name}}\" deleted",
+    "toast_delete_failed": "Failed to delete rule"
+  },
   "glossary_panel": {
     "toast_setting_saved": "Glossary setting saved",
     "toast_save_failed": "Failed to save setting",

--- a/frontend/src/pages/Settings/ScoringCustomRules.tsx
+++ b/frontend/src/pages/Settings/ScoringCustomRules.tsx
@@ -1,0 +1,215 @@
+/**
+ * ScoringCustomRules — user-defined regex scoring rules.
+ *
+ * Sonarr-style release-profile conditions: each rule's regex is matched
+ * case-insensitively against a candidate's release_info during scoring;
+ * a hit adds the rule's signed weight to the score.
+ */
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Loader2, Plus, Trash2 } from 'lucide-react'
+
+import { SettingsSection } from '@/components/settings/SettingsSection'
+import { toast } from '@/components/shared/Toast'
+import type { CustomScoringRule } from '@/api/settings'
+import {
+  useCreateCustomScoringRule,
+  useCustomScoringRules,
+  useDeleteCustomScoringRule,
+  useUpdateCustomScoringRule,
+} from '@/hooks/useApi'
+import { settingsInputStyle } from '@/styles/settingsShared'
+
+const inputStyle: React.CSSProperties = { ...settingsInputStyle, outline: 'none' }
+
+function extractApiError(err: unknown): string | null {
+  if (typeof err === 'object' && err !== null && 'response' in err) {
+    const resp = (err as { response?: { data?: { error?: string } } }).response
+    return resp?.data?.error ?? null
+  }
+  return null
+}
+
+export function ScoringCustomRules() {
+  const { t: tc } = useTranslation('common')
+  const { data, isLoading } = useCustomScoringRules()
+  const createRule = useCreateCustomScoringRule()
+  const updateRule = useUpdateCustomScoringRule()
+  const deleteRule = useDeleteCustomScoringRule()
+
+  const [name, setName] = useState('')
+  const [pattern, setPattern] = useState('')
+  const [weight, setWeight] = useState(10)
+
+  if (isLoading) {
+    return (
+      <SettingsSection
+        title={tc('settings:scoring_custom.title')}
+        description={tc('settings:scoring_custom.loading')}
+      >
+        <Loader2 size={14} className="animate-spin" />
+      </SettingsSection>
+    )
+  }
+
+  const rules: CustomScoringRule[] = data?.rules ?? []
+
+  const handleAdd = () => {
+    createRule.mutate(
+      { name: name.trim(), pattern, weight, enabled: true },
+      {
+        onSuccess: () => {
+          setName('')
+          setPattern('')
+          setWeight(10)
+          toast(tc('settings:scoring_custom.toast_created'))
+        },
+        onError: (err) =>
+          toast(
+            extractApiError(err) ?? tc('settings:scoring_custom.toast_create_failed'),
+            'error',
+          ),
+      },
+    )
+  }
+
+  const handleToggle = (rule: CustomScoringRule) => {
+    updateRule.mutate(
+      { ...rule, enabled: !rule.enabled },
+      {
+        onError: () => toast(tc('settings:scoring_custom.toast_update_failed'), 'error'),
+      },
+    )
+  }
+
+  const handleDelete = (rule: CustomScoringRule) => {
+    deleteRule.mutate(rule.id, {
+      onSuccess: () => toast(tc('settings:scoring_custom.toast_deleted', { name: rule.name })),
+      onError: () => toast(tc('settings:scoring_custom.toast_delete_failed'), 'error'),
+    })
+  }
+
+  const canAdd = name.trim().length > 0 && pattern.trim().length > 0
+
+  return (
+    <SettingsSection
+      title={tc('settings:scoring_custom.title')}
+      description={tc('settings:scoring_custom.section_desc')}
+    >
+      {rules.length === 0 && (
+        <p style={{ fontSize: 12, color: 'var(--text-muted)', padding: '8px 0' }}>
+          {tc('settings:scoring_custom.empty')}
+        </p>
+      )}
+
+      {rules.map((rule) => (
+        <div
+          key={rule.id}
+          data-testid={`custom-rule-row-${rule.id}`}
+          style={{
+            display: 'flex', alignItems: 'center', gap: 10,
+            padding: '6px 0', borderBottom: '1px solid var(--border)',
+            opacity: rule.enabled ? 1 : 0.55,
+          }}
+        >
+          <input
+            type="checkbox"
+            checked={rule.enabled}
+            data-testid={`custom-rule-toggle-${rule.id}`}
+            aria-label={tc('settings:scoring_custom.toggle')}
+            onChange={() => handleToggle(rule)}
+            style={{ accentColor: 'var(--accent)' }}
+          />
+          <span style={{ flex: '0 1 160px', fontSize: 13, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            {rule.name}
+          </span>
+          <code
+            style={{
+              flex: 1, fontSize: 11, color: 'var(--text-muted)',
+              fontFamily: 'var(--font-mono, monospace)',
+              overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+            }}
+            title={rule.pattern}
+          >
+            {rule.pattern}
+          </code>
+          <span
+            style={{
+              fontSize: 11, fontFamily: 'var(--font-mono, monospace)', whiteSpace: 'nowrap',
+              color: rule.weight > 0 ? 'var(--success)' : rule.weight < 0 ? 'var(--error)' : 'var(--text-muted)',
+            }}
+          >
+            {rule.weight > 0 ? `+${rule.weight}` : rule.weight}
+          </span>
+          <button
+            aria-label={tc('settings:scoring_custom.delete')}
+            data-testid={`custom-rule-delete-${rule.id}`}
+            onClick={() => handleDelete(rule)}
+            style={{
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              width: 24, height: 24, borderRadius: 5, padding: 0,
+              background: 'var(--bg-surface)', border: '1px solid var(--border)',
+              color: 'var(--error)', cursor: 'pointer',
+            }}
+          >
+            <Trash2 size={12} />
+          </button>
+        </div>
+      ))}
+
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 10, flexWrap: 'wrap' }}>
+        <input
+          type="text"
+          value={name}
+          data-testid="input-custom-rule-name"
+          placeholder={tc('settings:scoring_custom.name_placeholder')}
+          maxLength={100}
+          onChange={(e) => setName(e.target.value)}
+          style={{ ...inputStyle, width: 150 }}
+        />
+        <input
+          type="text"
+          value={pattern}
+          data-testid="input-custom-rule-pattern"
+          placeholder={tc('settings:scoring_custom.pattern_placeholder')}
+          maxLength={500}
+          onChange={(e) => setPattern(e.target.value)}
+          style={{ ...inputStyle, flex: 1, minWidth: 160, fontFamily: 'var(--font-mono, monospace)' }}
+        />
+        <input
+          type="number"
+          value={weight}
+          min={-999}
+          max={999}
+          data-testid="input-custom-rule-weight"
+          onChange={(e) => {
+            const n = parseInt(e.target.value, 10)
+            if (!isNaN(n)) setWeight(Math.max(-999, Math.min(999, n)))
+          }}
+          style={{ ...inputStyle, width: 72, textAlign: 'right', fontFamily: 'var(--font-mono, monospace)' }}
+        />
+        <button
+          data-testid="btn-custom-rule-add"
+          onClick={handleAdd}
+          disabled={!canAdd || createRule.isPending}
+          style={{
+            display: 'flex', alignItems: 'center', gap: 4,
+            padding: '4px 10px', borderRadius: 6, fontSize: 11, fontWeight: 500,
+            background: canAdd ? 'var(--accent)' : 'var(--bg-surface)',
+            color: canAdd ? '#fff' : 'var(--text-muted)',
+            border: canAdd ? 'none' : '1px solid var(--border)',
+            cursor: canAdd ? 'pointer' : 'default',
+            opacity: createRule.isPending ? 0.6 : 1,
+          }}
+        >
+          {createRule.isPending ? <Loader2 size={11} className="animate-spin" /> : <Plus size={11} />}
+          {tc('settings:scoring_custom.add')}
+        </button>
+      </div>
+
+      <p style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 8 }}>
+        {tc('settings:scoring_custom.hint')}
+      </p>
+    </SettingsSection>
+  )
+}

--- a/frontend/src/pages/Settings/ScoringTab.tsx
+++ b/frontend/src/pages/Settings/ScoringTab.tsx
@@ -25,6 +25,7 @@ import type { ScoringWeights, ScoringPreset } from '@/lib/types'
 import { settingsInputStyle } from '@/styles/settingsShared'
 import { ScoringPenaltyRules } from './ScoringPenaltyRules'
 import { ScoringReleaseGroupTiers } from './ScoringReleaseGroupTiers'
+import { ScoringCustomRules } from './ScoringCustomRules'
 
 const inputStyle: React.CSSProperties = { ...settingsInputStyle, outline: 'none' }
 
@@ -444,6 +445,9 @@ export function ScoringTab() {
 
       {/* ── 4b. Release-Group Tiers ────────────────────────────────────── */}
       <ScoringReleaseGroupTiers />
+
+      {/* ── 4c. Custom Regex Rules ─────────────────────────────────────── */}
+      <ScoringCustomRules />
 
       {/* ── 5. Advanced ────────────────────────────────────────────────── */}
       <div

--- a/frontend/src/pages/Settings/__tests__/ScoringCustomRules.test.tsx
+++ b/frontend/src/pages/Settings/__tests__/ScoringCustomRules.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ScoringCustomRules } from '../ScoringCustomRules'
+import type { CustomScoringRule } from '@/api/settings'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key.split('.').pop() ?? key,
+    i18n: { language: 'en', changeLanguage: vi.fn() },
+  }),
+}))
+
+const mockCreate = vi.fn()
+const mockUpdate = vi.fn()
+const mockDelete = vi.fn()
+let mockRules: CustomScoringRule[] = []
+
+vi.mock('@/hooks/useApi', () => ({
+  useCustomScoringRules: () => ({ data: { rules: mockRules }, isLoading: false }),
+  useCreateCustomScoringRule: () => ({ mutate: mockCreate, isPending: false }),
+  useUpdateCustomScoringRule: () => ({ mutate: mockUpdate, isPending: false }),
+  useDeleteCustomScoringRule: () => ({ mutate: mockDelete, isPending: false }),
+}))
+
+vi.mock('@/components/shared/Toast', () => ({ toast: vi.fn() }))
+
+const RULE: CustomScoringRule = {
+  id: 1,
+  name: 'Dual audio',
+  pattern: 'dual[ .-]?audio',
+  weight: 15,
+  enabled: true,
+}
+
+describe('ScoringCustomRules', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockRules = []
+  })
+
+  it('shows the empty state when no rules exist', () => {
+    render(<ScoringCustomRules />)
+    expect(screen.getByText('empty')).toBeInTheDocument()
+  })
+
+  it('renders rule rows with name, pattern, and weight', () => {
+    mockRules = [RULE]
+    render(<ScoringCustomRules />)
+    expect(screen.getByText('Dual audio')).toBeInTheDocument()
+    expect(screen.getByText('dual[ .-]?audio')).toBeInTheDocument()
+    expect(screen.getByText('+15')).toBeInTheDocument()
+  })
+
+  it('creates a rule from the add form', () => {
+    render(<ScoringCustomRules />)
+    fireEvent.change(screen.getByTestId('input-custom-rule-name'), { target: { value: 'Uncensored' } })
+    fireEvent.change(screen.getByTestId('input-custom-rule-pattern'), { target: { value: 'uncensored' } })
+    fireEvent.change(screen.getByTestId('input-custom-rule-weight'), { target: { value: '20' } })
+    fireEvent.click(screen.getByTestId('btn-custom-rule-add'))
+    expect(mockCreate).toHaveBeenCalledWith(
+      { name: 'Uncensored', pattern: 'uncensored', weight: 20, enabled: true },
+      expect.anything(),
+    )
+  })
+
+  it('disables the add button when name or pattern is empty', () => {
+    render(<ScoringCustomRules />)
+    expect(screen.getByTestId('btn-custom-rule-add')).toBeDisabled()
+  })
+
+  it('toggles a rule enabled state', () => {
+    mockRules = [RULE]
+    render(<ScoringCustomRules />)
+    fireEvent.click(screen.getByTestId('custom-rule-toggle-1'))
+    expect(mockUpdate).toHaveBeenCalledWith({ ...RULE, enabled: false }, expect.anything())
+  })
+
+  it('deletes a rule', () => {
+    mockRules = [RULE]
+    render(<ScoringCustomRules />)
+    fireEvent.click(screen.getByTestId('custom-rule-delete-1'))
+    expect(mockDelete).toHaveBeenCalledWith(1, expect.anything())
+  })
+})

--- a/frontend/src/pages/Settings/__tests__/ScoringTab.test.tsx
+++ b/frontend/src/pages/Settings/__tests__/ScoringTab.test.tsx
@@ -58,6 +58,11 @@ vi.mock('@/hooks/useApi', () => ({
   // Release-group tiers hooks consumed by ScoringReleaseGroupTiers section
   useReleaseGroupTiers: () => ({ data: { tiers: [], step: 10 }, isLoading: false }),
   useUpdateReleaseGroupTiers: () => ({ mutate: vi.fn(), isPending: false }),
+  // Custom regex rule hooks consumed by ScoringCustomRules section
+  useCustomScoringRules: () => ({ data: { rules: [] }, isLoading: false }),
+  useCreateCustomScoringRule: () => ({ mutate: vi.fn(), isPending: false }),
+  useUpdateCustomScoringRule: () => ({ mutate: vi.fn(), isPending: false }),
+  useDeleteCustomScoringRule: () => ({ mutate: vi.fn(), isPending: false }),
 }))
 
 vi.mock('@/components/shared/Toast', () => ({ toast: vi.fn() }))


### PR DESCRIPTION
## Was ist neu

**Nutzerdefinierte Regex-Scoring-Regeln** im Stil der Sonarr-Release-Profile: Jede Regel enthält einen Regex, der case-insensitiv gegen die `release_info` eines Kandidaten geprüft wird; ein Treffer addiert das signierte Gewicht der Regel (−999…999) zum Score. Regeln lassen sich per Toggle deaktivieren, ohne sie zu löschen. Beispiele: `dual[ .-]?audio` → +15, `\bMTL\b` → −100, `uncensored` → +20.

> **Stacked PR:** basiert auf #164 (Release-Group-Tiers). Bitte #164 zuerst mergen — diese Basis wird von GitHub danach automatisch auf `master` umgestellt.

## Umsetzung

- **DB** — neue Tabelle `custom_scoring_rules` (id, name, pattern, weight, enabled, Timestamps) mit `has_table`-geschützter Alembic-Migration (`f8c9d0e1a2b3`, revidiert `e7a1b2c3d4f5`) plus Modell-Export.
- **Repository** — `CustomScoringRuleRepository` mit gemeinsamer Feld-Validierung für Create/Update: Name ≤ 100 Zeichen, Pattern ≤ 500 Zeichen und muss kompilieren, Gewicht −999…999, max. 200 Regeln.
- **Pipeline** — `apply_custom_regex_rules()` läuft am Ende von `apply_penalty_pipeline()` und liefert `custom_<id>`-Breakdown-Einträge (im UI-Breakdown als `rule:custom_<id>` sichtbar). Kompilierte Patterns werden mit 60 s TTL gecacht (gleiche Vorgehensweise wie die Rule-Weight-Overrides); die CRUD-Routen invalidieren den Cache sofort. Matching-Input ist auf 300 Zeichen begrenzt, um Regex-Backtracking auf adversarialen Provider-Strings zu beschränken. Nicht mehr kompilierbare Patterns werden übersprungen und geloggt — Scoring bricht nie ab.
- **API** — `GET`/`POST /api/v1/scoring/custom-rules`, `PUT`/`DELETE /api/v1/scoring/custom-rules/<id>` mit apispec-Doku; Validierungsfehler als 400 mit konkreter Meldung (z. B. `invalid regex: missing ], unterminated subpattern`).
- **Frontend** — neue Sektion „Custom Regex Rules" unter *Settings → Scoring*: Regel-Tabelle mit Enable-Checkbox, Lösch-Button und farbcodiertem Gewicht, plus Add-Formular (Name / Regex / Gewicht). Backend-Fehlermeldungen (z. B. ungültiger Regex) werden im Toast durchgereicht. i18n en + de.

## Tests

- `backend/tests/test_custom_scoring_rules.py` — 20 Tests: Repository-CRUD inkl. Validierungsfehler, Pipeline-Anwendung (Match/No-Match/Disabled/Case-Insensitivity/negatives Gewicht/leere release_info), Cache-Invalidierung, API-Lifecycle inkl. 400/404.
- `frontend/.../ScoringCustomRules.test.tsx` — 6 Komponententests (Empty State, Zeilen-Rendering, Create, Add-Button-Gating, Toggle, Delete).
- Regressionen grün: `test_penalty_rules` + `test_penalty_pipeline_integration` (28 passed); `tsc -b` sauber, ESLint 0 Errors.

## Hinweise

- Keine Regeln vorhanden = kein Verhaltensunterschied (leerer Cache, Pipeline unverändert).
- Migration ist idempotent gegenüber `create_all()`-Installationen (Fresh Installs, Test-Harness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LufxECMqmfKf4oWD38vbxq

---
_Generated by [Claude Code](https://claude.ai/code/session_01LufxECMqmfKf4oWD38vbxq)_