### PR TITLE
feat(wanted): per-series subtitle format requirement (ASS only)

### DIFF
--- a/backend/db/migrations/versions/2026_07_30_1100-a4b5c6d7e8f9_add_subtitle_format_requirement.py
+++ b/backend/db/migrations/versions/2026_07_30_1100-a4b5c6d7e8f9_add_subtitle_format_requirement.py
@@ -1,0 +1,45 @@
+"""add subtitle_format_requirement column to series_settings
+
+Per-series subtitle format requirement. NULL means inherit the global
+behavior (ASS preferred with SRT fallback); "require_ass" means the wanted
+pipeline never falls back to SRT provider results for this series.
+
+Guarded with a column check: the schema is also created straight from the
+models via create_all() (fresh installs, the test harness), so the migration
+must be a no-op when the column is already there.
+
+Revision ID: a4b5c6d7e8f9
+Revises: f8c9d0e1a2b3
+Create Date: 2026-07-30
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "a4b5c6d7e8f9"
+down_revision = "f8c9d0e1a2b3"
+branch_labels = None
+depends_on = None
+
+_COLUMN = "subtitle_format_requirement"
+
+
+def _has_column(bind) -> bool:
+    insp = sa.inspect(bind)
+    if not insp.has_table("series_settings"):
+        return False
+    return _COLUMN in {c["name"] for c in insp.get_columns("series_settings")}
+
+
+def upgrade() -> None:
+    if _has_column(op.get_bind()):
+        return
+    with op.batch_alter_table("series_settings") as batch_op:
+        batch_op.add_column(sa.Column(_COLUMN, sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    if not _has_column(op.get_bind()):
+        return
+    with op.batch_alter_table("series_settings") as batch_op:
+        batch_op.drop_column(_COLUMN)

--- a/backend/db/models/core.py
+++ b/backend/db/models/core.py
@@ -443,6 +443,12 @@ class SeriesSettings(db.Model):
     audio_exclude_languages_override: Mapped[str | None] = mapped_column(
         Text, nullable=True, default=None
     )  # JSON array string
+    # Per-series subtitle format requirement. NULL = inherit global behavior
+    # (ASS preferred with SRT fallback). "require_ass" = never fall back to
+    # SRT provider results for this series.
+    subtitle_format_requirement: Mapped[str | None] = mapped_column(
+        Text, nullable=True, default=None
+    )
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
 
 

--- a/backend/routes/series_settings_overrides.py
+++ b/backend/routes/series_settings_overrides.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 bp = Blueprint("series_settings_overrides", __name__, url_prefix="/api/v1/series")
 
 _ALLOWED_PRIORITY = {"premium", "standard", "backlog"}
+_ALLOWED_FORMAT_REQUIREMENTS = {"require_ass"}
 _MIN_ATTEMPTS_MIN = 0
 _MIN_ATTEMPTS_MAX = 50
 
@@ -55,6 +56,19 @@ def patch_series_settings(series_id: int):
         if cv is not None and not isinstance(cv, bool):
             return jsonify({"error": "cleanup_foreign_tracks must be true, false, or null"}), 400
 
+    # Validate subtitle_format_requirement — null (inherit) or "require_ass"
+    if "subtitle_format_requirement" in data:
+        fv = data["subtitle_format_requirement"]
+        if fv is not None and fv not in _ALLOWED_FORMAT_REQUIREMENTS:
+            return jsonify(
+                {
+                    "error": (
+                        "subtitle_format_requirement must be one of "
+                        f"{sorted(_ALLOWED_FORMAT_REQUIREMENTS)} or null"
+                    )
+                }
+            ), 400
+
     now = datetime.now(UTC)
     row = db.session.get(SeriesSettings, series_id)
     if row is None:
@@ -72,6 +86,8 @@ def patch_series_settings(series_id: int):
         row.min_attempts_per_day = int(data["min_attempts_per_day"])
     if "cleanup_foreign_tracks" in data:
         row.cleanup_foreign_tracks = data["cleanup_foreign_tracks"]
+    if "subtitle_format_requirement" in data:
+        row.subtitle_format_requirement = data["subtitle_format_requirement"]
     row.updated_at = now
     db.session.commit()
 
@@ -81,5 +97,6 @@ def patch_series_settings(series_id: int):
             "priority_override": row.priority_override,
             "min_attempts_per_day": row.min_attempts_per_day,
             "cleanup_foreign_tracks": row.cleanup_foreign_tracks,
+            "subtitle_format_requirement": row.subtitle_format_requirement,
         }
     ), 200

--- a/backend/services/series_format.py
+++ b/backend/services/series_format.py
@@ -1,0 +1,35 @@
+"""Per-series subtitle format requirement lookup.
+
+``subtitle_format_requirement`` on SeriesSettings:
+  - NULL / unset — inherit the global behavior (ASS preferred, SRT fallback)
+  - "require_ass" — the wanted pipeline never falls back to SRT provider
+    results for this series
+
+Best-effort accessor in the style of ``services.foreign_track_cleanup``:
+never raises, returns None when the series has no explicit requirement.
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+REQUIRE_ASS = "require_ass"
+ALLOWED_REQUIREMENTS = (REQUIRE_ASS,)
+
+
+def get_series_format_requirement(sonarr_series_id: int | None) -> str | None:
+    """Return "require_ass" or None for the given series (None on any error)."""
+    if not sonarr_series_id:
+        return None
+    try:
+        from db.models.core import SeriesSettings
+        from extensions import db
+
+        ss = db.session.get(SeriesSettings, sonarr_series_id)
+        if ss is None:
+            return None
+        value = ss.subtitle_format_requirement
+        return value if value in ALLOWED_REQUIREMENTS else None
+    except Exception:
+        logger.debug("format requirement: series lookup failed", exc_info=True)
+        return None

--- a/backend/tests/test_series_format_requirement.py
+++ b/backend/tests/test_series_format_requirement.py
@@ -1,0 +1,139 @@
+"""Tests for the per-series subtitle format requirement (require_ass)."""
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _set_requirement(series_id: int, value: str | None) -> None:
+    from db.models.core import SeriesSettings
+    from extensions import db
+
+    now = datetime.now(UTC)
+    row = db.session.get(SeriesSettings, series_id)
+    if row is None:
+        row = SeriesSettings(
+            sonarr_series_id=series_id,
+            absolute_order=0,
+            min_attempts_per_day=0,
+            updated_at=now,
+        )
+        db.session.add(row)
+    row.subtitle_format_requirement = value
+    row.updated_at = now
+    db.session.commit()
+
+
+class TestGetSeriesFormatRequirement:
+    def test_none_for_unknown_series(self, app_ctx):
+        from services.series_format import get_series_format_requirement
+
+        assert get_series_format_requirement(987654) is None
+
+    def test_none_for_missing_series_id(self, app_ctx):
+        from services.series_format import get_series_format_requirement
+
+        assert get_series_format_requirement(None) is None
+        assert get_series_format_requirement(0) is None
+
+    def test_returns_require_ass_when_set(self, app_ctx):
+        from services.series_format import get_series_format_requirement
+
+        _set_requirement(500, "require_ass")
+        assert get_series_format_requirement(500) == "require_ass"
+
+    def test_unknown_value_treated_as_none(self, app_ctx):
+        from services.series_format import get_series_format_requirement
+
+        _set_requirement(501, "require_vtt")
+        assert get_series_format_requirement(501) is None
+
+    def test_null_value_is_none(self, app_ctx):
+        from services.series_format import get_series_format_requirement
+
+        _set_requirement(502, None)
+        assert get_series_format_requirement(502) is None
+
+
+class TestPatchRoute:
+    def test_patch_sets_requirement(self, client):
+        r = client.patch(
+            "/api/v1/series/600/settings",
+            json={"subtitle_format_requirement": "require_ass"},
+        )
+        assert r.status_code == 200
+        assert r.get_json()["subtitle_format_requirement"] == "require_ass"
+
+    def test_patch_clears_requirement_with_null(self, client):
+        client.patch(
+            "/api/v1/series/601/settings",
+            json={"subtitle_format_requirement": "require_ass"},
+        )
+        r = client.patch(
+            "/api/v1/series/601/settings",
+            json={"subtitle_format_requirement": None},
+        )
+        assert r.status_code == 200
+        assert r.get_json()["subtitle_format_requirement"] is None
+
+    def test_patch_rejects_unknown_value(self, client):
+        r = client.patch(
+            "/api/v1/series/602/settings",
+            json={"subtitle_format_requirement": "require_vtt"},
+        )
+        assert r.status_code == 400
+
+    def test_patch_without_field_leaves_value_untouched(self, client):
+        client.patch(
+            "/api/v1/series/603/settings",
+            json={"subtitle_format_requirement": "require_ass"},
+        )
+        r = client.patch("/api/v1/series/603/settings", json={"min_attempts_per_day": 3})
+        assert r.status_code == 200
+        assert r.get_json()["subtitle_format_requirement"] == "require_ass"
+
+
+class TestWantedSearchEnforcement:
+    """search_wanted_item must skip the SRT searches for require_ass series."""
+
+    def _run_search(self, app_ctx, monkeypatch, requirement):
+        from wanted_search import search as search_mod
+
+        series_id = 700
+        _set_requirement(series_id, requirement)
+
+        item = {
+            "id": 1,
+            "sonarr_series_id": series_id,
+            "file_path": "/media/show/S01E01.mkv",
+            "target_language": "de",
+        }
+        monkeypatch.setattr(search_mod, "get_wanted_item", lambda _id: item)
+        monkeypatch.setattr(search_mod, "update_wanted_search", lambda _id: None)
+        monkeypatch.setattr(search_mod, "build_query_from_wanted", lambda _item: MagicMock())
+
+        manager = MagicMock()
+        manager.search.return_value = []
+        with patch.object(search_mod, "get_provider_manager", return_value=manager):
+            result = search_mod.search_wanted_item(1)
+
+        assert "error" not in result
+        from providers.base import SubtitleFormat
+
+        formats = [kwargs.get("format_filter") for _args, kwargs in manager.search.call_args_list]
+        return formats
+
+    def test_require_ass_skips_srt_searches(self, app_ctx, monkeypatch):
+        from providers.base import SubtitleFormat
+
+        formats = self._run_search(app_ctx, monkeypatch, "require_ass")
+        assert formats.count(SubtitleFormat.ASS) == 2
+        assert SubtitleFormat.SRT not in formats
+
+    def test_no_requirement_runs_all_four_searches(self, app_ctx, monkeypatch):
+        from providers.base import SubtitleFormat
+
+        formats = self._run_search(app_ctx, monkeypatch, None)
+        assert formats.count(SubtitleFormat.ASS) == 2
+        assert formats.count(SubtitleFormat.SRT) == 2

--- a/backend/wanted_search/process.py
+++ b/backend/wanted_search/process.py
@@ -1023,11 +1023,21 @@ def process_wanted_item(
     else:
         logger.debug("Wanted %d: auto_translate disabled, skipping source ASS translation", item_id)
 
+    # Per-series format requirement: "require_ass" never falls back to SRT
+    # provider results, regardless of what Steps 1+2 returned.
+    from services.series_format import REQUIRE_ASS, get_series_format_requirement
+
+    _require_ass = get_series_format_requirement(item.get("sonarr_series_id")) == REQUIRE_ASS
+    if _require_ass:
+        logger.info("Wanted %d: series requires ASS subtitles, skipping SRT steps", item_id)
+
     # Phase 2: skip SRT steps if no ASS was found in Steps 1+2 (providers likely have nothing)
-    _skip_srt = getattr(settings, "wanted_skip_srt_on_no_ass", True) and not ctx["ass_had_results"]
-    if _skip_srt:
+    _skip_srt = _require_ass or (
+        getattr(settings, "wanted_skip_srt_on_no_ass", True) and not ctx["ass_had_results"]
+    )
+    if _skip_srt and not _require_ass:
         logger.debug("Wanted %d: No ASS found in Steps 1+2, skipping SRT steps", item_id)
-    else:
+    if not _skip_srt:
         # Step 3: target-language SRT direct
         result = _try_target_srt_direct(ctx)
         if result is not None:

--- a/backend/wanted_search/search.py
+++ b/backend/wanted_search/search.py
@@ -106,6 +106,14 @@ def search_wanted_item(item_id: int) -> dict:
     source_query = copy.deepcopy(target_query)
     source_query.languages = [source_lang]
 
+    # Per-series format requirement: "require_ass" skips the SRT searches
+    # (3+4) entirely so no SRT candidates are ever offered for this series.
+    from services.series_format import REQUIRE_ASS, get_series_format_requirement
+
+    require_ass = get_series_format_requirement(item.get("sonarr_series_id")) == REQUIRE_ASS
+    if require_ass:
+        logger.info("Wanted %d: series requires ASS subtitles, skipping SRT searches", item_id)
+
     all_results = []
 
     # Search 1: target_language ASS (Priority 1)
@@ -124,21 +132,22 @@ def search_wanted_item(item_id: int) -> dict:
         logger.warning("Source ASS search failed for wanted %d: %s", item_id, e, exc_info=True)
         # Continue with other searches - don't fail entire operation
 
-    # Search 3: target_language SRT (Priority 3)
-    try:
-        results = manager.search(target_query, format_filter=SubtitleFormat.SRT)
-        all_results.extend([_result_to_dict(r) for r in results[:20]])
-    except Exception as e:
-        logger.warning("Target SRT search failed for wanted %d: %s", item_id, e, exc_info=True)
-        # Continue with other searches - don't fail entire operation
+    if not require_ass:
+        # Search 3: target_language SRT (Priority 3)
+        try:
+            results = manager.search(target_query, format_filter=SubtitleFormat.SRT)
+            all_results.extend([_result_to_dict(r) for r in results[:20]])
+        except Exception as e:
+            logger.warning("Target SRT search failed for wanted %d: %s", item_id, e, exc_info=True)
+            # Continue with other searches - don't fail entire operation
 
-    # Search 4: source_language SRT (Priority 4)
-    try:
-        results = manager.search(source_query, format_filter=SubtitleFormat.SRT)
-        all_results.extend([_result_to_dict(r) for r in results[:20]])
-    except Exception as e:
-        logger.warning("Source SRT search failed for wanted %d: %s", item_id, e, exc_info=True)
-        # Continue with other searches - don't fail entire operation
+        # Search 4: source_language SRT (Priority 4)
+        try:
+            results = manager.search(source_query, format_filter=SubtitleFormat.SRT)
+            all_results.extend([_result_to_dict(r) for r in results[:20]])
+        except Exception as e:
+            logger.warning("Source SRT search failed for wanted %d: %s", item_id, e, exc_info=True)
+            # Continue with other searches - don't fail entire operation
 
     # Deduplicate by (provider, subtitle_id) — four separate searches can return the same result
     # This happens especially when item_lang == source_lang (e.g. both configured as "de")

--- a/frontend/src/api/seriesSettings.ts
+++ b/frontend/src/api/seriesSettings.ts
@@ -6,6 +6,8 @@ export interface SeriesOverridePayload {
   min_attempts_per_day?: number
   // 0.71.1: tri-state — true (force), false (skip), null (inherit global default).
   cleanup_foreign_tracks?: boolean | null
+  // null (inherit: ASS preferred, SRT fallback) | "require_ass" (never fall back to SRT)
+  subtitle_format_requirement?: string | null
 }
 
 export interface SeriesOverrideResponse {
@@ -13,6 +15,7 @@ export interface SeriesOverrideResponse {
   priority_override: string | null
   min_attempts_per_day: number
   cleanup_foreign_tracks: boolean | null
+  subtitle_format_requirement: string | null
 }
 
 /**

--- a/frontend/src/components/library/SeriesOverrideSettings.tsx
+++ b/frontend/src/components/library/SeriesOverrideSettings.tsx
@@ -3,10 +3,15 @@ import { useTranslation } from 'react-i18next'
 
 export interface SeriesOverrideSettingsProps {
   readonly seriesId: number
-  readonly initial: { priority_override: string | null; min_attempts_per_day: number }
+  readonly initial: {
+    priority_override: string | null
+    min_attempts_per_day: number
+    subtitle_format_requirement?: string | null
+  }
   readonly onSave: (payload: {
     priority_override: string | null
     min_attempts_per_day: number
+    subtitle_format_requirement: string | null
   }) => void
 }
 
@@ -27,15 +32,18 @@ export default function SeriesOverrideSettings({
   const { t } = useTranslation('settings')
   const [priority, setPriority] = useState<string>(initial.priority_override ?? '')
   const [min, setMin] = useState<number>(initial.min_attempts_per_day)
+  const [formatReq, setFormatReq] = useState<string>(initial.subtitle_format_requirement ?? '')
 
   const dirty =
     priority !== (initial.priority_override ?? '') ||
-    min !== initial.min_attempts_per_day
+    min !== initial.min_attempts_per_day ||
+    formatReq !== (initial.subtitle_format_requirement ?? '')
 
   const handleSave = () => {
     onSave({
       priority_override: priority === '' ? null : priority,
       min_attempts_per_day: min,
+      subtitle_format_requirement: formatReq === '' ? null : formatReq,
     })
   }
 
@@ -69,6 +77,17 @@ export default function SeriesOverrideSettings({
             setMin(clamped)
           }}
         />
+      </label>
+      <label>
+        {t('series_override.format_requirement')}
+        <select
+          data-testid="format-requirement-select"
+          value={formatReq}
+          onChange={(e) => setFormatReq(e.target.value)}
+        >
+          <option value="">{t('series_override.format_inherit')}</option>
+          <option value="require_ass">{t('series_override.format_require_ass')}</option>
+        </select>
       </label>
       <button data-testid="save-override" disabled={!dirty} onClick={handleSave}>
         {t('series_override.save')}

--- a/frontend/src/components/library/__tests__/SeriesOverrideSettings.test.tsx
+++ b/frontend/src/components/library/__tests__/SeriesOverrideSettings.test.tsx
@@ -37,6 +37,7 @@ describe('SeriesOverrideSettings', () => {
     expect(onSave).toHaveBeenCalledWith({
       priority_override: 'premium',
       min_attempts_per_day: 5,
+      subtitle_format_requirement: null,
     })
   })
 
@@ -56,6 +57,7 @@ describe('SeriesOverrideSettings', () => {
     expect(onSave).toHaveBeenCalledWith({
       priority_override: null,
       min_attempts_per_day: 0,
+      subtitle_format_requirement: null,
     })
   })
 
@@ -75,6 +77,26 @@ describe('SeriesOverrideSettings', () => {
     expect(onSave).toHaveBeenCalledWith({
       priority_override: null,
       min_attempts_per_day: 50,
+      subtitle_format_requirement: null,
+    })
+  })
+  test('format requirement select maps to subtitle_format_requirement', () => {
+    const onSave = vi.fn()
+    render(
+      <SeriesOverrideSettings
+        seriesId={1}
+        initial={{ priority_override: null, min_attempts_per_day: 0 }}
+        onSave={onSave}
+      />,
+    )
+    fireEvent.change(screen.getByTestId('format-requirement-select'), {
+      target: { value: 'require_ass' },
+    })
+    fireEvent.click(screen.getByTestId('save-override'))
+    expect(onSave).toHaveBeenCalledWith({
+      priority_override: null,
+      min_attempts_per_day: 0,
+      subtitle_format_requirement: 'require_ass',
     })
   })
 })

--- a/frontend/src/i18n/locales/de/settings.json
+++ b/frontend/src/i18n/locales/de/settings.json
@@ -1554,6 +1554,9 @@
     "standard": "Standard",
     "backlog": "Backlog",
     "min_attempts": "Mindestversuche pro Tag",
+    "format_requirement": "Untertitel-Format",
+    "format_inherit": "Erben (ASS bevorzugt, SRT-Fallback)",
+    "format_require_ass": "Nur ASS (nie auf SRT ausweichen)",
     "save": "Speichern"
   },
   "scoring": {

--- a/frontend/src/i18n/locales/en/settings.json
+++ b/frontend/src/i18n/locales/en/settings.json
@@ -1554,6 +1554,9 @@
     "standard": "Standard",
     "backlog": "Backlog",
     "min_attempts": "Minimum attempts per day",
+    "format_requirement": "Subtitle format",
+    "format_inherit": "Inherit (ASS preferred, SRT fallback)",
+    "format_require_ass": "ASS only (never fall back to SRT)",
     "save": "Save"
   },
   "scoring": {

--- a/frontend/src/pages/SeriesDetail.tsx
+++ b/frontend/src/pages/SeriesDetail.tsx
@@ -611,7 +611,11 @@ export function SeriesDetailPage() {
         >
           <SeriesOverrideSettings
             seriesId={seriesId}
-            initial={{ priority_override: null, min_attempts_per_day: 0 }}
+            initial={{
+              priority_override: null,
+              min_attempts_per_day: 0,
+              subtitle_format_requirement: null,
+            }}
             onSave={(payload) => overrideMutation.mutate(payload)}
           />
         </div>


### PR DESCRIPTION
## Was ist neu

**Format-Anforderung pro Serie**: Manche Anime will man nur mit gestylten ASS-Subs, andere notfalls auch als SRT. Das neue Feld `subtitle_format_requirement` auf `series_settings` macht das steuerbar:

- `NULL` (Standard) — erbt das globale Verhalten: ASS bevorzugt, SRT-Fallback.
- `"require_ass"` — die Wanted-Pipeline weicht für diese Serie **nie** auf SRT-Provider-Ergebnisse aus.

> **Stacked PR:** basiert auf #166 (Custom-Regex-Regeln), das wiederum auf #164 basiert. Merge-Reihenfolge: #164 → #166 → dieser PR. Die Migrationskette ist entsprechend linear (`e7a1b2c3d4f5` → `f8c9d0e1a2b3` → `a4b5c6d7e8f9`).

## Umsetzung

- **DB** — neue nullable Text-Spalte auf `series_settings` mit spaltengeprüfter (idempotenter) Alembic-Migration.
- **`services/series_format.py`** — Best-Effort-Accessor nach dem Vorbild von `foreign_track_cleanup`: wirft nie, unbekannte Werte werden wie NULL behandelt.
- **Auto-Pipeline (`process_wanted_item`)** — bei `require_ass` werden die SRT-Schritte (3+4) der Download-Kaskade übersprungen, unabhängig von `wanted_skip_srt_on_no_ass`. Der Embedded-/Translate-Fallback (Schritt 5) bleibt unberührt, da er von lokalen Mediendateien arbeitet.
- **Manuelle Suche (`search_wanted_item`)** — die SRT-Suchen (3+4) entfallen, sodass für die Serie gar keine SRT-Kandidaten mehr angeboten werden.
- **API** — `PATCH /api/v1/series/<id>/settings` akzeptiert das Feld (`null | "require_ass"`, sonst 400) und gibt es in der Antwort zurück.
- **Frontend** — im Scheduler-Override-Panel der Seriendetails gibt es ein neues Select „Untertitel-Format": *Erben (ASS bevorzugt, SRT-Fallback)* / *Nur ASS (nie auf SRT ausweichen)*. i18n en + de.

## Tests

- `backend/tests/test_series_format_requirement.py` — 11 Tests: Service-Accessor (unbekannte Serie, fehlende ID, gesetzter/unbekannter/NULL-Wert), PATCH-Route (setzen, mit `null` löschen, 400 bei unbekanntem Wert, Feld bleibt bei Teil-Updates unangetastet), Enforcement in `search_wanted_item` (require_ass → nur 2 ASS-Suchen; ohne Requirement → alle 4 Suchen).
- Frontend: bestehende `SeriesOverrideSettings`-Tests auf das neue Payload-Feld erweitert plus neuer Test für das Format-Select (5 Tests, alle grün).
- Regressionen grün: `test_wanted_search_dry_run`, `test_wanted_search_local_sidecar`, `test_routes_series_overrides`; `tsc -b` sauber, ESLint 0 Errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LufxECMqmfKf4oWD38vbxq

---
_Generated by [Claude Code](https://claude.ai/code/session_01LufxECMqmfKf4oWD38vbxq)_