### PR TITLE
feat: history rollback, reason column, wanted dry-run, health dashboard & sync stats

### DIFF
--- a/backend/config_settings.py
+++ b/backend/config_settings.py
@@ -67,6 +67,10 @@ _ALLOWED_BOOT_FIELDS: frozenset[str] = frozenset(
         "log_format",
         "cors_origins",
         "redis_url",
+        # Env-only kill-switch for anonymous usage stats (see BootSettings
+        # docstring on the field) — must stay env-loadable so self-hosters
+        # can disable/redirect sending before the UI ever loads.
+        "stats_endpoint",
     }
 )
 

--- a/backend/db/library.py
+++ b/backend/db/library.py
@@ -39,6 +39,11 @@ def get_download_history(
     )
 
 
+def get_download_by_id(download_id: int) -> dict | None:
+    """Get one download-history entry by its DB id, or None."""
+    return _get_repo().get_download_by_id(download_id)
+
+
 def get_download_stats() -> dict:
     """Get aggregated download statistics."""
     return _get_repo().get_download_stats()

--- a/backend/db/repositories/library.py
+++ b/backend/db/repositories/library.py
@@ -90,14 +90,40 @@ class LibraryRepository(BaseRepository):
             data_stmt = data_stmt.where(cond)
         entries = self.session.execute(data_stmt).scalars().all()
 
+        data = [self._to_dict(e) for e in entries]
+
+        # Enrich upgrade rows with the replaced download's score/format so the
+        # UI can show WHY the entry exists ("Upgrade +40" vs. plain download)
+        # without a per-row lookup. One batch query for the whole page.
+        prev_ids = {e.upgraded_from_id for e in entries if e.upgraded_from_id}
+        prev_map: dict[int, tuple] = {}
+        if prev_ids:
+            prev_rows = self.session.execute(
+                select(
+                    SubtitleDownload.id,
+                    SubtitleDownload.score,
+                    SubtitleDownload.format,
+                ).where(SubtitleDownload.id.in_(prev_ids))
+            ).all()
+            prev_map = {row[0]: (row[1], row[2]) for row in prev_rows}
+        for row in data:
+            prev = prev_map.get(row.get("upgraded_from_id"))
+            row["previous_score"] = prev[0] if prev else None
+            row["previous_format"] = prev[1] if prev else None
+
         total_pages = max(1, (count + per_page - 1) // per_page)
         return {
-            "data": [self._to_dict(e) for e in entries],
+            "data": data,
             "page": page,
             "per_page": per_page,
             "total": count,
             "total_pages": total_pages,
         }
+
+    def get_download_by_id(self, download_id: int) -> dict | None:
+        """Return one subtitle_downloads row as a dict, or None."""
+        entry = self.session.get(SubtitleDownload, download_id)
+        return self._to_dict(entry) if entry else None
 
     def get_download_stats(self) -> dict:
         """Get aggregated download statistics.

--- a/backend/providers/download_manager.py
+++ b/backend/providers/download_manager.py
@@ -414,6 +414,15 @@ def save_subtitle(
         logger.error("Failed to create directory for %s: %s", output_path, e)
         raise RuntimeError(f"Cannot create directory for subtitle: {e}") from e
 
+    # Preserve an existing sidecar into the single-slot .bak before it is
+    # replaced (re-download, upgrade) so the History rollback endpoint can
+    # bring it back. No-op when a bak already exists — that slot holds the
+    # oldest preserved version and must never be overwritten.
+    if os.path.isfile(output_path):
+        from services.subtitle_restore import backup_before_replace
+
+        backup_before_replace(output_path)
+
     # Write file with error handling. Atomic (tmp + os.replace) so a crash mid-
     # write can't replace a previously-good sidecar with a truncated one.
     try:

--- a/backend/providers/plugins/template/README.md
+++ b/backend/providers/plugins/template/README.md
@@ -78,11 +78,11 @@ Each config field is a dict with these keys:
 
 ```python
 {
-    "key": "api_key",          # Internal key, passed as kwarg to __init__
-    "label": "API Key",        # Human-readable label in the Settings UI
-    "type": "password",        # "text", "password", or "number"
-    "required": True,          # If True, provider needs this to function
-    "default": "",             # Default value (optional)
+    "key": "api_key",  # Internal key, passed as kwarg to __init__
+    "label": "API Key",  # Human-readable label in the Settings UI
+    "type": "password",  # "text", "password", or "number"
+    "required": True,  # If True, provider needs this to function
+    "default": "",  # Default value (optional)
 }
 ```
 
@@ -93,8 +93,20 @@ Config values are stored in the database under `plugin.<name>.<key>` namespace. 
 ```python
 config_fields = [
     {"key": "api_key", "label": "API Key", "type": "password", "required": True},
-    {"key": "base_url", "label": "Base URL", "type": "text", "required": False, "default": "https://api.example.com"},
-    {"key": "results_per_page", "label": "Results Per Page", "type": "number", "required": False, "default": "50"},
+    {
+        "key": "base_url",
+        "label": "Base URL",
+        "type": "text",
+        "required": False,
+        "default": "https://api.example.com",
+    },
+    {
+        "key": "results_per_page",
+        "label": "Results Per Page",
+        "type": "number",
+        "required": False,
+        "default": "50",
+    },
 ]
 ```
 
@@ -201,9 +213,9 @@ result.matches = {"series", "season", "episode"}
 Set `rate_limit = (max_requests, window_seconds)` on your class. The `ProviderManager` enforces this limit across all search and download calls. Example:
 
 ```python
-rate_limit = (5, 1)    # 5 requests per second (OpenSubtitles-style)
-rate_limit = (100, 60) # 100 requests per minute
-rate_limit = (0, 0)    # No rate limiting
+rate_limit = (5, 1)  # 5 requests per second (OpenSubtitles-style)
+rate_limit = (100, 60)  # 100 requests per minute
+rate_limit = (0, 0)  # No rate limiting
 ```
 
 The `RetryingSession` from `create_session()` also handles HTTP 429 responses automatically (reads `Retry-After` header).
@@ -220,10 +232,10 @@ Sublarr provides three specialized exceptions in `providers.base`:
 
 ```python
 from providers.base import (
-    ProviderAuthError,       # 401/403 -- authentication failed
+    ProviderAuthError,  # 401/403 -- authentication failed
     ProviderRateLimitError,  # 429 -- rate limit exceeded
-    ProviderTimeoutError,    # Request timed out
-    ProviderError,           # Generic provider error (base class)
+    ProviderTimeoutError,  # Request timed out
+    ProviderError,  # Generic provider error (base class)
 )
 ```
 
@@ -252,10 +264,11 @@ Use `create_session()` from `providers.http_session` for HTTP calls:
 ```python
 from providers.http_session import create_session
 
+
 def initialize(self):
     self.session = create_session(
-        max_retries=self.max_retries,   # From class attribute
-        timeout=self.timeout,           # From class attribute
+        max_retries=self.max_retries,  # From class attribute
+        timeout=self.timeout,  # From class attribute
         user_agent="Sublarr-Plugin/1.0",
     )
     # Set authentication headers
@@ -276,17 +289,18 @@ The session provides:
 import zipfile
 import io
 
+
 def download(self, result):
     resp = self.session.get(result.download_url)
     resp.raise_for_status()
     content = resp.content
 
-    if content[:4] == b'PK\x03\x04':  # ZIP magic bytes
+    if content[:4] == b"PK\x03\x04":  # ZIP magic bytes
         with zipfile.ZipFile(io.BytesIO(content)) as zf:
             for name in zf.namelist():
-                if name.endswith(('.srt', '.ass', '.ssa')):
+                if name.endswith((".srt", ".ass", ".ssa")):
                     content = zf.read(name)
-                    if name.endswith(('.ass', '.ssa')):
+                    if name.endswith((".ass", ".ssa")):
                         result.format = SubtitleFormat.ASS
                     break
 
@@ -299,12 +313,13 @@ def download(self, result):
 ```python
 import lzma
 
+
 def download(self, result):
     resp = self.session.get(result.download_url)
     resp.raise_for_status()
     content = resp.content
 
-    if content[:6] == b'\xfd7zXZ\x00':  # XZ magic bytes
+    if content[:6] == b"\xfd7zXZ\x00":  # XZ magic bytes
         content = lzma.decompress(content)
 
     result.content = content
@@ -317,15 +332,16 @@ def download(self, result):
 import rarfile
 import io
 
+
 def download(self, result):
     resp = self.session.get(result.download_url)
     resp.raise_for_status()
     content = resp.content
 
-    if content[:4] == b'Rar!':  # RAR magic bytes
+    if content[:4] == b"Rar!":  # RAR magic bytes
         with rarfile.RarFile(io.BytesIO(content)) as rf:
             for name in rf.namelist():
-                if name.endswith(('.srt', '.ass', '.ssa')):
+                if name.endswith((".srt", ".ass", ".ssa")):
                     content = rf.read(name)
                     break
 
@@ -342,6 +358,7 @@ def search(self, query):
     elif query.is_movie:
         return self._search_movie(query)
     return []
+
 
 def _search_episode(self, query):
     params = {

--- a/backend/routes/blacklist/history.py
+++ b/backend/routes/blacklist/history.py
@@ -1,6 +1,7 @@
-"""Download history routes — /history, /history/stats."""
+"""Download history routes — /history, /history/stats, /history/<id>/rollback."""
 
 import logging
+import os
 
 from flask import jsonify, request
 
@@ -124,6 +125,134 @@ def list_history():
         sort_dir=sort_dir,
     )
     return jsonify(result)
+
+
+def _resolve_sidecar_path(entry: dict) -> str:
+    """Derive the sidecar path a history entry produced (mapped + validated).
+
+    History rows store the VIDEO file path; the sidecar lives at
+    ``<video_base>.<lang>.<fmt>``. Raises ValueError when the derived path
+    falls outside media_path.
+    """
+    from config import get_settings, map_path
+    from security_utils import is_safe_path
+    from translator import get_output_path_for_lang
+
+    fmt = entry.get("format") or "srt"
+    path = get_output_path_for_lang(map_path(entry["file_path"]), fmt, entry.get("language"))
+    if not is_safe_path(path, get_settings().media_path):
+        raise ValueError(f"Derived sidecar path {path!r} is outside media_path")
+    return path
+
+
+@bp.route("/history/<int:download_id>/rollback", methods=["POST"])
+def rollback_history_entry(download_id):
+    """Roll back a history entry: restore the previously replaced subtitle.
+    ---
+    post:
+      security:
+        - apiKeyAuth: []
+      tags:
+        - Blacklist
+      summary: Roll back a subtitle download
+      description: >
+        Restores the subtitle version that this download replaced, using the
+        single-slot .bak backup written at replacement time. Same-format
+        entries swap active and backup (invoking rollback again flips them
+        back). Format-upgrade entries (e.g. SRT->ASS) restore the old-format
+        sidecar and retire the current one into its own backup slot.
+      parameters:
+        - in: path
+          name: download_id
+          required: true
+          schema:
+            type: integer
+      responses:
+        200:
+          description: Restored
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                  path:
+                    type: string
+        404:
+          description: Entry or backup not found
+        409:
+          description: Restore failed
+    """
+    from db.activity import log_activity
+    from db.library import get_download_by_id
+    from db.models.activity import EVENT_DOWNLOAD
+    from services.subtitle_restore import RestoreError, backup_before_replace, restore_from_bak
+    from subtitle_filename import find_existing_bak
+
+    entry = get_download_by_id(download_id)
+    if not entry:
+        return jsonify({"error": "History entry not found"}), 404
+
+    try:
+        active_path = _resolve_sidecar_path(entry)
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 403
+
+    prev = None
+    if entry.get("upgraded_from_id"):
+        prev = get_download_by_id(entry["upgraded_from_id"])
+
+    cross_format = bool(
+        prev
+        and (
+            (prev.get("format") or "srt") != (entry.get("format") or "srt")
+            or prev.get("language") != entry.get("language")
+        )
+    )
+
+    if cross_format:
+        # Format upgrade (e.g. SRT->ASS): the previous version lives at a
+        # DIFFERENT sidecar path. Restore its bak, retire the current file.
+        try:
+            prev_active = _resolve_sidecar_path(prev)
+        except ValueError as e:
+            return jsonify({"error": str(e)}), 403
+
+        bak_path = find_existing_bak(prev_active)
+        if bak_path is None:
+            return jsonify({"error": "No backup of the previous subtitle exists"}), 404
+
+        if os.path.isfile(active_path):
+            # Keep the retired file recoverable: park it in its own bak slot.
+            backup_before_replace(active_path)
+            try:
+                os.remove(active_path)
+            except OSError as e:
+                return jsonify({"error": f"Could not remove current subtitle: {e}"}), 409
+        try:
+            os.replace(bak_path, prev_active)
+        except OSError as e:
+            return jsonify({"error": f"Could not restore backup: {e}"}), 409
+        result = {"status": "restored", "path": prev_active, "removed": active_path}
+    else:
+        try:
+            result = restore_from_bak(active_path)
+        except RestoreError as e:
+            return jsonify({"error": str(e)}), e.http_status
+
+    log_activity(
+        EVENT_DOWNLOAD,
+        file_path=entry["file_path"],
+        status="rollback",
+        details={
+            "provider": entry.get("provider_name"),
+            "language": entry.get("language"),
+            "restored_path": result.get("path"),
+        },
+    )
+    logger.info("History %d rolled back: %s", download_id, result.get("path"))
+    return jsonify(result), 200
 
 
 @bp.route("/history/stats", methods=["GET"])

--- a/backend/routes/subtitle_processor.py
+++ b/backend/routes/subtitle_processor.py
@@ -21,7 +21,7 @@ from flask import Blueprint, current_app, jsonify, request
 from config import get_settings, map_path
 from security_utils import is_safe_path
 from services.background_tasks import submit_background
-from subtitle_filename import bak_path_for, find_existing_bak
+from subtitle_filename import find_existing_bak
 
 bp = Blueprint("subtitle_processor", __name__, url_prefix="/api/v1")
 logger = logging.getLogger(__name__)
@@ -122,56 +122,13 @@ def undo_process():
     if ext not in (".srt", ".ass", ".ssa"):
         return jsonify({"error": "Only .srt, .ass, and .ssa files are supported"}), 400
 
-    # Resolve where the bak actually lives. find_existing_bak checks the
-    # canonical hidden location first, then the legacy sibling location
-    # so pre-migration backups still restore correctly.
-    bak_path = find_existing_bak(abs_path)
-    if bak_path is None:
-        return jsonify({"error": "No backup found for this file"}), 404
+    from services.subtitle_restore import RestoreError, restore_from_bak
 
-    # Where new baks must land going forward — different from bak_path
-    # when we're restoring a legacy sibling-located backup.
-    canonical_bak_path = bak_path_for(abs_path)
-
-    if not os.path.exists(abs_path):
-        # Active sub gone — simple rename, nothing to swap.
-        try:
-            os.replace(bak_path, abs_path)
-        except OSError as e:
-            return jsonify({"error": f"Could not restore backup: {e}"}), 409
-        return jsonify({"status": "restored", "path": abs_path, "swapped": False}), 200
-
-    # Atomic swap via temp path. If step 2 or 3 fails we roll back step 1.
-    # Step 3 always lands the new bak in the canonical hidden location,
-    # even when the source bak was a legacy sibling — every restore
-    # opportunistically migrates the layout.
-    os.makedirs(os.path.dirname(canonical_bak_path), exist_ok=True)
-    tmp_path = f"{bak_path}.swap-tmp"
     try:
-        os.replace(abs_path, tmp_path)  # step 1: active -> tmp
-    except OSError as e:
-        return jsonify({"error": f"Could not stage active file: {e}"}), 409
-    try:
-        os.replace(bak_path, abs_path)  # step 2: bak -> active
-    except OSError as e:
-        try:
-            os.replace(tmp_path, abs_path)  # rollback step 1
-        except OSError:
-            logger.error(
-                "undo: rollback failed; left tmp at %s, active gone", tmp_path, exc_info=True
-            )
-        return jsonify({"error": f"Could not restore backup: {e}"}), 409
-    try:
-        os.replace(tmp_path, canonical_bak_path)  # step 3: tmp -> canonical bak
-    except OSError as e:
-        # Active is restored but new bak failed to land. Active state is
-        # correct; surface the partial outcome so the caller can decide.
-        logger.warning("undo: swap completed but new bak rename failed: %s", e)
-        return jsonify(
-            {"status": "restored", "path": abs_path, "swapped": False, "warning": str(e)}
-        ), 200
-
-    return jsonify({"status": "restored", "path": abs_path, "swapped": True}), 200
+        result = restore_from_bak(abs_path)
+    except RestoreError as e:
+        return jsonify({"error": str(e)}), e.http_status
+    return jsonify(result), 200
 
 
 @bp.route("/tools/process/bak-exists", methods=["GET"])

--- a/backend/routes/system/__init__.py
+++ b/backend/routes/system/__init__.py
@@ -10,6 +10,7 @@ from routes.system import (  # noqa: E402, F401
     budget,
     health,
     health_detailed,
+    health_library,
     logs,
     maintenance,
     notifications,

--- a/backend/routes/system/health_library.py
+++ b/backend/routes/system/health_library.py
@@ -1,0 +1,56 @@
+"""GET /api/v1/health/library — library health overview for the Health page."""
+
+import logging
+
+from flask import jsonify
+
+from cache_response import cached_get
+from routes.system import bp
+
+logger = logging.getLogger(__name__)
+
+
+@bp.route("/health/library", methods=["GET"])
+@cached_get(ttl_seconds=60)
+def health_library():
+    """Library health overview.
+    ---
+    get:
+      tags:
+        - System
+      summary: Library health overview
+      description: >
+        Aggregated "where does it hurt" view: series/movies with missing
+        subtitles, wanted items stuck in a failure state (including
+        unmatched/unsourceable episodes), and per-provider health derived
+        from circuit-breaker states and provider statistics.
+      security:
+        - apiKeyAuth: []
+      responses:
+        200:
+          description: Health overview
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  totals:
+                    type: object
+                    additionalProperties:
+                      type: integer
+                  series:
+                    type: array
+                    items:
+                      type: object
+                  problems:
+                    type: array
+                    items:
+                      type: object
+                  providers:
+                    type: array
+                    items:
+                      type: object
+    """
+    from services.health_overview import get_library_health
+
+    return jsonify(get_library_health())

--- a/backend/routes/wanted/__init__.py
+++ b/backend/routes/wanted/__init__.py
@@ -8,6 +8,7 @@ import routes.wanted.automation  # noqa: E402, F401
 import routes.wanted.batch_extract  # noqa: E402, F401
 import routes.wanted.batch_probe  # noqa: E402, F401
 import routes.wanted.bulk_actions  # noqa: E402, F401
+import routes.wanted.dry_run  # noqa: E402, F401
 import routes.wanted.extract  # noqa: E402, F401
 import routes.wanted.list  # noqa: E402, F401
 import routes.wanted.mt_pending  # noqa: E402, F401

--- a/backend/routes/wanted/dry_run.py
+++ b/backend/routes/wanted/dry_run.py
@@ -1,0 +1,128 @@
+"""Wanted dry-run route — preview what the automation pipeline would pick.
+
+POST /api/v1/wanted/dry-run runs ``process_wanted_item(dry_run=True)`` for a
+small batch of wanted items: the full pipeline (profile gates, provider
+search, upgrade decision) executes, but nothing is written to disk or the DB
+at the found paths. Each item's pre-run status is restored afterwards so a
+preview never leaves rows stuck in "searching" (the pipeline's first
+mutation) — the same courtesy services.mt_reseek extends after its preview
+call.
+"""
+
+import logging
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+from flask import current_app, jsonify, request
+
+from routes.wanted import bp
+
+logger = logging.getLogger(__name__)
+
+# Provider searches take seconds per item; the route is synchronous, so cap
+# the batch to keep response times reasonable.
+MAX_DRY_RUN_ITEMS = 10
+_DRY_RUN_WORKERS = 3
+
+
+def _dry_run_one(app, item_id: int) -> dict:
+    """Run one preview inside its own app context; restore the item's status."""
+    with app.app_context():
+        from db.wanted import get_wanted_item, update_wanted_status
+        from wanted_search import process_wanted_item
+
+        item = get_wanted_item(item_id)
+        if not item:
+            return {"wanted_id": item_id, "status": "error", "error": "Item not found"}
+        prior_status = item.get("status")
+
+        try:
+            result = process_wanted_item(item_id, dry_run=True)
+        except Exception as exc:
+            logger.exception("Dry run failed for wanted %d", item_id)
+            result = {"wanted_id": item_id, "status": "error", "error": str(exc)}
+        finally:
+            # The pipeline bumps status to "searching" before it can know it
+            # is a preview. Put back whatever was there — unless a pre-flight
+            # gate legitimately resolved the row (e.g. sidecar already
+            # present deletes it), in which case there is nothing to restore.
+            try:
+                if prior_status and get_wanted_item(item_id):
+                    update_wanted_status(item_id, prior_status)
+            except Exception:
+                logger.debug("Could not restore status for wanted %d", item_id, exc_info=True)
+
+        result.setdefault("dry_run", True)
+        return result
+
+
+@bp.route("/wanted/dry-run", methods=["POST"])
+def wanted_dry_run():
+    """Preview which subtitles the pipeline would download for wanted items.
+    ---
+    post:
+      tags:
+        - Wanted
+      summary: Dry-run wanted items
+      description: >
+        Runs the full search pipeline for up to 10 wanted items WITHOUT
+        writing anything: providers are queried for real, but no subtitle is
+        saved, no history is recorded, and the wanted rows keep their status.
+        Returns per-item results with the provider, score, format and output
+        path that a real run would produce.
+      security:
+        - apiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [item_ids]
+              properties:
+                item_ids:
+                  type: array
+                  items:
+                    type: integer
+                  maxItems: 10
+      responses:
+        200:
+          description: Per-item dry-run results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  results:
+                    type: array
+                    items:
+                      type: object
+        400:
+          description: Invalid request body
+    """
+    data = request.get_json(force=True, silent=True) or {}
+    item_ids = data.get("item_ids")
+    if not isinstance(item_ids, list) or not item_ids:
+        return jsonify({"error": "item_ids (non-empty list) is required"}), 400
+    try:
+        item_ids = [int(i) for i in item_ids]
+    except (TypeError, ValueError):
+        return jsonify({"error": "item_ids must be integers"}), 400
+    if len(item_ids) > MAX_DRY_RUN_ITEMS:
+        return jsonify({"error": f"At most {MAX_DRY_RUN_ITEMS} items per dry run"}), 400
+
+    app = current_app._get_current_object()
+    results: list[dict] = []
+    with ThreadPoolExecutor(max_workers=min(_DRY_RUN_WORKERS, len(item_ids))) as executor:
+        futures = {executor.submit(_dry_run_one, app, item_id): item_id for item_id in item_ids}
+        for future in as_completed(futures):
+            item_id = futures[future]
+            try:
+                results.append(future.result())
+            except Exception as exc:
+                logger.exception("Dry-run worker crashed for wanted %d", item_id)
+                results.append({"wanted_id": item_id, "status": "error", "error": str(exc)})
+
+    # Preserve the request order — as_completed returns in finish order.
+    order = {item_id: idx for idx, item_id in enumerate(item_ids)}
+    results.sort(key=lambda r: order.get(r.get("wanted_id"), len(order)))
+    return jsonify({"results": results}), 200

--- a/backend/services/health_overview.py
+++ b/backend/services/health_overview.py
@@ -1,0 +1,169 @@
+"""Library health overview — the data behind GET /api/v1/health/library.
+
+Aggregates three "where does it hurt" views from data that already exists:
+
+  * ``series``   — which series/movies have missing subtitles, and how many
+                   of their wanted items are stuck in a failure state.
+  * ``problems`` — the concrete wanted items that failed or were classified
+                   with a ``failure_kind`` (no_result, provider_error,
+                   unsourceable, ...), i.e. episodes the pipeline could not
+                   satisfy or match.
+  * ``providers``— per-provider health: circuit-breaker state merged with
+                   the hit/failure counters from provider_stats.
+
+Everything is read-only and bounded (top-N lists) so the endpoint stays
+cheap enough for a dashboard poll.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy import case, func, select
+
+logger = logging.getLogger(__name__)
+
+# Bounded list sizes — a dashboard needs the worst offenders, not everything.
+MAX_SERIES_ROWS = 50
+MAX_PROBLEM_ROWS = 100
+
+# Wanted statuses that mean "the user does not want this tracked".
+_EXCLUDED_STATUSES = ("ignored",)
+
+
+def _is_problem_clause(wanted_model):
+    """Filter: item is stuck — failed outright or classified with a failure kind."""
+    return (wanted_model.status == "failed") | (wanted_model.failure_kind.isnot(None))
+
+
+def get_library_health() -> dict:
+    from db.models.circuit_breaker import CircuitBreakerState
+    from db.models.core import WantedItem
+    from db.models.providers import ProviderStats
+    from extensions import db
+
+    session = db.session
+
+    # ── series/movies with missing subtitles ────────────────────────────────
+    problem_case = case((_is_problem_clause(WantedItem), 1), else_=0)
+    series_rows = session.execute(
+        select(
+            WantedItem.title,
+            WantedItem.item_type,
+            func.count(WantedItem.id).label("missing"),
+            func.sum(problem_case).label("problems"),
+        )
+        .where(WantedItem.status.notin_(_EXCLUDED_STATUSES))
+        .group_by(WantedItem.title, WantedItem.item_type)
+        .order_by(func.count(WantedItem.id).desc())
+        .limit(MAX_SERIES_ROWS)
+    ).all()
+    series = [
+        {
+            "title": row[0] or "?",
+            "item_type": row[1],
+            "missing": int(row[2] or 0),
+            "problems": int(row[3] or 0),
+        }
+        for row in series_rows
+    ]
+
+    # ── concrete problem items (failed / unmatched episodes) ────────────────
+    problem_rows = (
+        session.execute(
+            select(WantedItem)
+            .where(_is_problem_clause(WantedItem))
+            .where(WantedItem.status.notin_(_EXCLUDED_STATUSES))
+            .order_by(WantedItem.updated_at.desc())
+            .limit(MAX_PROBLEM_ROWS)
+        )
+        .scalars()
+        .all()
+    )
+    problems = [
+        {
+            "id": item.id,
+            "title": item.title,
+            "season_episode": item.season_episode or "",
+            "item_type": item.item_type,
+            "target_language": item.target_language or "",
+            "status": item.status,
+            "failure_kind": item.failure_kind,
+            "error": item.error or "",
+            "search_count": item.search_count or 0,
+            "updated_at": item.updated_at.isoformat() if item.updated_at else None,
+        }
+        for item in problem_rows
+    ]
+
+    # ── provider health: circuit breaker ⋈ provider_stats ───────────────────
+    breakers = {
+        row.name: row for row in session.execute(select(CircuitBreakerState)).scalars().all()
+    }
+    stats_rows = session.execute(select(ProviderStats)).scalars().all()
+    provider_names = sorted(set(breakers) | {r.provider_name for r in stats_rows})
+    providers = []
+    for name in provider_names:
+        breaker = breakers.get(name)
+        stats = next((r for r in stats_rows if r.provider_name == name), None)
+        searches = (stats.total_searches or 0) if stats else 0
+        hits = (stats.successful_searches or 0) if stats else 0
+        breaker_state = (breaker.state if breaker else "closed") or "closed"
+        auto_disabled = bool(stats.auto_disabled) if stats else False
+        hit_rate = round(hits / searches, 3) if searches else None
+        providers.append(
+            {
+                "provider": name,
+                "breaker_state": breaker_state,
+                "breaker_failures": int(breaker.failure_count or 0) if breaker else 0,
+                "searches": int(searches),
+                "hit_rate": hit_rate,
+                "failed_downloads": int(stats.failed_downloads or 0) if stats else 0,
+                "auto_disabled": auto_disabled,
+                # A provider "hurts" when its breaker is not closed, it was
+                # auto-disabled, or it answers searches but almost never hits.
+                "degraded": (
+                    breaker_state != "closed"
+                    or auto_disabled
+                    or (searches >= 10 and hit_rate is not None and hit_rate < 0.05)
+                ),
+            }
+        )
+    providers.sort(key=lambda p: (not p["degraded"], p["provider"]))
+
+    # ── totals ──────────────────────────────────────────────────────────────
+    wanted_total = (
+        session.execute(
+            select(func.count(WantedItem.id)).where(
+                WantedItem.status.notin_(_EXCLUDED_STATUSES)
+            )
+        ).scalar_one()
+        or 0
+    )
+    problems_total = (
+        session.execute(
+            select(func.count(WantedItem.id))
+            .where(_is_problem_clause(WantedItem))
+            .where(WantedItem.status.notin_(_EXCLUDED_STATUSES))
+        ).scalar_one()
+        or 0
+    )
+    unmatched_total = (
+        session.execute(
+            select(func.count(WantedItem.id)).where(WantedItem.failure_kind == "unsourceable")
+        ).scalar_one()
+        or 0
+    )
+
+    return {
+        "totals": {
+            "wanted": int(wanted_total),
+            "problems": int(problems_total),
+            "unmatched": int(unmatched_total),
+            "series_affected": len(series),
+            "providers_degraded": sum(1 for p in providers if p["degraded"]),
+        },
+        "series": series,
+        "problems": problems,
+        "providers": providers,
+    }

--- a/backend/services/health_overview.py
+++ b/backend/services/health_overview.py
@@ -134,9 +134,7 @@ def get_library_health() -> dict:
     # ── totals ──────────────────────────────────────────────────────────────
     wanted_total = (
         session.execute(
-            select(func.count(WantedItem.id)).where(
-                WantedItem.status.notin_(_EXCLUDED_STATUSES)
-            )
+            select(func.count(WantedItem.id)).where(WantedItem.status.notin_(_EXCLUDED_STATUSES))
         ).scalar_one()
         or 0
     )

--- a/backend/services/statistics_service.py
+++ b/backend/services/statistics_service.py
@@ -31,6 +31,7 @@ def _range_start(range_key: str) -> datetime | None:
 
 
 def get_subtitles_stats(range_key: str = "30d") -> dict:
+    from db.models.core import SyncJobRun
     from db.models.providers import SubtitleDownload
     from extensions import db
 
@@ -51,6 +52,14 @@ def get_subtitles_stats(range_key: str = "30d") -> dict:
         if r.score is not None:
             scores.append(r.score)
 
+    # Sync success rate over the same range (ffsubsync/alass audit rows).
+    sync_stmt = select(SyncJobRun.status, func.count()).group_by(SyncJobRun.status)
+    if start is not None:
+        sync_stmt = sync_stmt.where(SyncJobRun.created_at >= start)
+    sync_by_status = {row[0]: row[1] for row in db.session.execute(sync_stmt).all()}
+    sync_runs = sum(sync_by_status.values())
+    sync_ok = sync_by_status.get("ok", 0)
+
     return {
         "range": range_key,
         "total": len(rows),
@@ -58,6 +67,9 @@ def get_subtitles_stats(range_key: str = "30d") -> dict:
         "by_provider": dict(by_provider),
         "by_language": dict(by_language),
         "avg_score": round(sum(scores) / len(scores), 1) if scores else 0,
+        "sync_runs": int(sync_runs),
+        "sync_ok": int(sync_ok),
+        "sync_rate": round(sync_ok / sync_runs, 3) if sync_runs else None,
     }
 
 

--- a/backend/services/subtitle_restore.py
+++ b/backend/services/subtitle_restore.py
@@ -1,0 +1,124 @@
+"""Restore a subtitle sidecar from its single-slot ``.bak`` backup.
+
+Extracted from ``routes.subtitle_processor.undo_process`` so the History
+rollback endpoint (``POST /api/v1/history/<id>/rollback``) can share the
+exact same swap semantics instead of growing a second, subtly different
+implementation.
+
+The contract is the one the undo route has always had: when the active
+sidecar still exists, a 3-rename atomic swap flips active and bak so a
+second invocation flips them back (no data loss either way). When the
+active is gone, the bak is simply renamed into place.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from subtitle_filename import bak_path_for, find_existing_bak
+
+logger = logging.getLogger(__name__)
+
+
+class RestoreError(Exception):
+    """Restore failed. ``http_status`` maps the failure onto the API response."""
+
+    def __init__(self, message: str, http_status: int = 409):
+        super().__init__(message)
+        self.http_status = http_status
+
+
+def restore_from_bak(abs_path: str) -> dict:
+    """Swap ``abs_path`` with its ``.bak`` backup.
+
+    Args:
+        abs_path: Absolute path of the active subtitle sidecar to restore.
+            Path-safety validation is the caller's job — this function only
+            performs filesystem renames.
+
+    Returns:
+        ``{"status": "restored", "path": ..., "swapped": bool}`` plus an
+        optional ``"warning"`` key when the restore succeeded but the new
+        bak could not be written back.
+
+    Raises:
+        RestoreError: No backup exists (404) or a rename failed (409).
+    """
+    # Resolve where the bak actually lives. find_existing_bak checks the
+    # canonical hidden location first, then the legacy sibling location
+    # so pre-migration backups still restore correctly.
+    bak_path = find_existing_bak(abs_path)
+    if bak_path is None:
+        raise RestoreError("No backup found for this file", http_status=404)
+
+    # Where new baks must land going forward — different from bak_path
+    # when we're restoring a legacy sibling-located backup.
+    canonical_bak_path = bak_path_for(abs_path)
+
+    if not os.path.exists(abs_path):
+        # Active sub gone — simple rename, nothing to swap.
+        try:
+            os.replace(bak_path, abs_path)
+        except OSError as e:
+            raise RestoreError(f"Could not restore backup: {e}") from e
+        return {"status": "restored", "path": abs_path, "swapped": False}
+
+    # Atomic swap via temp path. If step 2 or 3 fails we roll back step 1.
+    # Step 3 always lands the new bak in the canonical hidden location,
+    # even when the source bak was a legacy sibling — every restore
+    # opportunistically migrates the layout.
+    os.makedirs(os.path.dirname(canonical_bak_path), exist_ok=True)
+    tmp_path = f"{bak_path}.swap-tmp"
+    try:
+        os.replace(abs_path, tmp_path)  # step 1: active -> tmp
+    except OSError as e:
+        raise RestoreError(f"Could not stage active file: {e}") from e
+    try:
+        os.replace(bak_path, abs_path)  # step 2: bak -> active
+    except OSError as e:
+        try:
+            os.replace(tmp_path, abs_path)  # rollback step 1
+        except OSError:
+            logger.error(
+                "restore: rollback failed; left tmp at %s, active gone", tmp_path, exc_info=True
+            )
+        raise RestoreError(f"Could not restore backup: {e}") from e
+    try:
+        os.replace(tmp_path, canonical_bak_path)  # step 3: tmp -> canonical bak
+    except OSError as e:
+        # Active is restored but new bak failed to land. Active state is
+        # correct; surface the partial outcome so the caller can decide.
+        logger.warning("restore: swap completed but new bak rename failed: %s", e)
+        return {"status": "restored", "path": abs_path, "swapped": False, "warning": str(e)}
+
+    return {"status": "restored", "path": abs_path, "swapped": True}
+
+
+def backup_before_replace(active_path: str) -> str | None:
+    """Preserve ``active_path`` into the single-slot bak before it is replaced.
+
+    Only writes when NO backup exists yet (canonical or legacy) — the bak is
+    a single-slot undo and an existing one must never be overwritten (see
+    tests/test_processing_bak_is_never_overwritten.py for the incident that
+    rule comes from).
+
+    Returns the bak path when a backup was created, else ``None``. Never
+    raises: a failed backup must not abort the download/upgrade that
+    triggered it.
+    """
+    try:
+        if not os.path.isfile(active_path):
+            return None
+        if find_existing_bak(active_path) is not None:
+            return None
+        bak_path = bak_path_for(active_path)
+        os.makedirs(os.path.dirname(bak_path), exist_ok=True)
+        import shutil
+
+        shutil.copy2(active_path, bak_path)
+        logger.info("Backed up %s -> %s before replacement", active_path, bak_path)
+        return bak_path
+    except OSError as e:
+        logger.warning("Could not back up %s before replacement: %s", active_path, e)
+        return None

--- a/backend/tests/test_health_overview.py
+++ b/backend/tests/test_health_overview.py
@@ -1,0 +1,159 @@
+"""Tests for services.health_overview + GET /api/v1/health/library
+and the sync-rate fields added to /api/v1/statistics/subtitles."""
+
+from datetime import UTC, datetime
+
+
+def _add_wanted(app, title, status="wanted", failure_kind=None, item_type="episode", **kw):
+    from db.models.core import WantedItem
+    from extensions import db
+
+    with app.app_context():
+        now = datetime.now(UTC)
+        item = WantedItem(
+            item_type=item_type,
+            title=title,
+            file_path=kw.get("file_path", f"/media/{title}/{title}-{status}.mkv"),
+            status=status,
+            failure_kind=failure_kind,
+            season_episode=kw.get("season_episode", "S01E01"),
+            target_language="de",
+            error=kw.get("error", ""),
+            search_count=kw.get("search_count", 0),
+            added_at=now,
+            updated_at=now,
+        )
+        db.session.add(item)
+        db.session.commit()
+        return item.id
+
+
+def _add_provider_stats(app, name, searches=0, hits=0, auto_disabled=False):
+    from db.models.providers import ProviderStats
+    from extensions import db
+
+    with app.app_context():
+        row = ProviderStats(
+            provider_name=name,
+            total_searches=searches,
+            successful_searches=hits,
+            auto_disabled=1 if auto_disabled else 0,
+            updated_at=datetime.now(UTC),
+        )
+        db.session.add(row)
+        db.session.commit()
+
+
+def _add_breaker(app, name, state="open", failures=5):
+    from db.models.circuit_breaker import CircuitBreakerState
+    from extensions import db
+
+    with app.app_context():
+        db.session.add(
+            CircuitBreakerState(
+                name=name,
+                state=state,
+                failure_count=failures,
+                updated_at=datetime.now(UTC),
+            )
+        )
+        db.session.commit()
+
+
+class TestLibraryHealthService:
+    def test_empty_library(self, app_ctx):
+        from services.health_overview import get_library_health
+
+        result = get_library_health()
+        assert result["totals"]["wanted"] == 0
+        assert result["totals"]["problems"] == 0
+        assert result["series"] == []
+        assert result["problems"] == []
+
+    def test_series_aggregation_and_problem_items(self, client):
+        app = client.application
+        _add_wanted(app, "Show A", status="wanted", file_path="/m/a1.mkv")
+        _add_wanted(app, "Show A", status="failed", error="File not found", file_path="/m/a2.mkv")
+        _add_wanted(app, "Show A", failure_kind="unsourceable", file_path="/m/a3.mkv")
+        _add_wanted(app, "Show B", status="wanted", file_path="/m/b1.mkv")
+        _add_wanted(app, "Show C", status="ignored", file_path="/m/c1.mkv")
+
+        resp = client.get("/api/v1/health/library")
+        assert resp.status_code == 200
+        body = resp.get_json()
+
+        assert body["totals"]["wanted"] == 4  # ignored excluded
+        assert body["totals"]["problems"] == 2
+        assert body["totals"]["unmatched"] == 1
+
+        by_title = {s["title"]: s for s in body["series"]}
+        assert by_title["Show A"]["missing"] == 3
+        assert by_title["Show A"]["problems"] == 2
+        assert by_title["Show B"]["missing"] == 1
+        assert "Show C" not in by_title
+
+        kinds = {p["failure_kind"] for p in body["problems"]}
+        assert "unsourceable" in kinds
+        assert all(p["status"] != "ignored" for p in body["problems"])
+
+    def test_provider_health_merges_breaker_and_stats(self, client):
+        app = client.application
+        _add_provider_stats(app, "goodprov", searches=100, hits=60)
+        _add_provider_stats(app, "deadprov", searches=50, hits=1)
+        _add_breaker(app, "brokenprov", state="open", failures=7)
+
+        resp = client.get("/api/v1/health/library")
+        assert resp.status_code == 200
+        providers = {p["provider"]: p for p in resp.get_json()["providers"]}
+
+        assert providers["goodprov"]["degraded"] is False
+        assert providers["deadprov"]["degraded"] is True  # 2% hit rate over 50 searches
+        assert providers["brokenprov"]["degraded"] is True
+        assert providers["brokenprov"]["breaker_state"] == "open"
+        assert providers["brokenprov"]["breaker_failures"] == 7
+        # Degraded providers sort first.
+        listed = [p["provider"] for p in resp.get_json()["providers"]]
+        assert listed.index("goodprov") > max(
+            listed.index("deadprov"), listed.index("brokenprov")
+        )
+
+
+class TestSyncRateInSubtitlesStats:
+    def _add_sync_run(self, app, status, engine="ffsubsync"):
+        from db.models.core import SyncJobRun
+        from extensions import db
+
+        with app.app_context():
+            db.session.add(
+                SyncJobRun(
+                    engine=engine,
+                    status=status,
+                    offset_ms=100,
+                    duration_ms=1000,
+                    subtitle_path="/m/a.de.srt",
+                    video_path="/m/a.mkv",
+                    created_at=datetime.now(UTC),
+                )
+            )
+            db.session.commit()
+
+    def test_sync_rate_none_without_runs(self, client):
+        resp = client.get("/api/v1/statistics/subtitles")
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["sync_runs"] == 0
+        assert body["sync_rate"] is None
+
+    def test_sync_rate_computed(self, client):
+        app = client.application
+        self._add_sync_run(app, "ok")
+        self._add_sync_run(app, "ok")
+        self._add_sync_run(app, "ok")
+        self._add_sync_run(app, "failed")
+
+        resp = client.get("/api/v1/statistics/subtitles")
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["sync_runs"] == 4
+        assert body["sync_ok"] == 3
+        assert body["sync_rate"] == 0.75

--- a/backend/tests/test_health_overview.py
+++ b/backend/tests/test_health_overview.py
@@ -113,9 +113,7 @@ class TestLibraryHealthService:
         assert providers["brokenprov"]["breaker_failures"] == 7
         # Degraded providers sort first.
         listed = [p["provider"] for p in resp.get_json()["providers"]]
-        assert listed.index("goodprov") > max(
-            listed.index("deadprov"), listed.index("brokenprov")
-        )
+        assert listed.index("goodprov") > max(listed.index("deadprov"), listed.index("brokenprov"))
 
 
 class TestSyncRateInSubtitlesStats:

--- a/backend/tests/test_history_rollback.py
+++ b/backend/tests/test_history_rollback.py
@@ -1,0 +1,211 @@
+"""Tests for the History rollback feature.
+
+Covers:
+- services.subtitle_restore.backup_before_replace (single-slot semantics)
+- save_subtitle preserving an existing sidecar into the bak slot
+- POST /api/v1/history/<id>/rollback (same-format swap, cross-format
+  upgrade rollback, missing entry/backup)
+- get_download_history enrichment with previous_score/previous_format
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+from subtitle_filename import bak_path_for
+
+# ── backup_before_replace ─────────────────────────────────────────────────────
+
+
+class TestBackupBeforeReplace:
+    def test_creates_bak_when_slot_free(self, tmp_path):
+        from services.subtitle_restore import backup_before_replace
+
+        active = tmp_path / "ep.de.srt"
+        active.write_text("old content", encoding="utf-8")
+
+        bak = backup_before_replace(str(active))
+
+        assert bak == bak_path_for(str(active))
+        assert open(bak, encoding="utf-8").read() == "old content"
+        # Active file itself is untouched (copy, not move).
+        assert active.read_text(encoding="utf-8") == "old content"
+
+    def test_never_overwrites_existing_bak(self, tmp_path):
+        """The bak is a single-slot undo — an existing one must survive."""
+        from services.subtitle_restore import backup_before_replace
+
+        active = tmp_path / "ep.de.srt"
+        active.write_text("second version", encoding="utf-8")
+        existing_bak = bak_path_for(str(active))
+        os.makedirs(os.path.dirname(existing_bak), exist_ok=True)
+        with open(existing_bak, "w", encoding="utf-8") as f:
+            f.write("pristine original")
+
+        assert backup_before_replace(str(active)) is None
+        assert open(existing_bak, encoding="utf-8").read() == "pristine original"
+
+    def test_noop_when_active_missing(self, tmp_path):
+        from services.subtitle_restore import backup_before_replace
+
+        assert backup_before_replace(str(tmp_path / "missing.de.srt")) is None
+
+
+# ── save_subtitle writes a bak before replacing ──────────────────────────────
+
+
+def _make_result(content: bytes = b"1\n00:00:01,000 --> 00:00:02,000\nNeu\n"):
+    from providers.base import SubtitleFormat, SubtitleResult
+
+    r = SubtitleResult.__new__(SubtitleResult)
+    r.content = content
+    r.format = SubtitleFormat.SRT
+    r.provider_name = "test_provider"
+    r.language = "de"
+    r.score = 100
+    r.subtitle_id = "sub123"
+    return r
+
+
+def _make_manager():
+    from providers import ProviderManager
+
+    mgr = ProviderManager.__new__(ProviderManager)
+    mgr._providers = {}
+    return mgr
+
+
+class TestSaveSubtitleBackupOnReplace:
+    def test_existing_sidecar_is_preserved_into_bak(self, tmp_path):
+        mgr = _make_manager()
+        result = _make_result()
+        output = str(tmp_path / "episode.de.srt")
+        with open(output, "w", encoding="utf-8") as f:
+            f.write("previous version")
+
+        mock_settings = MagicMock(media_path=str(tmp_path), dedup_on_download=False)
+        with (
+            patch("config.get_settings", return_value=mock_settings),
+            patch("security_utils.is_safe_path", return_value=True),
+        ):
+            saved = mgr.save_subtitle(result, output)
+
+        assert os.path.isfile(saved)
+        bak = bak_path_for(output)
+        assert os.path.isfile(bak), "replaced sidecar must be preserved in the bak slot"
+        assert open(bak, encoding="utf-8").read() == "previous version"
+
+    def test_fresh_save_creates_no_bak(self, tmp_path):
+        mgr = _make_manager()
+        result = _make_result()
+        output = str(tmp_path / "episode.de.srt")
+
+        mock_settings = MagicMock(media_path=str(tmp_path), dedup_on_download=False)
+        with (
+            patch("config.get_settings", return_value=mock_settings),
+            patch("security_utils.is_safe_path", return_value=True),
+        ):
+            mgr.save_subtitle(result, output)
+
+        assert not os.path.exists(bak_path_for(output))
+
+
+# ── Rollback route ───────────────────────────────────────────────────────────
+
+
+def _record_download(client, file_path, fmt="srt", lang="de", score=100, upgraded_from_id=None):
+    from db.providers import record_subtitle_download
+
+    with client.application.app_context():
+        record_subtitle_download(
+            "test_provider",
+            "sub123",
+            lang,
+            fmt,
+            file_path,
+            score,
+            upgraded_from_id=upgraded_from_id,
+        )
+        from db.providers import get_latest_download_id
+
+        return get_latest_download_id(file_path)
+
+
+class TestRollbackRoute:
+    def test_entry_not_found(self, client):
+        resp = client.post("/api/v1/history/999999/rollback")
+        assert resp.status_code == 404
+
+    def test_no_backup_returns_404(self, client, tmp_path):
+        mkv = tmp_path / "ep.mkv"
+        mkv.touch()
+        sidecar = tmp_path / "ep.de.srt"
+        sidecar.write_text("current", encoding="utf-8")
+        dl_id = _record_download(client, str(mkv))
+
+        resp = client.post(f"/api/v1/history/{dl_id}/rollback")
+        assert resp.status_code == 404
+        assert "backup" in resp.get_json()["error"].lower()
+
+    def test_same_format_rollback_swaps_active_and_bak(self, client, tmp_path):
+        mkv = tmp_path / "ep.mkv"
+        mkv.touch()
+        sidecar = tmp_path / "ep.de.srt"
+        sidecar.write_text("new version", encoding="utf-8")
+        bak = bak_path_for(str(sidecar))
+        os.makedirs(os.path.dirname(bak), exist_ok=True)
+        with open(bak, "w", encoding="utf-8") as f:
+            f.write("old version")
+        dl_id = _record_download(client, str(mkv))
+
+        resp = client.post(f"/api/v1/history/{dl_id}/rollback")
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["status"] == "restored"
+        assert sidecar.read_text(encoding="utf-8") == "old version"
+        # Swap semantics: invoking rollback again flips back.
+        assert open(bak, encoding="utf-8").read() == "new version"
+
+    def test_cross_format_rollback_restores_old_and_retires_new(self, client, tmp_path):
+        mkv = tmp_path / "ep.mkv"
+        mkv.touch()
+        # The upgrade replaced ep.de.srt with ep.de.ass; the old SRT was
+        # preserved in its bak slot at upgrade time.
+        old_srt_active = tmp_path / "ep.de.srt"
+        old_bak = bak_path_for(str(old_srt_active))
+        os.makedirs(os.path.dirname(old_bak), exist_ok=True)
+        with open(old_bak, "w", encoding="utf-8") as f:
+            f.write("old srt version")
+        new_ass = tmp_path / "ep.de.ass"
+        new_ass.write_text("new ass version", encoding="utf-8")
+
+        prev_id = _record_download(client, str(mkv), fmt="srt", score=100)
+        new_id = _record_download(client, str(mkv), fmt="ass", score=180, upgraded_from_id=prev_id)
+
+        resp = client.post(f"/api/v1/history/{new_id}/rollback")
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["status"] == "restored"
+        assert old_srt_active.read_text(encoding="utf-8") == "old srt version"
+        assert not new_ass.exists(), "the upgraded ASS must be retired"
+        # The retired ASS is itself recoverable from its bak slot.
+        assert open(bak_path_for(str(new_ass)), encoding="utf-8").read() == "new ass version"
+
+
+# ── History listing enrichment ───────────────────────────────────────────────
+
+
+class TestHistoryPreviousFields:
+    def test_upgrade_entry_carries_previous_score_and_format(self, client, tmp_path):
+        mkv = tmp_path / "ep.mkv"
+        mkv.touch()
+        prev_id = _record_download(client, str(mkv), fmt="srt", score=90)
+        _record_download(client, str(mkv), fmt="ass", score=150, upgraded_from_id=prev_id)
+
+        resp = client.get("/api/v1/history")
+        assert resp.status_code == 200
+        entries = resp.get_json()["data"]
+        by_format = {e["format"]: e for e in entries}
+        assert by_format["ass"]["upgraded_from_id"] == prev_id
+        assert by_format["ass"]["previous_score"] == 90
+        assert by_format["ass"]["previous_format"] == "srt"
+        assert by_format["srt"]["previous_score"] is None

--- a/backend/tests/test_routes_wanted_dry_run.py
+++ b/backend/tests/test_routes_wanted_dry_run.py
@@ -1,0 +1,95 @@
+"""Tests for POST /api/v1/wanted/dry-run (pipeline preview batch route)."""
+
+from db.wanted import get_wanted_item, upsert_wanted_item
+
+
+def _make_wanted_item(client, tmp_path, name="ep.mkv"):
+    mkv = tmp_path / name
+    mkv.touch()
+    with client.application.app_context():
+        row_id, _ = upsert_wanted_item(
+            item_type="episode",
+            file_path=str(mkv),
+            target_language="de",
+        )
+    return row_id
+
+
+class TestDryRunValidation:
+    def test_missing_item_ids(self, client):
+        resp = client.post("/api/v1/wanted/dry-run", json={})
+        assert resp.status_code == 400
+
+    def test_empty_item_ids(self, client):
+        resp = client.post("/api/v1/wanted/dry-run", json={"item_ids": []})
+        assert resp.status_code == 400
+
+    def test_non_integer_item_ids(self, client):
+        resp = client.post("/api/v1/wanted/dry-run", json={"item_ids": ["abc"]})
+        assert resp.status_code == 400
+
+    def test_too_many_items(self, client):
+        resp = client.post("/api/v1/wanted/dry-run", json={"item_ids": list(range(1, 20))})
+        assert resp.status_code == 400
+
+
+class TestDryRunExecution:
+    def test_unknown_item_reports_error(self, client):
+        resp = client.post("/api/v1/wanted/dry-run", json={"item_ids": [999999]})
+        assert resp.status_code == 200
+        results = resp.get_json()["results"]
+        assert len(results) == 1
+        assert results[0]["wanted_id"] == 999999
+        assert results[0]["status"] == "error"
+
+    def test_preview_result_passthrough_and_order(self, client, tmp_path, monkeypatch):
+        id_a = _make_wanted_item(client, tmp_path, "a.mkv")
+        id_b = _make_wanted_item(client, tmp_path, "b.mkv")
+
+        def fake_process(item_id, dry_run=False, **kwargs):
+            assert dry_run is True
+            return {
+                "wanted_id": item_id,
+                "status": "found",
+                "dry_run": True,
+                "provider": "test_provider",
+                "score": 123,
+                "format": "ass",
+                "output_path": f"/media/{item_id}.de.ass",
+            }
+
+        import wanted_search
+
+        monkeypatch.setattr(wanted_search, "process_wanted_item", fake_process)
+
+        resp = client.post("/api/v1/wanted/dry-run", json={"item_ids": [id_b, id_a]})
+        assert resp.status_code == 200
+        results = resp.get_json()["results"]
+        assert [r["wanted_id"] for r in results] == [id_b, id_a]
+        assert all(r["status"] == "found" for r in results)
+        assert results[0]["provider"] == "test_provider"
+
+    def test_status_restored_after_preview(self, client, tmp_path, monkeypatch):
+        item_id = _make_wanted_item(client, tmp_path)
+
+        def fake_process(inner_id, dry_run=False, **kwargs):
+            # The real pipeline bumps the row to "searching" before it knows
+            # it is a preview — simulate that mutation.
+            from db.wanted import update_wanted_status
+
+            update_wanted_status(inner_id, "searching")
+            return {"wanted_id": inner_id, "status": "not_found", "dry_run": True}
+
+        import wanted_search
+
+        monkeypatch.setattr(wanted_search, "process_wanted_item", fake_process)
+
+        with client.application.app_context():
+            before = get_wanted_item(item_id)["status"]
+
+        resp = client.post("/api/v1/wanted/dry-run", json={"item_ids": [item_id]})
+        assert resp.status_code == 200
+
+        with client.application.app_context():
+            after = get_wanted_item(item_id)["status"]
+        assert after == before, "dry run must not leave the item stuck in 'searching'"

--- a/backend/tests/test_scheduler_listeners.py
+++ b/backend/tests/test_scheduler_listeners.py
@@ -129,8 +129,11 @@ def test_listener_error_does_not_crash_scheduler(scheduler, caplog):
         scheduled_run_time=datetime.now(UTC),
     )
     with (
+        # Patch the name in core's namespace — core.py binds _write_job_run
+        # at import time, so patching the package re-export never reaches
+        # the listener.
         patch(
-            "services.scheduler._write_job_run",
+            "services.scheduler.core._write_job_run",
             side_effect=RuntimeError("db down"),
         ),
         caplog.at_level(logging.ERROR, logger="services.scheduler"),

--- a/backend/tools/lint_no_new_env_fields.py
+++ b/backend/tools/lint_no_new_env_fields.py
@@ -156,7 +156,7 @@ def main(argv: list[str]) -> int:
     for msg in violations:
         print(f"  - {msg}")
     print()
-    print("UI-first convention (since v0.88.0-beta): only the 11 fields in")
+    print("UI-first convention (since v0.88.0-beta): only the fields in")
     print("_ALLOWED_BOOT_FIELDS are env-loadable. Everything else is UI-only.")
     return 1
 

--- a/backend/wanted_search/process.py
+++ b/backend/wanted_search/process.py
@@ -243,10 +243,15 @@ def _try_target_ass_direct(ctx: dict) -> dict | None:
 
         output_path = get_output_path_for_lang(file_path, "ass", item_lang)
 
-        # If upgrading from SRT, remove old SRT file
+        # If upgrading from SRT, retire the old SRT file. Preserve it into
+        # its single-slot .bak first (when that slot is free) so the History
+        # rollback endpoint can restore the pre-upgrade state.
         if is_upgrade:
             old_srt = get_output_path_for_lang(file_path, "srt", item_lang)
             if os.path.exists(old_srt):
+                from services.subtitle_restore import backup_before_replace
+
+                backup_before_replace(old_srt)
                 os.remove(old_srt)
                 logger.info("Wanted %d: Removed old SRT: %s", item_id, old_srt)
             record_upgrade(

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -39,6 +39,7 @@ const SetupPage = lazy(() => import('@/pages/Setup').then(m => ({ default: m.Set
 const LoginPage = lazy(() => import('@/pages/Login').then(m => ({ default: m.LoginPage })))
 const MovieDetailPage = lazy(() => import('@/pages/MovieDetail').then(m => ({ default: m.MovieDetailPage })))
 const StatisticsPage = lazy(() => import('@/pages/StatisticsPage').then(m => ({ default: m.StatisticsPage })))
+const HealthPage = lazy(() => import('@/pages/HealthPage').then(m => ({ default: m.HealthPage })))
 const WantedPage = lazy(() => import('@/pages/Wanted').then(m => ({ default: m.WantedPage })))
 const TrashPage = lazy(() => import('@/pages/Trash').then(m => ({ default: m.TrashPage })))
 const LogsPage = lazy(() => import('@/pages/Logs').then(m => ({ default: m.LogsPage })))
@@ -88,6 +89,7 @@ function AnimatedRoutes() {
           <Route path="/language-profiles" element={<Navigate to="/settings/subtitles/languages" replace />} />
           <Route path="/movies/:id" element={<Suspense fallback={<FormSkeleton />}><MovieDetailPage /></Suspense>} />
           <Route path="/statistics" element={<Suspense fallback={<PageSkeleton />}><StatisticsPage /></Suspense>} />
+          <Route path="/health" element={<Suspense fallback={<PageSkeleton />}><HealthPage /></Suspense>} />
           {/* Redirect old standalone pages into settings sub-routes */}
           <Route path="/tasks" element={<Navigate to="/settings/automation" replace />} />
           <Route path="/plugins" element={<Navigate to="/settings/providers" replace />} />

--- a/frontend/src/api/system.ts
+++ b/frontend/src/api/system.ts
@@ -13,6 +13,7 @@
  * All existing imports from '@/api/system' continue to work unchanged.
  */
 export * from './system/activity'
+export * from './system/healthLibrary'
 export * from './system/history'
 export * from './system/logs'
 export * from './system/standalone'

--- a/frontend/src/api/system/healthLibrary.ts
+++ b/frontend/src/api/system/healthLibrary.ts
@@ -1,0 +1,51 @@
+/** Library health overview — GET /api/v1/health/library (Health page). */
+import { api } from '../core'
+
+export interface HealthSeriesRow {
+  title: string
+  item_type: string
+  missing: number
+  problems: number
+}
+
+export interface HealthProblemRow {
+  id: number
+  title: string
+  season_episode: string
+  item_type: string
+  target_language: string
+  status: string
+  failure_kind: string | null
+  error: string
+  search_count: number
+  updated_at: string | null
+}
+
+export interface HealthProviderRow {
+  provider: string
+  breaker_state: string
+  breaker_failures: number
+  searches: number
+  hit_rate: number | null
+  failed_downloads: number
+  auto_disabled: boolean
+  degraded: boolean
+}
+
+export interface LibraryHealth {
+  totals: {
+    wanted: number
+    problems: number
+    unmatched: number
+    series_affected: number
+    providers_degraded: number
+  }
+  series: HealthSeriesRow[]
+  problems: HealthProblemRow[]
+  providers: HealthProviderRow[]
+}
+
+export async function getLibraryHealth(): Promise<LibraryHealth> {
+  const { data } = await api.get('/health/library')
+  return data
+}

--- a/frontend/src/api/system/history.ts
+++ b/frontend/src/api/system/history.ts
@@ -41,3 +41,10 @@ export async function getHistoryStats(): Promise<HistoryStats> {
   const { data } = await api.get('/history/stats')
   return data
 }
+
+export async function rollbackHistoryEntry(
+  id: number
+): Promise<{ status: string; path: string; removed?: string; warning?: string }> {
+  const { data } = await api.post(`/history/${id}/rollback`)
+  return data
+}

--- a/frontend/src/api/system/statistics.ts
+++ b/frontend/src/api/system/statistics.ts
@@ -10,6 +10,9 @@ export interface SubtitlesStats {
   by_provider: Record<string, number>
   by_language: Record<string, number>
   avg_score: number
+  sync_runs: number
+  sync_ok: number
+  sync_rate: number | null
 }
 
 export interface TranslationStats {

--- a/frontend/src/api/wanted.ts
+++ b/frontend/src/api/wanted.ts
@@ -173,6 +173,25 @@ export async function searchAllWanted(): Promise<{ status: string }> {
   return data
 }
 
+/** One item's dry-run (pipeline preview) outcome — nothing was written. */
+export interface WantedDryRunResult {
+  wanted_id: number
+  status: 'found' | 'not_found' | 'skipped' | 'failed' | 'error'
+  dry_run?: boolean
+  provider?: string
+  score?: number
+  format?: string
+  output_path?: string
+  reason?: string
+  error?: string
+}
+
+/** Preview what the automation pipeline would download, without writing anything. */
+export async function dryRunWanted(itemIds: number[]): Promise<{ results: WantedDryRunResult[] }> {
+  const { data } = await api.post('/wanted/dry-run', { item_ids: itemIds }, { timeout: 300_000 })
+  return data
+}
+
 export interface BatchProbeStatus {
   running: boolean
   total: number

--- a/frontend/src/components/layout/IconSidebar.tsx
+++ b/frontend/src/components/layout/IconSidebar.tsx
@@ -1,6 +1,6 @@
 import { NavLink } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import { LayoutDashboard, BookOpen, Bell, Settings, Search, Trash2, ScrollText, BarChart3 } from 'lucide-react'
+import { LayoutDashboard, BookOpen, Bell, Settings, Search, Trash2, ScrollText, BarChart3, HeartPulse } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { formatVersion } from '@/lib/version'
 import { useHealth, useUpdateInfo } from '@/hooks/useApi'
@@ -26,6 +26,7 @@ const mainNavItems: readonly NavItem[] = [
 
 const bottomNavItems: readonly NavItem[] = [
   { to: '/statistics', labelKey: 'nav.statistics', icon: BarChart3, testId: 'nav-link-statistics' },
+  { to: '/health', labelKey: 'nav.health', icon: HeartPulse, testId: 'nav-link-health' },
   { to: '/settings', labelKey: 'nav.settings', icon: Settings, testId: 'nav-link-settings' },
   { to: '/logs', labelKey: 'nav.logs', icon: ScrollText, testId: 'nav-link-logs' },
 ] as const

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -16,6 +16,7 @@ import {
   BarChart3,
   ListChecks,
   Heart,
+  HeartPulse,
   Star,
   LogOut,
   Puzzle,
@@ -63,6 +64,7 @@ const navGroups: NavGroup[] = [
     items: [
       { to: '/settings', labelKey: 'nav.settings', icon: Settings },
       { to: '/statistics', labelKey: 'nav.statistics', icon: BarChart3 },
+      { to: '/health', labelKey: 'nav.health', icon: HeartPulse },
       { to: '/tasks', labelKey: 'nav.tasks', icon: ListChecks },
       { to: '/logs', labelKey: 'nav.logs', icon: ScrollText },
       { to: '/plugins', labelKey: 'nav.plugins', icon: Puzzle },

--- a/frontend/src/components/wanted/DryRunModal.tsx
+++ b/frontend/src/components/wanted/DryRunModal.tsx
@@ -1,0 +1,148 @@
+/**
+ * DryRunModal — preview what the automation pipeline would download.
+ *
+ * Runs POST /wanted/dry-run for one wanted item: the full pipeline executes
+ * (profile gates, provider search, upgrade decision) but nothing is written
+ * to disk or the DB. Shows the provider/score/format/path a real run would
+ * produce.
+ */
+
+import { useEffect } from 'react'
+import { createPortal } from 'react-dom'
+import { useQuery } from '@tanstack/react-query'
+import { X, Loader2, FlaskConical, CheckCircle2, CircleSlash, AlertCircle } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { dryRunWanted, type WantedDryRunResult } from '@/api/wanted'
+
+interface DryRunModalProps {
+  open: boolean
+  itemId?: number
+  itemTitle: string
+  onClose: () => void
+}
+
+function ResultBody({ result, t }: { result: WantedDryRunResult; t: (key: string, opts?: Record<string, unknown>) => string }) {
+  if (result.status === 'found') {
+    return (
+      <div className="space-y-3">
+        <div className="flex items-center gap-2 text-sm" style={{ color: 'var(--success)' }}>
+          <CheckCircle2 size={16} />
+          <span className="font-medium">{t('wanted_row.dry_run_found')}</span>
+        </div>
+        <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1.5 text-xs">
+          <dt style={{ color: 'var(--text-muted)' }}>{t('interactive_search.col_provider')}</dt>
+          <dd className="capitalize" style={{ color: 'var(--text-primary)', fontFamily: 'var(--font-mono)' }}>{result.provider}</dd>
+          <dt style={{ color: 'var(--text-muted)' }}>{t('interactive_search.col_score')}</dt>
+          <dd style={{ color: 'var(--text-primary)', fontFamily: 'var(--font-mono)' }}>{result.score}</dd>
+          <dt style={{ color: 'var(--text-muted)' }}>{t('interactive_search.col_format')}</dt>
+          <dd className="uppercase" style={{ color: 'var(--text-primary)', fontFamily: 'var(--font-mono)' }}>{result.format}</dd>
+          <dt style={{ color: 'var(--text-muted)' }}>{t('wanted_row.dry_run_target')}</dt>
+          <dd className="break-all" style={{ color: 'var(--text-secondary)', fontFamily: 'var(--font-mono)' }}>{result.output_path}</dd>
+        </dl>
+      </div>
+    )
+  }
+  if (result.status === 'not_found') {
+    return (
+      <div className="flex items-center gap-2 text-sm" style={{ color: 'var(--text-secondary)' }}>
+        <CircleSlash size={16} />
+        {t('wanted_row.dry_run_not_found')}
+      </div>
+    )
+  }
+  if (result.status === 'skipped') {
+    return (
+      <div className="flex items-start gap-2 text-sm" style={{ color: 'var(--text-secondary)' }}>
+        <CircleSlash size={16} className="shrink-0 mt-0.5" />
+        <span>{t('wanted_row.dry_run_skipped')}{result.reason ? ` — ${result.reason}` : ''}</span>
+      </div>
+    )
+  }
+  return (
+    <div className="flex items-start gap-2 text-sm" style={{ color: 'var(--error)' }}>
+      <AlertCircle size={16} className="shrink-0 mt-0.5" />
+      <span>{result.error ?? t('wanted_row.dry_run_failed')}</span>
+    </div>
+  )
+}
+
+export function DryRunModal({ open, itemId, itemTitle, onClose }: DryRunModalProps) {
+  const { t } = useTranslation('library')
+
+  const query = useQuery({
+    queryKey: ['wanted-dry-run', itemId],
+    queryFn: () => dryRunWanted([itemId!]),
+    enabled: open && !!itemId,
+    staleTime: 0,
+    gcTime: 60_000,
+    retry: false,
+  })
+
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [open, onClose])
+
+  if (!open) return null
+
+  const result = query.data?.results?.[0]
+  const isLoading = query.isLoading || query.isFetching
+
+  return createPortal(
+    <>
+      <div className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm" onClick={onClose} />
+      <div
+        className="fixed inset-0 z-50 flex items-center justify-center p-4 pointer-events-none"
+        aria-modal="true"
+        role="dialog"
+      >
+        <div
+          className="pointer-events-auto w-full max-w-lg rounded-lg shadow-2xl overflow-hidden"
+          style={{ backgroundColor: 'var(--bg-elevated)', border: '1px solid var(--border)' }}
+          onClick={(e) => e.stopPropagation()}
+        >
+          {/* Header */}
+          <div className="flex items-center justify-between px-5 py-4 border-b border-[var(--border)]">
+            <div className="flex items-center gap-3 min-w-0">
+              <FlaskConical className="w-5 h-5 text-teal-400 shrink-0" />
+              <div className="min-w-0">
+                <p className="text-xs uppercase tracking-wider" style={{ color: 'var(--text-muted)' }}>
+                  {t('wanted_row.dry_run_title')}
+                </p>
+                <h2 className="text-sm font-semibold truncate" style={{ color: 'var(--text-primary)' }}>{itemTitle}</h2>
+              </div>
+            </div>
+            <button onClick={onClose} className="p-1 rounded" style={{ color: 'var(--text-muted)' }}>
+              <X size={16} />
+            </button>
+          </div>
+
+          {/* Body */}
+          <div className="px-5 py-4">
+            {isLoading ? (
+              <div className="flex items-center gap-2 text-sm py-2" style={{ color: 'var(--text-secondary)' }}>
+                <Loader2 size={16} className="animate-spin" />
+                {t('wanted_row.dry_run_running')}
+              </div>
+            ) : query.isError ? (
+              <div className="flex items-center gap-2 text-sm" style={{ color: 'var(--error)' }}>
+                <AlertCircle size={16} />
+                {t('wanted_row.dry_run_failed')}
+              </div>
+            ) : result ? (
+              <ResultBody result={result} t={t} />
+            ) : null}
+            <p className="text-[11px] mt-4" style={{ color: 'var(--text-muted)' }}>
+              {t('wanted_row.dry_run_note')}
+            </p>
+          </div>
+        </div>
+      </div>
+    </>,
+    document.body
+  )
+}

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -23,6 +23,8 @@ import enEditor from './locales/en/editor.json'
 import deEditor from './locales/de/editor.json'
 import enSetup from './locales/en/setup.json'
 import deSetup from './locales/de/setup.json'
+import enHealth from './locales/en/health.json'
+import deHealth from './locales/de/health.json'
 
 i18n
   .use(LanguageDetector)
@@ -40,6 +42,7 @@ i18n
         onboarding: enOnboarding,
         editor: enEditor,
         setup: enSetup,
+        health: enHealth,
       },
       de: {
         common: deCommon,
@@ -52,11 +55,12 @@ i18n
         onboarding: deOnboarding,
         editor: deEditor,
         setup: deSetup,
+        health: deHealth,
       },
     },
     fallbackLng: 'de',
     defaultNS: 'common',
-    ns: ['common', 'dashboard', 'settings', 'library', 'activity', 'logs', 'statistics', 'onboarding', 'editor', 'setup'],
+    ns: ['common', 'dashboard', 'settings', 'library', 'activity', 'logs', 'statistics', 'onboarding', 'editor', 'setup', 'health'],
     interpolation: {
       escapeValue: false, // React already escapes
     },

--- a/frontend/src/i18n/locales/de/activity.json
+++ b/frontend/src/i18n/locales/de/activity.json
@@ -101,7 +101,8 @@
       "format": "Format",
       "score": "Score",
       "date": "Datum",
-      "actions": "Aktionen"
+      "actions": "Aktionen",
+      "reason": "Grund"
     },
     "no_history": "Noch kein Download-Verlauf",
     "preview_subtitle": "Untertitel vorschau",
@@ -113,7 +114,19 @@
     "blacklist_confirm_action": "Sperren",
     "blacklist_also_delete": "Datei ebenfalls löschen",
     "blacklisted_success": "Zur Sperrliste hinzugefügt",
-    "deleted_and_blacklisted": "Untertitel gelöscht und gesperrt"
+    "deleted_and_blacklisted": "Untertitel gelöscht und gesperrt",
+    "reason_upgrade": "Upgrade",
+    "reason_upgrade_tooltip": "Hat einen zuvor geladenen Untertitel durch einen besseren ersetzt",
+    "reason_new": "Neu",
+    "reason_manual": "Manuell",
+    "reason_whisper": "Whisper",
+    "reason_mt": "MT",
+    "rollback": "Vorherige Version wiederherstellen",
+    "rollback_confirm_title": "Vorherige Version wiederherstellen?",
+    "rollback_confirm_text": "Der aktuelle Untertitel wird mit seinem Backup getauscht — ein erneuter Rollback stellt die aktuelle Version wieder her.",
+    "rollback_confirm_action": "Wiederherstellen",
+    "rollback_success": "Vorherige Untertitel-Version wiederhergestellt",
+    "rollback_failed": "Rollback fehlgeschlagen"
   },
   "blacklist": {
     "title": "Sperrliste",

--- a/frontend/src/i18n/locales/de/common.json
+++ b/frontend/src/i18n/locales/de/common.json
@@ -10,6 +10,7 @@
     "settings": "Einstellungen",
     "logs": "Protokolle",
     "statistics": "Statistiken",
+    "health": "Health",
     "tasks": "Aufgaben",
     "plugins": "Plugins",
     "trash": "Papierkorb",

--- a/frontend/src/i18n/locales/de/health.json
+++ b/frontend/src/i18n/locales/de/health.json
@@ -1,0 +1,55 @@
+{
+  "title": "Health",
+  "subtitle": "Wo es in der Bibliothek klemmt: fehlende Untertitel, nicht gematchte Episoden, fehlschlagende Provider",
+  "refresh_note": "Aktualisiert sich automatisch jede Minute.",
+  "totals": {
+    "wanted": "Fehlende Untertitel",
+    "problems": "Problem-Einträge",
+    "unmatched": "Nicht gematcht",
+    "series_affected": "Betroffene Serien",
+    "providers_degraded": "Provider beeinträchtigt"
+  },
+  "series": {
+    "title": "Serien & Filme mit fehlenden Untertiteln",
+    "col_title": "Titel",
+    "col_type": "Typ",
+    "col_missing": "Fehlend",
+    "col_problems": "Probleme",
+    "type_episode": "Serie",
+    "type_movie": "Film",
+    "empty": "Keine fehlenden Untertitel — alles abgedeckt.",
+    "hint": "Details und Aktionen pro Episode gibt es auf der",
+    "wanted_link": "Wanted-Seite"
+  },
+  "problems": {
+    "title": "Fehlgeschlagene & nicht gematchte Einträge",
+    "col_item": "Eintrag",
+    "col_lang": "Sprache",
+    "col_kind": "Grund",
+    "col_error": "Fehler",
+    "col_attempts": "Versuche",
+    "col_updated": "Aktualisiert",
+    "empty": "Keine fehlgeschlagenen oder nicht gematchten Einträge."
+  },
+  "failure": {
+    "no_result": "Kein Treffer",
+    "no_result_slow": "Kein Treffer (langsamer Retry)",
+    "provider_error": "Provider-Fehler",
+    "unsourceable": "Nicht gematcht",
+    "failed": "Fehlgeschlagen"
+  },
+  "providers": {
+    "title": "Provider-Gesundheit",
+    "col_provider": "Provider",
+    "col_state": "Status",
+    "col_searches": "Suchen",
+    "col_hit_rate": "Trefferquote",
+    "col_failed_downloads": "Fehlgeschlagene Downloads",
+    "col_breaker_failures": "Breaker-Fehler",
+    "state_closed": "OK",
+    "state_open": "Offen",
+    "state_half_open": "Halb offen",
+    "auto_disabled": "Auto-deaktiviert",
+    "empty": "Noch keine Provider-Aktivität aufgezeichnet."
+  }
+}

--- a/frontend/src/i18n/locales/de/library.json
+++ b/frontend/src/i18n/locales/de/library.json
@@ -526,7 +526,16 @@
     "col_score": "Score",
     "col_release": "Release",
     "preview_subtitle": "Untertitel-Vorschau",
-    "interactive_search": "Interaktive Suche"
+    "interactive_search": "Interaktive Suche",
+    "dry_run": "Testlauf (Vorschau)",
+    "dry_run_title": "Testlauf",
+    "dry_run_running": "Provider werden durchsucht — es wird nichts geschrieben…",
+    "dry_run_found": "Ein Untertitel würde heruntergeladen",
+    "dry_run_not_found": "Es würde kein passender Untertitel gefunden",
+    "dry_run_skipped": "Eintrag würde übersprungen",
+    "dry_run_failed": "Testlauf fehlgeschlagen",
+    "dry_run_target": "Zielpfad",
+    "dry_run_note": "Nur Vorschau: Die Provider wurden real abgefragt, aber keine Datei gespeichert und keine Historie geschrieben."
   },
   "mt_pending": {
     "toolbar_button": "Ausstehende Originale",

--- a/frontend/src/i18n/locales/de/statistics.json
+++ b/frontend/src/i18n/locales/de/statistics.json
@@ -27,7 +27,12 @@
     "title": "Untertitel",
     "by_source": "Nach Quelle",
     "by_language": "Nach Sprache",
-    "by_provider": "Nach Provider"
+    "by_provider": "Nach Provider",
+    "sync_rate": "Sync-Erfolgsrate",
+    "sync_runs_one": "{{count}} Sync-Lauf",
+    "sync_runs_other": "{{count}} Sync-Läufe",
+    "sync_ok": "Syncs OK",
+    "sync_failed": "Syncs fehlgeschlagen"
   },
   "translation": {
     "title": "Übersetzung",

--- a/frontend/src/i18n/locales/en/activity.json
+++ b/frontend/src/i18n/locales/en/activity.json
@@ -101,7 +101,8 @@
       "format": "Format",
       "score": "Score",
       "date": "Date",
-      "actions": "Actions"
+      "actions": "Actions",
+      "reason": "Reason"
     },
     "no_history": "No download history yet",
     "preview_subtitle": "Preview subtitle",
@@ -113,7 +114,19 @@
     "blacklist_confirm_action": "Blacklist",
     "blacklist_also_delete": "Also delete the file",
     "blacklisted_success": "Added to blacklist",
-    "deleted_and_blacklisted": "Subtitle deleted and blacklisted"
+    "deleted_and_blacklisted": "Subtitle deleted and blacklisted",
+    "reason_upgrade": "Upgrade",
+    "reason_upgrade_tooltip": "Replaced a previously downloaded subtitle with a better one",
+    "reason_new": "New",
+    "reason_manual": "Manual",
+    "reason_whisper": "Whisper",
+    "reason_mt": "MT",
+    "rollback": "Restore previous version",
+    "rollback_confirm_title": "Restore previous version?",
+    "rollback_confirm_text": "The current subtitle is swapped with its backup — running the rollback again restores the current version.",
+    "rollback_confirm_action": "Restore",
+    "rollback_success": "Previous subtitle version restored",
+    "rollback_failed": "Rollback failed"
   },
   "blacklist": {
     "title": "Blacklist",

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -10,6 +10,7 @@
     "settings": "Settings",
     "logs": "Logs",
     "statistics": "Statistics",
+    "health": "Health",
     "tasks": "Tasks",
     "plugins": "Plugins",
     "trash": "Trash",

--- a/frontend/src/i18n/locales/en/health.json
+++ b/frontend/src/i18n/locales/en/health.json
@@ -1,0 +1,55 @@
+{
+  "title": "Health",
+  "subtitle": "Where the library hurts: missing subtitles, unmatched episodes, failing providers",
+  "refresh_note": "Refreshes automatically every minute.",
+  "totals": {
+    "wanted": "Missing subtitles",
+    "problems": "Problem items",
+    "unmatched": "Unmatched",
+    "series_affected": "Series affected",
+    "providers_degraded": "Providers degraded"
+  },
+  "series": {
+    "title": "Series & movies with missing subtitles",
+    "col_title": "Title",
+    "col_type": "Type",
+    "col_missing": "Missing",
+    "col_problems": "Problems",
+    "type_episode": "Series",
+    "type_movie": "Movie",
+    "empty": "No missing subtitles — everything is covered.",
+    "hint": "Details and actions per episode live on the",
+    "wanted_link": "Wanted page"
+  },
+  "problems": {
+    "title": "Failed & unmatched items",
+    "col_item": "Item",
+    "col_lang": "Lang",
+    "col_kind": "Reason",
+    "col_error": "Error",
+    "col_attempts": "Attempts",
+    "col_updated": "Updated",
+    "empty": "No failed or unmatched items."
+  },
+  "failure": {
+    "no_result": "No result",
+    "no_result_slow": "No result (slow retry)",
+    "provider_error": "Provider error",
+    "unsourceable": "Unmatched",
+    "failed": "Failed"
+  },
+  "providers": {
+    "title": "Provider health",
+    "col_provider": "Provider",
+    "col_state": "State",
+    "col_searches": "Searches",
+    "col_hit_rate": "Hit rate",
+    "col_failed_downloads": "Failed downloads",
+    "col_breaker_failures": "Breaker failures",
+    "state_closed": "OK",
+    "state_open": "Open",
+    "state_half_open": "Half-open",
+    "auto_disabled": "Auto-disabled",
+    "empty": "No provider activity recorded yet."
+  }
+}

--- a/frontend/src/i18n/locales/en/library.json
+++ b/frontend/src/i18n/locales/en/library.json
@@ -526,7 +526,16 @@
     "col_score": "Score",
     "col_release": "Release",
     "preview_subtitle": "Preview subtitle",
-    "interactive_search": "Interactive search"
+    "interactive_search": "Interactive search",
+    "dry_run": "Dry run (preview)",
+    "dry_run_title": "Dry Run",
+    "dry_run_running": "Searching providers — nothing will be written…",
+    "dry_run_found": "A subtitle would be downloaded",
+    "dry_run_not_found": "No matching subtitle would be found",
+    "dry_run_skipped": "Item would be skipped",
+    "dry_run_failed": "Dry run failed",
+    "dry_run_target": "Target path",
+    "dry_run_note": "Preview only: providers were queried for real, but no file was saved and no history was recorded."
   },
   "mt_pending": {
     "toolbar_button": "Pending originals",

--- a/frontend/src/i18n/locales/en/statistics.json
+++ b/frontend/src/i18n/locales/en/statistics.json
@@ -27,7 +27,12 @@
     "title": "Subtitles",
     "by_source": "By source",
     "by_language": "By language",
-    "by_provider": "By provider"
+    "by_provider": "By provider",
+    "sync_rate": "Sync success rate",
+    "sync_runs_one": "{{count}} sync run",
+    "sync_runs_other": "{{count}} sync runs",
+    "sync_ok": "Syncs OK",
+    "sync_failed": "Syncs failed"
   },
   "translation": {
     "title": "Translation",

--- a/frontend/src/pages/HealthPage.tsx
+++ b/frontend/src/pages/HealthPage.tsx
@@ -1,0 +1,263 @@
+/**
+ * Health page — "where does it hurt" overview of the library.
+ *
+ * Three bounded views from GET /api/v1/health/library: series with missing
+ * subtitles, wanted items stuck in a failure state (unmatched episodes), and
+ * per-provider health (circuit breaker ⋈ provider stats).
+ */
+import { useQuery } from '@tanstack/react-query'
+import { useTranslation } from 'react-i18next'
+import { HeartPulse, Loader2, AlertTriangle, CheckCircle2 } from 'lucide-react'
+import type { ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { PageHeader } from '@/components/layout/PageHeader'
+import { StatTile } from '@/components/statistics/primitives'
+import { getLibraryHealth, type HealthProblemRow, type HealthProviderRow } from '@/api/system/healthLibrary'
+import { formatRelativeTime, formatProviderName } from '@/lib/utils'
+
+function Section({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section className="space-y-2">
+      <h2 className="text-sm font-semibold text-secondary">{title}</h2>
+      {children}
+    </section>
+  )
+}
+
+function Th({ children, className = '' }: { children: ReactNode; className?: string }) {
+  return (
+    <th
+      scope="col"
+      className={`text-left text-[11px] font-semibold uppercase tracking-wider px-3 py-2 ${className}`}
+      style={{ color: 'var(--text-muted)' }}
+    >
+      {children}
+    </th>
+  )
+}
+
+function EmptyState({ label }: { label: string }) {
+  return (
+    <div className="flex items-center gap-2 px-3 py-6 text-sm" style={{ color: 'var(--text-secondary)' }}>
+      <CheckCircle2 size={15} style={{ color: 'var(--success)' }} />
+      {label}
+    </div>
+  )
+}
+
+function FailureKindBadge({ kind, status, t }: { kind: string | null; status: string; t: (key: string) => string }) {
+  const key = kind ?? status
+  const label = t(`failure.${key}`) === `failure.${key}` ? key : t(`failure.${key}`)
+  const isHard = kind === 'unsourceable' || status === 'failed'
+  return (
+    <span
+      className="text-[10px] px-1.5 py-0.5 rounded font-bold uppercase"
+      style={{
+        backgroundColor: isHard ? 'color-mix(in srgb, var(--error) 12%, transparent)' : 'color-mix(in srgb, var(--warning) 12%, transparent)',
+        color: isHard ? 'var(--error)' : 'var(--warning)',
+        fontFamily: 'var(--font-mono)',
+      }}
+    >
+      {label}
+    </span>
+  )
+}
+
+function ProblemRow({ item, t }: { item: HealthProblemRow; t: (key: string) => string }) {
+  return (
+    <tr style={{ borderBottom: '1px solid var(--border)' }}>
+      <td className="px-3 py-2">
+        <div className="text-sm font-medium truncate max-w-xs" style={{ color: 'var(--text-primary)' }}>{item.title}</div>
+        {item.season_episode && (
+          <div className="text-[11px]" style={{ color: 'var(--text-muted)', fontFamily: 'var(--font-mono)' }}>{item.season_episode}</div>
+        )}
+      </td>
+      <td className="px-3 py-2 text-xs uppercase" style={{ color: 'var(--text-secondary)', fontFamily: 'var(--font-mono)' }}>
+        {item.target_language}
+      </td>
+      <td className="px-3 py-2">
+        <FailureKindBadge kind={item.failure_kind} status={item.status} t={t} />
+      </td>
+      <td className="px-3 py-2 text-xs truncate max-w-[240px] hidden md:table-cell" title={item.error} style={{ color: 'var(--text-secondary)' }}>
+        {item.error || '—'}
+      </td>
+      <td className="px-3 py-2 text-xs tabular-nums hidden sm:table-cell" style={{ color: 'var(--text-secondary)', fontFamily: 'var(--font-mono)' }}>
+        {item.search_count}
+      </td>
+      <td className="px-3 py-2 text-xs tabular-nums hidden lg:table-cell" style={{ color: 'var(--text-muted)', fontFamily: 'var(--font-mono)' }}>
+        {item.updated_at ? formatRelativeTime(item.updated_at) : ''}
+      </td>
+    </tr>
+  )
+}
+
+function ProviderRow({ p, t }: { p: HealthProviderRow; t: (key: string) => string }) {
+  const stateColor = p.breaker_state === 'closed' && !p.auto_disabled ? 'var(--success)' : p.breaker_state === 'half_open' ? 'var(--warning)' : 'var(--error)'
+  return (
+    <tr style={{ borderBottom: '1px solid var(--border)' }}>
+      <td className="px-3 py-2">
+        <div className="flex items-center gap-2">
+          {p.degraded && <AlertTriangle size={13} style={{ color: 'var(--warning)' }} />}
+          <span className="text-sm font-medium capitalize" style={{ color: 'var(--text-primary)', fontFamily: 'var(--font-mono)' }}>
+            {formatProviderName(p.provider)}
+          </span>
+        </div>
+      </td>
+      <td className="px-3 py-2">
+        <span
+          className="text-[10px] px-1.5 py-0.5 rounded font-bold uppercase"
+          style={{ backgroundColor: `color-mix(in srgb, ${stateColor} 12%, transparent)`, color: stateColor, fontFamily: 'var(--font-mono)' }}
+        >
+          {p.auto_disabled ? t('providers.auto_disabled') : t(`providers.state_${p.breaker_state}`)}
+        </span>
+      </td>
+      <td className="px-3 py-2 text-xs tabular-nums hidden sm:table-cell" style={{ color: 'var(--text-secondary)', fontFamily: 'var(--font-mono)' }}>
+        {p.searches}
+      </td>
+      <td className="px-3 py-2 text-xs tabular-nums" style={{ color: 'var(--text-secondary)', fontFamily: 'var(--font-mono)' }}>
+        {p.hit_rate != null ? `${Math.round(p.hit_rate * 100)}%` : '—'}
+      </td>
+      <td className="px-3 py-2 text-xs tabular-nums hidden md:table-cell" style={{ color: p.failed_downloads > 0 ? 'var(--warning)' : 'var(--text-muted)', fontFamily: 'var(--font-mono)' }}>
+        {p.failed_downloads}
+      </td>
+      <td className="px-3 py-2 text-xs tabular-nums hidden lg:table-cell" style={{ color: 'var(--text-muted)', fontFamily: 'var(--font-mono)' }}>
+        {p.breaker_failures}
+      </td>
+    </tr>
+  )
+}
+
+export function HealthPage() {
+  const { t } = useTranslation('health')
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['library-health'],
+    queryFn: getLibraryHealth,
+    refetchInterval: 60_000,
+  })
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-60" style={{ color: 'var(--text-muted)' }}>
+        <Loader2 size={20} className="animate-spin" />
+      </div>
+    )
+  }
+
+  const totals = data?.totals
+  const degradedProviders = (data?.providers ?? []).filter((p) => p.degraded)
+  const healthyProviders = (data?.providers ?? []).filter((p) => !p.degraded)
+
+  return (
+    <div className="max-w-5xl mx-auto p-4 space-y-6">
+      <PageHeader title={t('title')} subtitle={t('subtitle')} className="mb-0" />
+
+      {/* Totals */}
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-2">
+        <StatTile label={t('totals.wanted')} value={totals?.wanted ?? 0} />
+        <StatTile label={t('totals.problems')} value={totals?.problems ?? 0} />
+        <StatTile label={t('totals.unmatched')} value={totals?.unmatched ?? 0} />
+        <StatTile label={t('totals.series_affected')} value={totals?.series_affected ?? 0} />
+        <StatTile label={t('totals.providers_degraded')} value={totals?.providers_degraded ?? 0} />
+      </div>
+
+      {/* Series with missing subtitles */}
+      <Section title={t('series.title')}>
+        <div className="rounded-lg overflow-hidden" style={{ backgroundColor: 'var(--bg-surface)', border: '1px solid var(--border)' }}>
+          {data?.series.length ? (
+            <div className="overflow-x-auto max-h-[320px] overflow-y-auto">
+              <table className="w-full min-w-[420px]">
+                <thead>
+                  <tr style={{ borderBottom: '1px solid var(--border)' }}>
+                    <Th>{t('series.col_title')}</Th>
+                    <Th>{t('series.col_type')}</Th>
+                    <Th>{t('series.col_missing')}</Th>
+                    <Th>{t('series.col_problems')}</Th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.series.map((s) => (
+                    <tr key={`${s.item_type}:${s.title}`} style={{ borderBottom: '1px solid var(--border)' }}>
+                      <td className="px-3 py-2 text-sm font-medium truncate max-w-xs" style={{ color: 'var(--text-primary)' }}>{s.title}</td>
+                      <td className="px-3 py-2 text-xs" style={{ color: 'var(--text-muted)' }}>{t(`series.type_${s.item_type}`)}</td>
+                      <td className="px-3 py-2 text-xs tabular-nums" style={{ color: 'var(--warning)', fontFamily: 'var(--font-mono)' }}>{s.missing}</td>
+                      <td className="px-3 py-2 text-xs tabular-nums" style={{ color: s.problems > 0 ? 'var(--error)' : 'var(--text-muted)', fontFamily: 'var(--font-mono)' }}>{s.problems}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <EmptyState label={t('series.empty')} />
+          )}
+        </div>
+        <p className="text-[11px]" style={{ color: 'var(--text-muted)' }}>
+          {t('series.hint')} <Link to="/wanted" className="underline" style={{ color: 'var(--accent)' }}>{t('series.wanted_link')}</Link>
+        </p>
+      </Section>
+
+      {/* Problem items (failed / unmatched) */}
+      <Section title={t('problems.title')}>
+        <div className="rounded-lg overflow-hidden" style={{ backgroundColor: 'var(--bg-surface)', border: '1px solid var(--border)' }}>
+          {data?.problems.length ? (
+            <div className="overflow-x-auto max-h-[380px] overflow-y-auto">
+              <table className="w-full min-w-[520px]">
+                <thead>
+                  <tr style={{ borderBottom: '1px solid var(--border)' }}>
+                    <Th>{t('problems.col_item')}</Th>
+                    <Th>{t('problems.col_lang')}</Th>
+                    <Th>{t('problems.col_kind')}</Th>
+                    <Th className="hidden md:table-cell">{t('problems.col_error')}</Th>
+                    <Th className="hidden sm:table-cell">{t('problems.col_attempts')}</Th>
+                    <Th className="hidden lg:table-cell">{t('problems.col_updated')}</Th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.problems.map((item) => (
+                    <ProblemRow key={item.id} item={item} t={t} />
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <EmptyState label={t('problems.empty')} />
+          )}
+        </div>
+      </Section>
+
+      {/* Provider health */}
+      <Section title={t('providers.title')}>
+        <div className="rounded-lg overflow-hidden" style={{ backgroundColor: 'var(--bg-surface)', border: '1px solid var(--border)' }}>
+          {data?.providers.length ? (
+            <div className="overflow-x-auto max-h-[380px] overflow-y-auto">
+              <table className="w-full min-w-[520px]">
+                <thead>
+                  <tr style={{ borderBottom: '1px solid var(--border)' }}>
+                    <Th>{t('providers.col_provider')}</Th>
+                    <Th>{t('providers.col_state')}</Th>
+                    <Th className="hidden sm:table-cell">{t('providers.col_searches')}</Th>
+                    <Th>{t('providers.col_hit_rate')}</Th>
+                    <Th className="hidden md:table-cell">{t('providers.col_failed_downloads')}</Th>
+                    <Th className="hidden lg:table-cell">{t('providers.col_breaker_failures')}</Th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {[...degradedProviders, ...healthyProviders].map((p) => (
+                    <ProviderRow key={p.provider} p={p} t={t} />
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <EmptyState label={t('providers.empty')} />
+          )}
+        </div>
+      </Section>
+
+      <div className="flex items-center gap-1.5 text-[11px]" style={{ color: 'var(--text-muted)' }}>
+        <HeartPulse size={12} />
+        {t('refresh_note')}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/History.tsx
+++ b/frontend/src/pages/History.tsx
@@ -3,11 +3,12 @@ import { useTranslation } from 'react-i18next'
 import { useQueryClient } from '@tanstack/react-query'
 import { useHistory, useHistoryStats, useAddToBlacklist } from '@/hooks/useApi'
 import { deleteSubtitles } from '@/api/client'
+import { rollbackHistoryEntry } from '@/api/system/history'
 import { formatRelativeTime, formatProviderName, parseMediaTitle } from '@/lib/utils'
 import { toast } from '@/components/shared/Toast'
 import {
   Clock, Download, ChevronLeft, ChevronRight, Ban, Eye, GitCompare,
-  CheckSquare, Square, MinusSquare, X,
+  CheckSquare, Square, MinusSquare, X, RotateCcw, ArrowUpCircle,
 } from 'lucide-react'
 import SubtitleEditorModal from '@/components/editor/SubtitleEditorModal'
 import { FilterBar } from '@/components/filters/FilterBar'
@@ -29,6 +30,42 @@ type HistoryEntry = {
   score: number
   downloaded_at: string | null
   subtitle_id?: string
+  source?: string
+  upgraded_from_id?: number | null
+  previous_score?: number | null
+  previous_format?: string | null
+}
+
+/** "Why does this entry exist" badge: upgrade (with score delta) vs. plain download. */
+function ReasonBadge({ entry, t }: { entry: HistoryEntry; t: (key: string, opts?: Record<string, unknown>) => string }) {
+  if (entry.upgraded_from_id) {
+    const delta = entry.previous_score != null ? entry.score - entry.previous_score : null
+    const formatChange = entry.previous_format && entry.previous_format !== entry.format
+      ? `${entry.previous_format}→${entry.format}`.toUpperCase()
+      : null
+    const parts = [formatChange, delta != null ? `${delta >= 0 ? '+' : ''}${delta}` : null].filter(Boolean)
+    return (
+      <span
+        className="inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded font-bold"
+        style={{ backgroundColor: 'var(--accent-bg)', color: 'var(--accent)', fontFamily: 'var(--font-mono)' }}
+        title={t('history.reason_upgrade_tooltip')}
+      >
+        <ArrowUpCircle size={10} />
+        {t('history.reason_upgrade')}{parts.length ? ` ${parts.join(' ')}` : ''}
+      </span>
+    )
+  }
+  return (
+    <span
+      className="text-[10px] px-1.5 py-0.5 rounded font-medium"
+      style={{ backgroundColor: 'var(--bg-primary)', color: 'var(--text-muted)', fontFamily: 'var(--font-mono)' }}
+    >
+      {entry.source === 'manual' ? t('history.reason_manual')
+        : entry.source === 'whisper' ? t('history.reason_whisper')
+        : entry.source === 'machine_translation' ? t('history.reason_mt')
+        : t('history.reason_new')}
+    </span>
+  )
 }
 
 const HistoryTableRow = memo(function HistoryTableRow({
@@ -40,6 +77,7 @@ const HistoryTableRow = memo(function HistoryTableRow({
   onPreview,
   onDiff,
   onBlacklist,
+  onRollback,
   isBlacklistPending,
   t,
 }: {
@@ -51,8 +89,9 @@ const HistoryTableRow = memo(function HistoryTableRow({
   onPreview: (path: string) => void
   onDiff: (path: string) => void
   onBlacklist: (entry: HistoryEntry) => void
+  onRollback: (entry: HistoryEntry) => void
   isBlacklistPending: boolean
-  t: (key: string) => string
+  t: (key: string, opts?: Record<string, unknown>) => string
 }) {
   return (
     <tr
@@ -116,6 +155,9 @@ const HistoryTableRow = memo(function HistoryTableRow({
           {entry.format || '?'}
         </span>
       </td>
+      <td className="px-3 py-2.5 hidden lg:table-cell">
+        <ReasonBadge entry={entry} t={t} />
+      </td>
       <td className="px-3 py-2.5 hidden sm:table-cell">
         <span
           className="text-xs tabular-nums"
@@ -167,6 +209,16 @@ const HistoryTableRow = memo(function HistoryTableRow({
               </button>
             </>
           )}
+          <button
+            onClick={() => onRollback(entry)}
+            className="p-1 rounded transition-colors duration-150"
+            title={t('history.rollback')}
+            style={{ color: 'var(--text-muted)' }}
+            onMouseEnter={(e) => (e.currentTarget.style.color = 'var(--warning)')}
+            onMouseLeave={(e) => (e.currentTarget.style.color = 'var(--text-muted)')}
+          >
+            <RotateCcw size={14} />
+          </button>
           <button
             onClick={() => onBlacklist(entry)}
             disabled={isBlacklistPending}
@@ -234,6 +286,8 @@ export function HistoryPage() {
   const [activeFilters, setActiveFilters] = useState<ActiveFilter[]>([])
   const [blacklistConfirm, setBlacklistConfirm] = useState<HistoryEntry | null>(null)
   const [blacklistAlsoDelete, setBlacklistAlsoDelete] = useState(false)
+  const [rollbackConfirm, setRollbackConfirm] = useState<HistoryEntry | null>(null)
+  const [rollbackPending, setRollbackPending] = useState(false)
   const queryClient = useQueryClient()
 
   // Zustand selection store: subscribe only to this scope to avoid re-renders from other pages
@@ -298,6 +352,27 @@ export function HistoryPage() {
     setBlacklistAlsoDelete(false)
     setBlacklistConfirm(entry)
   }, [])
+
+  const onRollbackEntry = useCallback((entry: HistoryEntry) => {
+    setRollbackConfirm(entry)
+  }, [])
+
+  const handleRollbackConfirm = useCallback(async () => {
+    if (!rollbackConfirm) return
+    const entry = rollbackConfirm
+    setRollbackConfirm(null)
+    setRollbackPending(true)
+    try {
+      await rollbackHistoryEntry(entry.id)
+      queryClient.invalidateQueries({ queryKey: ['history'] })
+      toast(t('history.rollback_success'), 'success')
+    } catch (err) {
+      const detail = (err as { response?: { data?: { error?: string } } })?.response?.data?.error
+      toast(detail ?? t('history.rollback_failed'), 'error')
+    } finally {
+      setRollbackPending(false)
+    }
+  }, [rollbackConfirm, queryClient, t])
 
   const handleBlacklistConfirm = useCallback(async () => {
     if (!blacklistConfirm) return
@@ -430,6 +505,7 @@ export function HistoryPage() {
                 <th scope="col" className="text-left text-[11px] font-semibold uppercase tracking-wider px-3 py-2.5" style={{ color: 'var(--text-muted)' }}>{t('history.table.provider')}</th>
                 <th scope="col" className="text-left text-[11px] font-semibold uppercase tracking-wider px-3 py-2.5" style={{ color: 'var(--text-muted)' }}>{t('history.table.lang')}</th>
                 <th scope="col" className="text-left text-[11px] font-semibold uppercase tracking-wider px-3 py-2.5" style={{ color: 'var(--text-muted)' }}>{t('history.table.format')}</th>
+                <th scope="col" className="text-left text-[11px] font-semibold uppercase tracking-wider px-3 py-2.5 hidden lg:table-cell" style={{ color: 'var(--text-muted)' }}>{t('history.table.reason')}</th>
                 <th scope="col" className="text-left text-[11px] font-semibold uppercase tracking-wider px-3 py-2.5 hidden sm:table-cell" style={{ color: 'var(--text-muted)' }}>{t('history.table.score')}</th>
                 <th scope="col" className="text-left text-[11px] font-semibold uppercase tracking-wider px-3 py-2.5 hidden md:table-cell" style={{ color: 'var(--text-muted)' }}>{t('history.table.date')}</th>
                 <th scope="col" className="text-right text-[11px] font-semibold uppercase tracking-wider px-4 py-2.5" style={{ color: 'var(--text-muted)' }}>{t('history.table.actions')}</th>
@@ -444,6 +520,7 @@ export function HistoryPage() {
                     <td className="px-3 py-3"><div className="skeleton h-4 w-20 rounded" /></td>
                     <td className="px-3 py-3"><div className="skeleton h-4 w-8 rounded" /></td>
                     <td className="px-3 py-3"><div className="skeleton h-4 w-10 rounded" /></td>
+                    <td className="px-3 py-3 hidden lg:table-cell"><div className="skeleton h-4 w-14 rounded" /></td>
                     <td className="px-3 py-3 hidden sm:table-cell"><div className="skeleton h-4 w-8 rounded" /></td>
                     <td className="px-3 py-3 hidden md:table-cell"><div className="skeleton h-4 w-14 rounded" /></td>
                     <td className="px-4 py-3"><div className="skeleton h-4 w-6 rounded ml-auto" /></td>
@@ -461,13 +538,14 @@ export function HistoryPage() {
                     onPreview={onPreviewPath}
                     onDiff={onDiffPath}
                     onBlacklist={onBlacklistEntry}
+                    onRollback={onRollbackEntry}
                     isBlacklistPending={addBlacklist.isPending}
                     t={t}
                   />
                 ))
               ) : (
                 <tr>
-                  <td colSpan={8} className="px-4 py-8 text-center text-sm" style={{ color: 'var(--text-secondary)' }}>
+                  <td colSpan={9} className="px-4 py-8 text-center text-sm" style={{ color: 'var(--text-secondary)' }}>
                     {t('history.no_history')}
                   </td>
                 </tr>
@@ -525,6 +603,72 @@ export function HistoryPage() {
           initialMode={editorMode}
           onClose={() => setEditorFilePath(null)}
         />
+      )}
+
+      {/* Rollback Confirmation Dialog */}
+      {rollbackConfirm && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center"
+          style={{ backgroundColor: 'rgba(0,0,0,0.6)' }}
+          onClick={(e) => { if (e.target === e.currentTarget) setRollbackConfirm(null) }}
+        >
+          <div
+            className="w-full max-w-sm mx-4 rounded-xl p-5 space-y-4"
+            style={{ backgroundColor: 'var(--bg-surface)', border: '1px solid var(--border)' }}
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div className="flex items-center gap-2">
+                <RotateCcw size={16} style={{ color: 'var(--warning)' }} />
+                <h3 className="font-semibold text-sm" style={{ color: 'var(--text-primary)' }}>
+                  {t('history.rollback_confirm_title')}
+                </h3>
+              </div>
+              <button
+                onClick={() => setRollbackConfirm(null)}
+                className="p-1 rounded"
+                style={{ color: 'var(--text-muted)' }}
+              >
+                <X size={14} />
+              </button>
+            </div>
+
+            <div className="space-y-1.5">
+              <div className="text-xs" style={{ color: 'var(--text-secondary)' }}>
+                {t('history.rollback_confirm_text')}
+              </div>
+              <div
+                className="text-xs px-2 py-1.5 rounded font-medium truncate"
+                style={{ backgroundColor: 'var(--bg-primary)', color: 'var(--text-primary)', fontFamily: 'var(--font-mono)' }}
+              >
+                {(() => {
+                  const media = parseMediaTitle(rollbackConfirm.file_path)
+                  return `${media.title}${media.episodeCode ? ` · ${media.episodeCode}` : ''}`
+                })()}
+              </div>
+              <div className="text-xs capitalize" style={{ color: 'var(--text-muted)' }}>
+                {formatProviderName(rollbackConfirm.provider_name)} · {rollbackConfirm.language} · {rollbackConfirm.format?.toUpperCase()}
+              </div>
+            </div>
+
+            <div className="flex gap-2 justify-end pt-1">
+              <button
+                onClick={() => setRollbackConfirm(null)}
+                className="px-3 py-1.5 rounded-md text-sm transition-colors"
+                style={{ border: '1px solid var(--border)', color: 'var(--text-secondary)', backgroundColor: 'var(--bg-primary)' }}
+              >
+                {tc('actions.cancel')}
+              </button>
+              <button
+                onClick={handleRollbackConfirm}
+                disabled={rollbackPending}
+                className="px-3 py-1.5 rounded-md text-sm font-medium transition-colors"
+                style={{ backgroundColor: 'var(--warning)', color: 'white', opacity: rollbackPending ? 0.7 : 1 }}
+              >
+                {t('history.rollback_confirm_action')}
+              </button>
+            </div>
+          </div>
+        </div>
       )}
 
       {/* Blacklist Confirmation Dialog */}

--- a/frontend/src/pages/StatisticsPage.tsx
+++ b/frontend/src/pages/StatisticsPage.tsx
@@ -116,6 +116,19 @@ export function StatisticsPage() {
 
           {/* Subtitles breakdowns */}
           <Section title={t('subtitles.title')}>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-2 mb-2">
+              <StatTile
+                label={t('subtitles.sync_rate')}
+                value={subtitles.data?.sync_rate != null ? `${Math.round(subtitles.data.sync_rate * 100)}%` : '—'}
+                sub={t('subtitles.sync_runs', { count: subtitles.data?.sync_runs ?? 0 })}
+              />
+              <StatTile label={t('subtitles.sync_ok')} value={fmtNum(subtitles.data?.sync_ok ?? 0)} />
+              <StatTile
+                label={t('subtitles.sync_failed')}
+                value={fmtNum((subtitles.data?.sync_runs ?? 0) - (subtitles.data?.sync_ok ?? 0))}
+              />
+              <StatTile label={t('overview.avg_score')} value={subtitles.data?.avg_score ?? 0} />
+            </div>
             <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
               {(['by_source', 'by_language', 'by_provider'] as const).map((k) => (
                 <div key={k} className="rounded-lg p-3 bg-surface border border-border">

--- a/frontend/src/pages/Wanted.tsx
+++ b/frontend/src/pages/Wanted.tsx
@@ -16,6 +16,7 @@ import { Loader2, CheckSquare, Square, MinusSquare, Download, RefreshCw } from '
 import { StatusBadge } from '@/components/shared/StatusBadge'
 import SubtitleEditorModal from '@/components/editor/SubtitleEditorModal'
 import { InteractiveSearchModal } from '@/components/wanted/InteractiveSearchModal'
+import { DryRunModal } from '@/components/wanted/DryRunModal'
 import type { FilterDef, ActiveFilter } from '@/components/filters/FilterBar'
 import { BatchActionBar } from '@/components/batch/BatchActionBar'
 import { useSelectionStore } from '@/stores/selectionStore'
@@ -87,6 +88,7 @@ export function WantedPage() {
   const [searchingItems, setSearchingItems] = useState<Set<number>>(new Set())
   const [previewFilePath, setPreviewFilePath] = useState<string | null>(null)
   const [interactiveItem, setInteractiveItem] = useState<{ id: number; title: string } | null>(null)
+  const [dryRunItem, setDryRunItem] = useState<{ id: number; title: string } | null>(null)
 
   // FilterBar state
   const [activeFilters, setActiveFilters] = useState<ActiveFilter[]>([])
@@ -568,6 +570,7 @@ export function WantedPage() {
                       onUpdateStatus={(id, status) => updateStatus.mutate({ itemId: id, status })}
                       onPreview={setPreviewFilePath}
                       onInteractiveSearch={setInteractiveItem}
+                      onDryRun={setDryRunItem}
                       onBlacklist={(itemId, providerName, subtitleId, language) => {
                         const item = wantedData.find(d => d.id === itemId)
                         addBlacklist.mutate({
@@ -621,6 +624,14 @@ export function WantedPage() {
         itemTitle={interactiveItem?.title ?? ''}
         onClose={() => setInteractiveItem(null)}
         onDownloaded={() => setInteractiveItem(null)}
+      />
+
+      {/* Dry-Run Preview Modal */}
+      <DryRunModal
+        open={!!dryRunItem}
+        itemId={dryRunItem?.id}
+        itemTitle={dryRunItem?.title ?? ''}
+        onClose={() => setDryRunItem(null)}
       />
 
       {/* Pending-Original Review Modal (feature #8b) */}

--- a/frontend/src/pages/wanted/WantedGroupedRow.tsx
+++ b/frontend/src/pages/wanted/WantedGroupedRow.tsx
@@ -36,6 +36,7 @@ interface WantedGroupedRowProps {
   onUpdateStatus: (itemId: number, status: string) => void
   onPreview: (filePath: string) => void
   onInteractiveSearch: (item: { id: number; title: string }) => void
+  onDryRun: (item: { id: number; title: string }) => void
   onBlacklist: (itemId: number, providerName: string, subtitleId: string, language: string) => void
 }
 
@@ -60,6 +61,7 @@ export function WantedGroupedRow({
   onUpdateStatus,
   onPreview,
   onInteractiveSearch,
+  onDryRun,
   onBlacklist,
 }: WantedGroupedRowProps) {
   const { t } = useTranslation('library')
@@ -250,6 +252,7 @@ export function WantedGroupedRow({
                   onUpdateStatus={onUpdateStatus}
                   onPreview={onPreview}
                   onInteractiveSearch={onInteractiveSearch}
+                  onDryRun={onDryRun}
                 />
               </td>
             </tr>

--- a/frontend/src/pages/wanted/WantedTableRow.tsx
+++ b/frontend/src/pages/wanted/WantedTableRow.tsx
@@ -209,6 +209,7 @@ export interface WantedTableRowProps {
   onUpdateStatus: (itemId: number, status: string) => void
   onPreview: (filePath: string) => void
   onInteractiveSearch: (item: { id: number; title: string }) => void
+  onDryRun: (item: { id: number; title: string }) => void
   onBlacklist: (itemId: number, providerName: string, subtitleId: string, language: string) => void
 }
 
@@ -375,6 +376,7 @@ export function WantedTableRow({
   onUpdateStatus,
   onPreview,
   onInteractiveSearch,
+  onDryRun,
   onBlacklist,
 }: WantedTableRowProps) {
   const { t } = useTranslation('library')
@@ -499,6 +501,7 @@ export function WantedTableRow({
             onUpdateStatus={onUpdateStatus}
             onPreview={onPreview}
             onInteractiveSearch={onInteractiveSearch}
+            onDryRun={onDryRun}
           />
         </td>
       </tr>

--- a/frontend/src/pages/wanted/WantedTableRow.tsx
+++ b/frontend/src/pages/wanted/WantedTableRow.tsx
@@ -2,7 +2,7 @@ import { Fragment } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   Search, RefreshCw, Eye, EyeOff, Play, Loader2,
-  CheckSquare, Square, Download, ScanSearch,
+  CheckSquare, Square, Download, ScanSearch, FlaskConical,
 } from 'lucide-react'
 import { StatusBadge, SubtitleTypeBadge } from '@/components/shared/StatusBadge'
 import { formatRelativeTime, truncatePath } from '@/lib/utils'
@@ -231,6 +231,7 @@ interface WantedRowActionsProps {
   onUpdateStatus: (itemId: number, status: string) => void
   onPreview: (filePath: string) => void
   onInteractiveSearch: (item: { id: number; title: string }) => void
+  onDryRun: (item: { id: number; title: string }) => void
 }
 
 export function WantedRowActions({
@@ -246,6 +247,7 @@ export function WantedRowActions({
   onUpdateStatus,
   onPreview,
   onInteractiveSearch,
+  onDryRun,
 }: WantedRowActionsProps) {
   const { t } = useTranslation('library')
   return (
@@ -298,6 +300,17 @@ export function WantedRowActions({
         onMouseLeave={(e) => (e.currentTarget.style.color = 'var(--text-muted)')}
       >
         <ScanSearch size={14} />
+      </button>
+      <button
+        data-testid="wanted-dry-run-btn"
+        onClick={() => onDryRun({ id: item.id, title: item.title })}
+        className="p-1 rounded transition-colors duration-150"
+        title={t('wanted_row.dry_run')}
+        style={{ color: 'var(--text-muted)' }}
+        onMouseEnter={(e) => (e.currentTarget.style.color = 'var(--accent)')}
+        onMouseLeave={(e) => (e.currentTarget.style.color = 'var(--text-muted)')}
+      >
+        <FlaskConical size={14} />
       </button>
       <button
         data-testid="wanted-process-btn"


### PR DESCRIPTION
Implements the quality-of-life wishlist around the download pipeline: rollback, dry run, history reasons, a library health dashboard, and sync statistics.

## History rollback (one click)

- `save_subtitle` and the SRT→ASS upgrade path now preserve the replaced sidecar into the single-slot `.bak` (`.sublarr/backups/`) before overwriting/removing it — only when the slot is free, so the existing *bak is never overwritten* invariant holds.
- New `POST /api/v1/history/<id>/rollback`:
  - same-format entries atomically swap active↔backup (invoking rollback again flips back, no data loss either way)
  - format upgrades restore the old-format sidecar and retire the current one into its own backup slot (rollback is itself reversible)
- The swap logic was extracted from the undo route into `services/subtitle_restore.py` and is shared by both endpoints.
- History UI: restore button per row with confirmation dialog.

## History "Reason" column

- `/history` entries now carry `previous_score`/`previous_format` (one batch lookup per page over the existing `upgraded_from_id` chain).
- New column shows **Upgrade** (with format change + score delta, e.g. "Upgrade SRT→ASS +40") vs. **New/Manual/Whisper/MT** badges.

## Wanted dry-run preview

- New `POST /api/v1/wanted/dry-run` (up to 10 items, 3 parallel workers): runs `process_wanted_item(dry_run=True)` — providers are queried for real, but nothing is written to disk or DB. Each item's pre-run status is restored afterwards so previews never leave rows stuck in "searching".
- Per-row flask icon in the Wanted table opens a preview modal with the provider/score/format/target path a real run would produce.

## Health dashboard

- New `GET /api/v1/health/library` (cached 60 s) aggregating: series/movies with missing subtitles, failed & unmatched items (`failure_kind`, incl. `unsourceable`), and per-provider health (circuit-breaker state ⋈ provider stats; degraded = breaker open, auto-disabled, or <5 % hit rate over 10+ searches).
- New `/health` page with totals tiles and the three tables (degraded providers first), auto-refresh every 60 s, nav entries in both sidebars, new `health` i18n namespace (en/de).

## Sync success rate

- `/statistics/subtitles` now returns `sync_runs`/`sync_ok`/`sync_rate` from the `sync_job_runs` audit table over the selected range; the Statistics page shows the rate plus OK/failed counts.

## Testing

- 22 new backend tests (`test_history_rollback.py`, `test_routes_wanted_dry_run.py`, `test_health_overview.py`), all passing
- Regression: 430+ backend tests across the touched areas green, including the bak-is-never-overwritten invariant tests
- Frontend: `tsc --noEmit` clean, all 1166 vitest tests passing, no new ESLint errors
- All UI strings translated for en + de

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fz6s3TNb2KZ6EMWkzNpDcG