### PR TITLE
Fix #159 data loss (ungated wanted-search remux) + hardlink-aware remux (#160) + audit fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,10 @@ AnimeTosho, Subscene, Subf2m, Subsource, Kitsunekko, and most other providers wo
 | `SUBLARR_WANTED_SCAN_ON_STARTUP` | `false` | Run a full scan when the container starts |
 | `SUBLARR_WANTED_ANIME_ONLY` | `true` | Only scan anime series |
 | `SUBLARR_UPGRADE_ENABLED` | `true` | Replace low-quality subs with better versions |
+| `SUBLARR_EMBEDDED_EXTRACT_REMOVE_FROM_CONTAINER` | `false` | Remux extracted subtitle streams out of the container after extraction. Off by default; keep-language streams are never removed. |
+| `SUBLARR_REMUX_HARDLINK_POLICY` | `skip` | `skip` \| `warn` \| `allow` — what to do when a container remux would touch a **hardlinked** file. |
+
+> **⚠️ Hardlinks:** Most Sonarr/Radarr setups hardlink the media library to the torrent/usenet download folder. Any container remux (foreign-track cleanup, signs removal, stream removal after extraction) rewrites the file and **breaks that hardlink** — disk usage doubles and the seeding copy diverges from the library copy. The default `skip` policy refuses to remux hardlinked files; set `warn` or `allow` only if you accept the broken links.
 
 ### Path Mapping (remote *arr hosts)
 

--- a/backend/config_language_data.py
+++ b/backend/config_language_data.py
@@ -12,11 +12,14 @@ _LANGUAGE_TAGS: dict[str, set[str]] = {
     "fr": {"fr", "fra", "fre", "french"},
     "es": {"es", "spa", "spanish"},
     "it": {"it", "ita", "italian"},
-    "pt": {"pt", "por", "portuguese"},
+    # "pob"/"pb" are the Bazarr/OpenSubtitles conventions for pt-BR.
+    "pt": {"pt", "por", "portuguese", "pt-br", "pob", "pb"},
     "nl": {"nl", "nld", "dut", "dutch"},
     "sv": {"sv", "swe", "swedish"},
     "da": {"da", "dan", "danish"},
-    "no": {"no", "nor", "norwegian"},
+    # Bokmål (nb/nob) and Nynorsk (nn/nno) tags are common in real releases
+    # and must map onto the generic Norwegian target.
+    "no": {"no", "nor", "norwegian", "nb", "nob", "nn", "nno"},
     "fi": {"fi", "fin", "finnish"},
     "is": {"is", "isl", "ice", "icelandic"},
     "eu": {"eu", "eus", "baq", "basque"},
@@ -147,8 +150,24 @@ SUPPORTED_LANGUAGES: list[dict] = [
 
 
 def _get_language_tags(lang_code: str) -> set[str]:
-    """Get all known tags for a language code."""
-    return _LANGUAGE_TAGS.get(lang_code, {lang_code})
+    """Get all known tags for a language code.
+
+    The input is canonicalised first, so 3-letter/legacy codes ("ger",
+    "eng") expand exactly like their 2-letter equivalents — previously a
+    keep-list entry of "ger" produced the 1-element set {"ger"}, which
+    failed to match "de"/"deu"-tagged tracks on destructive cleanup paths.
+
+    Script-variant codes (zh-hans, zh-hant) additionally include their base
+    language's tags: real containers tag Chinese tracks "chi"/"zho"/"zh",
+    and a zh-hans target must never classify those as foreign/disposable.
+    """
+    key = (lang_code or "").lower().strip()
+    canonical = _REVERSE_LANGUAGE_TAGS.get(key, key)
+    tags = set(_LANGUAGE_TAGS.get(canonical, {key}))
+    if "-" in canonical:
+        base = canonical.split("-", 1)[0]
+        tags |= _LANGUAGE_TAGS.get(base, set())
+    return tags
 
 
 # Reverse lookup: any known tag -> canonical ISO 639-1 code.

--- a/backend/config_settings.py
+++ b/backend/config_settings.py
@@ -504,6 +504,11 @@ class UISettings(BaseModel):
     remux_backup_retention_days: int = 7  # 0 = keep forever
     remux_use_reflink: bool = True  # CoW reflink on Btrfs/XFS for zero-cost backups
     remux_arr_pause_enabled: bool = True  # Pause Sonarr/Radarr during remux
+    # Issue #160: rewriting a hardlinked file (the recommended *arr setup)
+    # breaks the link — disk usage doubles and the seeding copy diverges.
+    # "skip" refuses the remux and logs; "warn" proceeds with an auditable
+    # warning; "allow" is the pre-1.9.5 behaviour.
+    remux_hardlink_policy: str = "skip"  # skip | warn | allow
 
     # Subtitle backup files (.bak.srt/.bak.ass)
     subtitle_bak_retention_days: int = 30  # 0 = keep forever

--- a/backend/config_settings.py
+++ b/backend/config_settings.py
@@ -324,6 +324,11 @@ class UISettings(BaseModel):
     embedded_allow_sdh: bool = True
     embedded_sdh_penalty: int = 5
 
+    # Issue #159: container stream removal after extraction used to be an
+    # unconditional side effect. Opt-in now; even when enabled, streams in
+    # the keep-languages set are never removed.
+    embedded_extract_remove_from_container: bool = False
+
     # Dubtitle detection (roadmap A4 / issue #146). Off by default: surfaces
     # the dubtitle among multiple English tracks; suggest-then-confirm, never
     # silently applied. dubtitle_min_score is the Tier-2 audio-match threshold.

--- a/backend/config_settings.py
+++ b/backend/config_settings.py
@@ -67,6 +67,11 @@ _ALLOWED_BOOT_FIELDS: frozenset[str] = frozenset(
         "log_format",
         "cors_origins",
         "redis_url",
+        # Pre-DB by design: the anonymous-stats kill-switch must work via env
+        # before any UI/DB exists (self-hoster redirect/disable). Was declared
+        # on BootSettings since the opt-in stats feature but missed here when
+        # the linter allowlist was introduced.
+        "stats_endpoint",
     }
 )
 

--- a/backend/config_views.py
+++ b/backend/config_views.py
@@ -250,6 +250,7 @@ class ScanningSettings(_SettingsView):
             "remux_backup_retention_days",
             "remux_use_reflink",
             "remux_arr_pause_enabled",
+            "remux_hardlink_policy",
         )
     )
 

--- a/backend/config_views.py
+++ b/backend/config_views.py
@@ -186,6 +186,7 @@ class ScanningSettings(_SettingsView):
             "subtitle_automation_drain_interval_minutes",
             "embedded_allow_sdh",
             "embedded_sdh_penalty",
+            "embedded_extract_remove_from_container",
             "cleanup_foreign_tracks_default",
             "cleanup_foreign_tracks_keep_und",
             "cleanup_signs_removal_level",

--- a/backend/db/repositories/cleanup.py
+++ b/backend/db/repositories/cleanup.py
@@ -241,9 +241,12 @@ class CleanupRepository(BaseRepository):
             "rule_type": "signs_cleanup",
             "enabled": False,
             "schedule": "weekly",
+            # NOTE: keep_languages is intentionally absent — the signs
+            # executor is language-agnostic (last-track guard only) and
+            # never read the key; seeding it implied a protection that
+            # does not exist.
             "config_json": _json.dumps(
                 {
-                    "keep_languages": ["de", "en"],
                     "strip_embedded": True,
                     "permanent_delete": False,
                 }

--- a/backend/providers/download_manager.py
+++ b/backend/providers/download_manager.py
@@ -493,9 +493,32 @@ def save_subtitle(
         if _video:
             from services.foreign_track_cleanup import maybe_run_foreign_track_cleanup
 
+            # The keep-set must cover ALL of the profile's target languages,
+            # not just the language of the sub that happened to land first —
+            # a de+ja profile lost its embedded Japanese track the moment the
+            # German sidecar arrived.
+            _profile_targets: set[str] | None = None
+            try:
+                from config import get_settings as _ftc_get_settings
+                from services.embedded_extractor import (
+                    compute_keep_langs,
+                    resolve_profile_for_item,
+                )
+
+                _ftc_settings = _ftc_get_settings()
+                _item_stub = {"sonarr_series_id": series_id}
+                _profile = resolve_profile_for_item(_item_stub, _ftc_settings)
+                _profile_targets = compute_keep_langs(_profile, _ftc_settings)
+                if result.language:
+                    _profile_targets.add(str(result.language).lower())
+            except Exception as _prof_exc:
+                logger.debug("[foreign-track] profile keep-set fallback: %s", _prof_exc)
+                _profile_targets = None
+
             maybe_run_foreign_track_cleanup(
                 {"sonarr_series_id": series_id, "target_language": result.language},
                 _video,
+                target_languages=_profile_targets,
             )
     except Exception as _exc:
         logger.debug("[foreign-track] post-download hook skipped: %s", _exc)

--- a/backend/providers/plugins/template/README.md
+++ b/backend/providers/plugins/template/README.md
@@ -78,11 +78,11 @@ Each config field is a dict with these keys:
 
 ```python
 {
-    "key": "api_key",          # Internal key, passed as kwarg to __init__
-    "label": "API Key",        # Human-readable label in the Settings UI
-    "type": "password",        # "text", "password", or "number"
-    "required": True,          # If True, provider needs this to function
-    "default": "",             # Default value (optional)
+    "key": "api_key",  # Internal key, passed as kwarg to __init__
+    "label": "API Key",  # Human-readable label in the Settings UI
+    "type": "password",  # "text", "password", or "number"
+    "required": True,  # If True, provider needs this to function
+    "default": "",  # Default value (optional)
 }
 ```
 
@@ -93,8 +93,20 @@ Config values are stored in the database under `plugin.<name>.<key>` namespace. 
 ```python
 config_fields = [
     {"key": "api_key", "label": "API Key", "type": "password", "required": True},
-    {"key": "base_url", "label": "Base URL", "type": "text", "required": False, "default": "https://api.example.com"},
-    {"key": "results_per_page", "label": "Results Per Page", "type": "number", "required": False, "default": "50"},
+    {
+        "key": "base_url",
+        "label": "Base URL",
+        "type": "text",
+        "required": False,
+        "default": "https://api.example.com",
+    },
+    {
+        "key": "results_per_page",
+        "label": "Results Per Page",
+        "type": "number",
+        "required": False,
+        "default": "50",
+    },
 ]
 ```
 
@@ -201,9 +213,9 @@ result.matches = {"series", "season", "episode"}
 Set `rate_limit = (max_requests, window_seconds)` on your class. The `ProviderManager` enforces this limit across all search and download calls. Example:
 
 ```python
-rate_limit = (5, 1)    # 5 requests per second (OpenSubtitles-style)
-rate_limit = (100, 60) # 100 requests per minute
-rate_limit = (0, 0)    # No rate limiting
+rate_limit = (5, 1)  # 5 requests per second (OpenSubtitles-style)
+rate_limit = (100, 60)  # 100 requests per minute
+rate_limit = (0, 0)  # No rate limiting
 ```
 
 The `RetryingSession` from `create_session()` also handles HTTP 429 responses automatically (reads `Retry-After` header).
@@ -220,10 +232,10 @@ Sublarr provides three specialized exceptions in `providers.base`:
 
 ```python
 from providers.base import (
-    ProviderAuthError,       # 401/403 -- authentication failed
+    ProviderAuthError,  # 401/403 -- authentication failed
     ProviderRateLimitError,  # 429 -- rate limit exceeded
-    ProviderTimeoutError,    # Request timed out
-    ProviderError,           # Generic provider error (base class)
+    ProviderTimeoutError,  # Request timed out
+    ProviderError,  # Generic provider error (base class)
 )
 ```
 
@@ -252,10 +264,11 @@ Use `create_session()` from `providers.http_session` for HTTP calls:
 ```python
 from providers.http_session import create_session
 
+
 def initialize(self):
     self.session = create_session(
-        max_retries=self.max_retries,   # From class attribute
-        timeout=self.timeout,           # From class attribute
+        max_retries=self.max_retries,  # From class attribute
+        timeout=self.timeout,  # From class attribute
         user_agent="Sublarr-Plugin/1.0",
     )
     # Set authentication headers
@@ -276,17 +289,18 @@ The session provides:
 import zipfile
 import io
 
+
 def download(self, result):
     resp = self.session.get(result.download_url)
     resp.raise_for_status()
     content = resp.content
 
-    if content[:4] == b'PK\x03\x04':  # ZIP magic bytes
+    if content[:4] == b"PK\x03\x04":  # ZIP magic bytes
         with zipfile.ZipFile(io.BytesIO(content)) as zf:
             for name in zf.namelist():
-                if name.endswith(('.srt', '.ass', '.ssa')):
+                if name.endswith((".srt", ".ass", ".ssa")):
                     content = zf.read(name)
-                    if name.endswith(('.ass', '.ssa')):
+                    if name.endswith((".ass", ".ssa")):
                         result.format = SubtitleFormat.ASS
                     break
 
@@ -299,12 +313,13 @@ def download(self, result):
 ```python
 import lzma
 
+
 def download(self, result):
     resp = self.session.get(result.download_url)
     resp.raise_for_status()
     content = resp.content
 
-    if content[:6] == b'\xfd7zXZ\x00':  # XZ magic bytes
+    if content[:6] == b"\xfd7zXZ\x00":  # XZ magic bytes
         content = lzma.decompress(content)
 
     result.content = content
@@ -317,15 +332,16 @@ def download(self, result):
 import rarfile
 import io
 
+
 def download(self, result):
     resp = self.session.get(result.download_url)
     resp.raise_for_status()
     content = resp.content
 
-    if content[:4] == b'Rar!':  # RAR magic bytes
+    if content[:4] == b"Rar!":  # RAR magic bytes
         with rarfile.RarFile(io.BytesIO(content)) as rf:
             for name in rf.namelist():
-                if name.endswith(('.srt', '.ass', '.ssa')):
+                if name.endswith((".srt", ".ass", ".ssa")):
                     content = rf.read(name)
                     break
 
@@ -342,6 +358,7 @@ def search(self, query):
     elif query.is_movie:
         return self._search_movie(query)
     return []
+
 
 def _search_episode(self, query):
     params = {

--- a/backend/remux/__init__.py
+++ b/backend/remux/__init__.py
@@ -420,12 +420,56 @@ def _verify(original_path: str, remuxed_path: str, n_removed: int = 1) -> None:
 # ---------------------------------------------------------------------------
 
 
+def check_hardlink_policy(video_path: str) -> bool:
+    """Gate every container rewrite on ``remux_hardlink_policy`` (issue #160).
+
+    Most Sonarr/Radarr setups hardlink the library to the download folder;
+    a remux rewrites via temp + atomic replace and silently breaks that
+    link (disk usage doubles, the seeding copy diverges).
+
+    Returns True when the remux may proceed:
+      - ``allow``: always proceed (pre-1.9.5 behaviour).
+      - ``warn``:  proceed, but log an auditable warning for linked files.
+      - ``skip``:  refuse the remux for files with st_nlink > 1 (default).
+    A failed stat never blocks — the remux itself will surface the error.
+    """
+    try:
+        from config import get_settings
+
+        policy = (getattr(get_settings(), "remux_hardlink_policy", "skip") or "skip").lower()
+    except Exception:
+        policy = "skip"
+    if policy == "allow":
+        return True
+    try:
+        nlink = os.stat(video_path).st_nlink
+    except OSError:
+        return True
+    if nlink <= 1:
+        return True
+    if policy == "warn":
+        logger.warning(
+            "Remux: %s has %d hardlinks — proceeding anyway "
+            "(remux_hardlink_policy=warn); the hardlink will break",
+            video_path,
+            nlink,
+        )
+        return True
+    logger.info(
+        "Remux: skipped — %s has %d hardlinks (remux_hardlink_policy=skip; "
+        "set to 'warn' or 'allow' to remux hardlinked files)",
+        video_path,
+        nlink,
+    )
+    return False
+
+
 def remove_subtitle_streams(
     video_path: str,
     streams: list[tuple[int, int]],
     use_reflink: bool = True,
     trash_dir: str = ".sublarr",
-) -> str:
+) -> str | None:
     """Remove one or more subtitle streams from a video container in one pass.
 
     Parameters
@@ -444,8 +488,9 @@ def remove_subtitle_streams(
 
     Returns
     -------
-    str
-        Path to the created backup file.
+    str | None
+        Path to the created backup file, or None when the remux was skipped
+        by ``remux_hardlink_policy`` (hardlinked file, policy "skip").
 
     Raises
     ------
@@ -454,6 +499,9 @@ def remove_subtitle_streams(
     """
     if not streams:
         raise RemuxError("No streams specified for removal")
+
+    if not check_hardlink_policy(video_path):
+        return None
 
     backend = _detect_backend(video_path)
     video_dir = os.path.dirname(video_path)
@@ -506,7 +554,7 @@ def remove_subtitle_stream(
     subtitle_track_index: int,
     use_reflink: bool = True,
     trash_dir: str = ".sublarr",
-) -> str:
+) -> str | None:
     """Remove a single subtitle stream. Convenience wrapper around remove_subtitle_streams."""
     return remove_subtitle_streams(
         video_path=video_path,
@@ -570,6 +618,11 @@ def remove_foreign_subtitle_streams(
             "remove_foreign_subtitle_streams: empty target set, skipping %s",
             video_path,
         )
+        return None
+
+    # Early hardlink gate — avoids the probe and a misleading "stripping N
+    # tracks" log line when the policy would refuse the rewrite anyway.
+    if not check_hardlink_policy(video_path):
         return None
 
     try:
@@ -649,6 +702,9 @@ def remove_subtitle_streams_by_index(
         On backup failure, mkvmerge error, or verification failure.
     """
     if not drop_indices:
+        return None
+
+    if not check_hardlink_policy(video_path):
         return None
 
     # Map subtitle-relative positions (sub_index) -> global ffprobe stream index.

--- a/backend/remux/__init__.py
+++ b/backend/remux/__init__.py
@@ -636,9 +636,7 @@ def remove_foreign_subtitle_streams(
     # language because the container used a 3-letter tag.
     from config_language_data import normalize_language_code
 
-    normalized_targets = {
-        normalize_language_code(str(t).lower()) for t in target_languages if t
-    }
+    normalized_targets = {normalize_language_code(str(t).lower()) for t in target_languages if t}
     normalized_targets.discard("")
 
     streams_to_remove: list[tuple[int, int]] = []
@@ -648,8 +646,7 @@ def remove_foreign_subtitle_streams(
             continue
         lang = (stream.get("tags", {}).get("language", "und") or "und").lower()
         is_foreign = (
-            lang not in target_languages
-            and normalize_language_code(lang) not in normalized_targets
+            lang not in target_languages and normalize_language_code(lang) not in normalized_targets
         )
         if is_foreign and not (keep_und and lang == "und"):
             global_idx = stream.get("index")

--- a/backend/remux/__init__.py
+++ b/backend/remux/__init__.py
@@ -577,13 +577,27 @@ def remove_foreign_subtitle_streams(
     except Exception as exc:
         raise RemuxError(f"ffprobe failed on {video_path}: {exc}") from exc
 
+    # Defence in depth: callers are documented to pass a fully expanded tag
+    # set ({"de","deu","ger",...}), but compare canonical forms as well so a
+    # caller that passes bare 2-letter codes can never strip its own target
+    # language because the container used a 3-letter tag.
+    from config_language_data import normalize_language_code
+
+    normalized_targets = {
+        normalize_language_code(str(t).lower()) for t in target_languages if t
+    }
+    normalized_targets.discard("")
+
     streams_to_remove: list[tuple[int, int]] = []
     sub_only_idx = 0
     for stream in probe.get("streams", []):
         if stream.get("codec_type") != "subtitle":
             continue
         lang = (stream.get("tags", {}).get("language", "und") or "und").lower()
-        is_foreign = lang not in target_languages
+        is_foreign = (
+            lang not in target_languages
+            and normalize_language_code(lang) not in normalized_targets
+        )
         if is_foreign and not (keep_und and lang == "und"):
             global_idx = stream.get("index")
             if global_idx is not None:

--- a/backend/remux/__init__.py
+++ b/backend/remux/__init__.py
@@ -787,6 +787,10 @@ _SIDECAR_EXTS = (".ass", ".srt", ".vtt", ".sub")
 # Modifier suffixes that can appear between lang and extension:
 #   show.en.forced.srt, show.de.sdh.ass, show.en.hi.vtt
 # We preserve them so the cleanup knows "lang=en" even when there's a modifier.
+# NOTE: deliberately diverges from subtitle_filename.MODIFIERS (adds
+# sign/signs, lacks bak; single trailing token vs. unbounded stacking).
+# Every divergence errs toward NOT parsing — an unparsed sidecar is never
+# trashed — so keep it that way when editing either table.
 _SIDECAR_MODIFIERS = ("forced", "sdh", "hi", "cc", "sign", "signs")
 
 

--- a/backend/routes/subtitle_processor.py
+++ b/backend/routes/subtitle_processor.py
@@ -292,6 +292,28 @@ def _build_pipeline_mods(cfg: dict):
     return mods
 
 
+def _is_processing_exempt_sidecar(subtitle_path: str) -> bool:
+    """True for sidecars the auto-mods must never rewrite.
+
+    - Modifier variants (``.hi``, ``.sdh``, ``.cc``, ``.forced``): running
+      HI-removal over a ``.hi`` file destroys the whole point of that
+      variant (its non-HI twin usually sits right next to it).
+    - Combined bilingual files (``.de-en.combined.ass``): composed
+      artefacts, not processing fodder.
+    """
+    try:
+        from subtitle_filename import parse_combined_filename, parse_subtitle_filename
+
+        if parse_combined_filename(subtitle_path) is not None:
+            return True
+        parsed = parse_subtitle_filename(subtitle_path)
+        if parsed is not None and parsed.primary_modifier in ("hi", "sdh", "cc", "forced"):
+            return True
+    except Exception:
+        logger.debug("[pipeline] sidecar classification failed for %s", subtitle_path)
+    return False
+
+
 def _run_pipeline_for_path(subtitle_path: str, series_id: int | None) -> None:
     """Run the configured processing pipeline for one subtitle file.
 
@@ -300,6 +322,8 @@ def _run_pipeline_for_path(subtitle_path: str, series_id: int | None) -> None:
     """
     ext = os.path.splitext(subtitle_path)[1].lower()
     if ext not in (".srt", ".ass", ".ssa"):
+        return
+    if _is_processing_exempt_sidecar(subtitle_path):
         return
 
     from db.models.core import SeriesSettings
@@ -378,6 +402,16 @@ def _batch_process_series(series_id: int) -> None:
         sidecars = scan_subtitle_sidecars(video_path)
         for sidecar in sidecars:
             sub_path = sidecar["path"]
+            # Never rewrite modifier variants (.hi/.sdh/.cc/.forced) or
+            # combined bilingual files — HI-removal over a .hi sidecar
+            # destroys the variant it exists to provide.
+            if sidecar.get("combined") or sidecar.get("modifier") in (
+                "hi",
+                "sdh",
+                "cc",
+                "forced",
+            ):
+                continue
             result = None
             try:
                 result = apply_mods(sub_path, mods)

--- a/backend/routes/subtitles/trash.py
+++ b/backend/routes/subtitles/trash.py
@@ -48,7 +48,7 @@ def delete_subtitles():
 
     settings = get_settings()
     media_path = getattr(settings, "media_path", "/media")
-    retention = getattr(settings, "subtitle_trash_retention_days", 7)
+    retention = getattr(settings, "subtitle_trash_retention_days", 30)
     _auto_purge_old_trash(media_path, retention)
 
     batch_id = uuid.uuid4().hex
@@ -147,7 +147,7 @@ def batch_delete_series_subtitles(series_id: int):
 
     settings = get_settings()
     media_path = getattr(settings, "media_path", "/media")
-    retention = getattr(settings, "subtitle_trash_retention_days", 7)
+    retention = getattr(settings, "subtitle_trash_retention_days", 30)
     _auto_purge_old_trash(media_path, retention)
 
     batch_id = uuid.uuid4().hex
@@ -194,9 +194,12 @@ def list_trash():
     """
     settings = get_settings()
     media_path = getattr(settings, "media_path", "/media")
+    # retention is only used to COMPUTE expires_at below — no auto-purge
+    # here: this is a read-only GET, and merely opening the Trash page must
+    # never rmtree expired batches before the user can see and restore
+    # them. Expiry runs on the destructive POST routes and the scheduled
+    # cleanup rule instead.
     retention = getattr(settings, "subtitle_trash_retention_days", 30)
-    _auto_purge_old_trash(media_path, retention)
-
     trash_root = _get_trash_root(media_path)
     if not os.path.isdir(trash_root):
         return jsonify({"batches": []}), 200

--- a/backend/routes/tracks.py
+++ b/backend/routes/tracks.py
@@ -581,11 +581,32 @@ def _cleanup_series_sidecars(episode_files: dict, keep_langs: set, keep_format: 
         keep_format: "ass" | "srt" | "any" — if "ass", delete SRT when ASS exists for same lang
 
     Returns:
-        Number of files deleted.
+        Number of files moved to the trash.
     """
+    from config_language_data import _REVERSE_LANGUAGE_TAGS, normalize_language_code
     from routes.subtitles import scan_subtitle_sidecars  # noqa: I001
+    from services.cleanup_executors import _trash_path
+
+    # Sidecar tags come straight from filenames (often 3-letter: "eng",
+    # "ger") while the setting documents 2-letter codes ("de,en") — both
+    # sides MUST be canonicalised or the comparison deletes everything the
+    # batch extract just produced, target language included.
+    keep_normalised = {normalize_language_code(code) for code in keep_langs if code}
+    keep_normalised.discard("")
+    if not keep_normalised:
+        return 0
 
     deleted = 0
+
+    def _trash(path: str, reason: str) -> int:
+        # Recoverable trash, never a hard delete — this cleanup runs
+        # automatically after batch-extract and used to os.unlink files
+        # (including the target language, via the eng-vs-en mismatch).
+        if _trash_path(path):
+            logger.debug("[auto-cleanup] trashed %s (%s)", path, reason)
+            return 1
+        logger.warning("[auto-cleanup] could not trash %s", path)
+        return 0
 
     for file_info in episode_files.values():
         raw_path = file_info.get("path")
@@ -605,25 +626,24 @@ def _cleanup_series_sidecars(episode_files: dict, keep_langs: set, keep_format: 
             fmt = sidecar["format"]
             path = sidecar["path"]
 
-            # Delete if language not in keep list
-            if lang not in keep_langs:
-                try:
-                    os.unlink(path)
-                    deleted += 1
-                    logger.debug("[auto-cleanup] removed %s (not in keep_languages)", path)
-                except OSError as exc:
-                    logger.warning("[auto-cleanup] could not remove %s: %s", path, exc)
+            # Combined/bilingual artefacts (Show.de-en.combined.ass) are
+            # deliberately produced by combine_service — never cleanup fodder.
+            if sidecar.get("combined"):
                 continue
 
-            # Prefer-ASS: delete SRT when ASS exists for same language
+            normalised = normalize_language_code(lang)
+
+            # Trash if language not in keep list. Unknown/und tags are kept —
+            # cannot prove they are disposable.
+            if normalised not in keep_normalised:
+                if (lang or "").lower() in _REVERSE_LANGUAGE_TAGS:
+                    deleted += _trash(path, "not in keep_languages")
+                continue
+
+            # Prefer-ASS: trash SRT when ASS exists for same language
             if keep_format == "ass" and fmt == "srt":
                 if (lang, "ass") in existing:
-                    try:
-                        os.unlink(path)
-                        deleted += 1
-                        logger.debug("[auto-cleanup] removed SRT %s (ASS exists)", path)
-                    except OSError as exc:
-                        logger.warning("[auto-cleanup] could not remove %s: %s", path, exc)
+                    deleted += _trash(path, "SRT redundant, ASS exists")
 
     return deleted
 

--- a/backend/routes/wanted/batch_probe.py
+++ b/backend/routes/wanted/batch_probe.py
@@ -133,6 +133,9 @@ def _process_probe_result(item: dict, future) -> None:
                 keep_langs=keep_langs,
                 target_language=target_lang,
                 log_label=f"batch-probe item {item_id}",
+                remove_from_container=bool(
+                    getattr(settings, "embedded_extract_remove_from_container", False)
+                ),
             )
 
             if not result.any_extracted:

--- a/backend/services/cleanup_signs.py
+++ b/backend/services/cleanup_signs.py
@@ -154,9 +154,12 @@ def execute_signs_cleanup(media_path: str, config: dict, dry_run: bool = False) 
             * ``strip_embedded`` (bool, default False) — when True, also probe
               video files and remux out embedded streams that classify as
               signs/forced/songs.
-            * ``keep_languages`` (list[str], default ["de","en"]) — ISO-639-1
-              codes; the last keep-language embedded track per language is
-              never dropped.
+            * ``keep_languages`` — accepted for backwards compatibility but
+              NOT used: the embedded pass is deliberately language-agnostic.
+              The only protection is the last-track guard (never drop the
+              last text sub of a file), which is stricter than a language
+              filter — signs/forced tracks are removed regardless of
+              language, full-dialogue tracks are never touched.
         dry_run: When True nothing is deleted; returns counts + examples only.
 
     Returns:

--- a/backend/services/combine_service.py
+++ b/backend/services/combine_service.py
@@ -29,16 +29,24 @@ def resolve_combine_sources(video_path: str, languages: list[str]) -> tuple[list
     match ``languages`` (primary first), each the best sidecar for that language
     by ``plain > hi > forced`` priority.
     """
+    from config_language_data import normalize_language_code
     from services.sidecar_scan import scan_subtitle_sidecars
 
+    # Group by canonical code: extracted sidecars usually carry 3-letter
+    # filename tags (.ger.ass/.eng.ass) while combine_languages come from
+    # the profile as 2-letter codes — a raw-key lookup never matched and
+    # silently disabled auto-combine for extracted sidecars.
     by_lang: dict[str, list[dict]] = {}
     for side in scan_subtitle_sidecars(video_path):
-        by_lang.setdefault(side.get("language"), []).append(side)
+        if side.get("combined"):
+            continue
+        key = normalize_language_code(str(side.get("language") or "").lower())
+        by_lang.setdefault(key, []).append(side)
 
     present: list[dict] = []
     missing: list[str] = []
     for lang in languages:
-        best = pick_best_sidecar(by_lang.get(lang, []))
+        best = pick_best_sidecar(by_lang.get(normalize_language_code(str(lang).lower()), []))
         if best is None:
             missing.append(lang)
         else:

--- a/backend/services/embedded_extractor.py
+++ b/backend/services/embedded_extractor.py
@@ -471,13 +471,22 @@ def _pick_primary(
     back to the first sidecar in the list if none match. ``ass`` wins
     over ``srt`` when both languages match (.ass plays better with
     advanced styling).
+
+    Matching is canonical-code equality, not prefix comparison: the old
+    ``startswith(target[:2])`` missed "ger" for target "de" (picking a
+    random first track as primary) and false-matched "est" (Estonian)
+    for target "es".
     """
     if not extracted:
         return None, None, None
 
-    target_lc = (target_language or "").lower() or None
+    from config_language_data import normalize_language_code
+
+    target_lc = normalize_language_code((target_language or "").lower()) or None
     if target_lc:
-        target_matches = [e for e in extracted if e["language"].startswith(target_lc[:2])]
+        target_matches = [
+            e for e in extracted if normalize_language_code(e["language"]) == target_lc
+        ]
         if target_matches:
             ass_first = sorted(target_matches, key=lambda e: 0 if e["format"] == "ass" else 1)
             chosen = ass_first[0]
@@ -889,13 +898,31 @@ def compute_keep_langs(profile: dict, settings) -> set[str]:
     Always includes the profile's ``target_languages``. Adds
     ``settings.source_language`` when ``wanted_auto_translate`` is enabled
     so the source-lang sidecar survives long enough to be translated.
+
+    Script-variant targets (zh-hans, zh-hant) also keep their base code —
+    containers/sidecars are usually tagged with the generic language
+    ("chi"/"zho"/"zh" → "zh"), and those must never be trashed for a
+    zh-hans profile.
+
+    ``und``/``und1``/``und2`` placeholders are dropped: a keep-set of just
+    "undetermined" would pass the non-empty guards downstream and turn the
+    "empty set → no-op" safety design into "trash every recognised
+    language".
     """
     from config_language_data import normalize_language_code
 
-    keep = {normalize_language_code(code) for code in profile.get("target_languages", []) if code}
+    keep: set[str] = set()
+    codes = list(profile.get("target_languages", []))
     if getattr(settings, "wanted_auto_translate", False):
         src = getattr(settings, "source_language", "") or ""
         if src:
-            keep.add(normalize_language_code(src))
-    keep.discard("")
+            codes.append(src)
+    for code in codes:
+        if not code:
+            continue
+        normalised = normalize_language_code(code)
+        keep.add(normalised)
+        if "-" in normalised:
+            keep.add(normalised.split("-", 1)[0])
+    keep.difference_update({"", "und", "und1", "und2"})
     return keep

--- a/backend/services/embedded_extractor.py
+++ b/backend/services/embedded_extractor.py
@@ -375,12 +375,19 @@ def purge_signs_after_extract(
     video_path: str,
     *,
     log_label: str = "extractor",
+    extracted_paths: list[str] | None = None,
 ) -> int:
     """Trash freshly-extracted sidecars that classify as signs/forced/songs.
 
     Runs the same SignsRemovalLevel classifier as the library-wide cleanup rule
     (services.cleanup_signs) so newly extracted sidecars do not re-accumulate
     after the retroactive sweep.
+
+    ``extracted_paths`` limits the purge to the sidecars THIS pass produced.
+    Without it the purge globbed every sidecar next to the video — including
+    pre-existing, hand-downloaded files (e.g. a user's ``.de.forced.srt``),
+    which were trashed as collateral of an unrelated extract. The last-sub
+    guard still counts ALL sidecars on disk so it stays correct.
 
     Last-sub guard: a sidecar is never trashed if it would leave the
     (video_base, canonical_lang) pair with zero subtitles on disk.
@@ -412,10 +419,17 @@ def purge_signs_after_extract(
     video_base = os.path.splitext(video_path)[0]
 
     # Enumerate all sidecars belonging to this video (same glob pattern used
-    # by trash_non_target_sidecars in remux).
-    candidates: list[str] = []
+    # by trash_non_target_sidecars in remux) — needed for the last-sub guard
+    # even when the purge itself is scoped to extracted_paths.
+    all_sidecars: list[str] = []
     for ext in _SIDECAR_EXTS:
-        candidates.extend(_glob.glob(f"{video_base}.*{ext}"))
+        all_sidecars.extend(_glob.glob(f"{video_base}.*{ext}"))
+
+    if extracted_paths is not None:
+        extracted_set = {os.path.abspath(p) for p in extracted_paths}
+        candidates = [p for p in all_sidecars if os.path.abspath(p) in extracted_set]
+    else:
+        candidates = all_sidecars
 
     if not candidates:
         return 0
@@ -432,7 +446,7 @@ def purge_signs_after_extract(
         return (vb, lang)
 
     per_key: dict[tuple, int] = {}
-    for p in candidates:
+    for p in all_sidecars:
         key = _guard_key(p)
         per_key[key] = per_key.get(key, 0) + 1
 
@@ -574,9 +588,14 @@ def extract_and_cleanup(
 
     # Going-forward signs purge: trash signs/forced/songs sidecars produced by
     # this extract pass so the library does not re-accumulate them after the
-    # retroactive sweep (Task 9).
+    # retroactive sweep (Task 9). Scoped to this pass's output — pre-existing
+    # sidecars (e.g. hand-downloaded forced subs) are not purge fodder.
     if any_extracted:
-        sidecars_trashed += purge_signs_after_extract(file_path, log_label=log_label)
+        sidecars_trashed += purge_signs_after_extract(
+            file_path,
+            log_label=log_label,
+            extracted_paths=[e["output_path"] for e in extracted],
+        )
 
     primary_output_path, primary_format, primary_language = _pick_primary(
         extracted, target_language

--- a/backend/services/embedded_extractor.py
+++ b/backend/services/embedded_extractor.py
@@ -304,6 +304,9 @@ def remove_streams_from_container(
             use_reflink=getattr(settings, "remux_use_reflink", True),
             trash_dir=getattr(settings, "remux_trash_dir", ".sublarr"),
         )
+        if bak is None:
+            # Hardlink policy refused the rewrite (already logged in remux).
+            return
         logger.info(
             "[%s]: removed %d stream(s) from container (backup: %s)",
             log_label,

--- a/backend/services/embedded_extractor.py
+++ b/backend/services/embedded_extractor.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 from dataclasses import dataclass
 
 from flask import current_app
@@ -40,6 +41,9 @@ from services.background_tasks import submit_background
 from services.cleanup_executors import _trash_path  # module-level so tests can patch it
 
 logger = logging.getLogger(__name__)
+
+# ISO-639 shape for container language tags (mirrors routes/tracks._LANG_RE).
+_LANG_TAG_RE = re.compile(r"^[a-z]{2,3}(-[a-z]{2,4})?$")
 
 
 # ---------------------------------------------------------------------------
@@ -111,6 +115,11 @@ def collect_subtitle_streams(probe_data: dict) -> list[dict]:
             sub_index += 1
             continue
         lang = (stream.get("tags", {}).get("language", "und") or "und").lower()
+        # The tag is interpolated into the sidecar output path — reject
+        # anything that does not look like an ISO-639 code (path-traversal
+        # defence, same rule as routes/tracks._safe_language).
+        if not _LANG_TAG_RE.match(lang):
+            lang = "und"
         sub_streams.append(
             {
                 "sub_index": sub_index,
@@ -143,15 +152,22 @@ def extract_streams(
                              pre-existing from an earlier run).
         streams_to_remove    list of (global_stream_index, sub_index)
                              tuples to feed back into
-                             ``remove_streams_from_container``.
+                             ``remove_streams_from_container``. Contains
+                             ONLY streams that were freshly extracted in
+                             this pass — a stream whose sidecar already
+                             existed, or that was skipped as a duplicate,
+                             is never a removal candidate (issue #159:
+                             repeat runs kept remuxing, and duplicate
+                             (lang, fmt) tracks — e.g. anime "Full" +
+                             "Signs" both tagged eng — were removed
+                             without ever being extracted).
         extracted            list of dicts {language, format, sub_index,
                              output_path} describing every sidecar that
                              ended up on disk — used by callers to decide
                              which one is "primary".
 
     Duplicate (lang, fmt) combinations are collapsed: only the first
-    occurrence is extracted, the rest are still scheduled for container
-    removal so the MKV ends up clean.
+    occurrence is extracted; the rest stay in the container untouched.
     """
     from ass_utils import extract_subtitle_stream, get_subtitle_stream_output_path
 
@@ -165,9 +181,11 @@ def extract_streams(
         out = get_subtitle_stream_output_path(file_path, stream_info)
 
         if os.path.exists(out):
+            # Sidecar already on disk from an earlier run — nothing was
+            # extracted now, so the stream must NOT become a removal
+            # candidate (a repeat run would otherwise remux the container
+            # again and again).
             any_extracted = True
-            if stream_info.get("stream_index") is not None:
-                streams_to_remove.append((stream_info["stream_index"], stream_info["sub_index"]))
             if lang_fmt not in seen_lang_fmt:
                 extracted.append(
                     {
@@ -181,8 +199,10 @@ def extract_streams(
             continue
 
         if lang_fmt in seen_lang_fmt:
-            if stream_info.get("stream_index") is not None:
-                streams_to_remove.append((stream_info["stream_index"], stream_info["sub_index"]))
+            # Duplicate (lang, fmt): this stream's content is NOT in the
+            # sidecar written for the first occurrence (distinct tracks —
+            # e.g. "Full Dialogue" vs "Signs & Songs" — collapse to the
+            # same output path). It stays in the container.
             continue
 
         try:
@@ -219,6 +239,46 @@ def extract_streams(
 # ---------------------------------------------------------------------------
 # Container cleanup
 # ---------------------------------------------------------------------------
+
+
+def filter_streams_safe_to_remove(
+    sub_streams: list[dict],
+    streams_to_remove: list[tuple[int, int]],
+    keep_langs: set[str],
+) -> list[tuple[int, int]]:
+    """Drop removal candidates whose language must be kept.
+
+    Defence in depth for the container rewrite (issue #159: the eng target
+    stream was remuxed out along with everything else):
+
+      - A stream whose ``normalize_language_code(language)`` is in
+        ``keep_langs`` is never removed.
+      - Unknown/``und`` tags are treated as KEEP (cannot prove they are
+        disposable).
+      - An empty ``keep_langs`` removes NOTHING — mirrors the
+        "empty target set → no-op" guard in
+        ``remux.remove_foreign_subtitle_streams``: never strip blind.
+    """
+    if not streams_to_remove:
+        return []
+    if not keep_langs:
+        return []
+
+    from config_language_data import _REVERSE_LANGUAGE_TAGS, normalize_language_code
+
+    lang_by_stream_index = {
+        s.get("stream_index"): (s.get("language") or "und") for s in sub_streams
+    }
+    safe: list[tuple[int, int]] = []
+    for stream_index, sub_index in streams_to_remove:
+        raw = (lang_by_stream_index.get(stream_index) or "und").lower()
+        if raw not in _REVERSE_LANGUAGE_TAGS:
+            # Unknown or und tag — cannot prove it is disposable, keep it.
+            continue
+        if normalize_language_code(raw) in keep_langs:
+            continue
+        safe.append((stream_index, sub_index))
+    return safe
 
 
 def remove_streams_from_container(
@@ -434,14 +494,18 @@ def extract_and_cleanup(
     *,
     target_language: str | None = None,
     log_label: str = "extractor",
+    remove_from_container: bool = False,
 ) -> ExtractResult:
     """Run the full extract-and-cleanup pipeline against a container.
 
     Pipeline:
       1. Classify every text-based subtitle stream
       2. Extract each one to a sidecar (skipping duplicates)
-      3. Remove the extracted streams from the container in one mkvmerge
-         pass (with backup into ``remux_trash_dir``)
+      3. Only when ``remove_from_container`` is True: remove the freshly
+         extracted streams from the container in one mkvmerge pass (with
+         backup into ``remux_trash_dir``). Streams whose language is in
+         ``keep_langs`` are never removed, and an empty ``keep_langs``
+         removes nothing (see ``filter_streams_safe_to_remove``).
       4. Trash sidecars on disk whose language is not in ``keep_langs``
 
     Args:
@@ -457,6 +521,11 @@ def extract_and_cleanup(
             trashed.
         log_label: Tag prepended to log lines so each call site is
             identifiable in production logs.
+        remove_from_container: Opt-in for the container rewrite (step 3).
+            Defaults to False — issue #159: the rewrite used to be an
+            unconditional side effect of extraction, stripping streams
+            (including target-language ones) from users who never asked
+            for it and breaking *arr hardlinks.
 
     Returns:
         ExtractResult — see dataclass docstring.
@@ -476,7 +545,16 @@ def extract_and_cleanup(
         file_path, sub_streams, log_label=log_label
     )
 
-    remove_streams_from_container(file_path, streams_to_remove, log_label=log_label)
+    if remove_from_container:
+        safe_to_remove = filter_streams_safe_to_remove(sub_streams, streams_to_remove, keep_langs)
+        remove_streams_from_container(file_path, safe_to_remove, log_label=log_label)
+    elif streams_to_remove:
+        logger.debug(
+            "[%s]: container removal disabled — keeping %d extracted stream(s) in %s",
+            log_label,
+            len(streams_to_remove),
+            file_path,
+        )
 
     sidecars_trashed = 0
     if any_extracted and keep_langs:
@@ -538,7 +616,13 @@ def validate_extract_target(file_path: str) -> str | None:
     return None
 
 
-def extract_embedded_sub(item_id: int, file_path: str, auto_translate: bool = False) -> dict:
+def extract_embedded_sub(
+    item_id: int,
+    file_path: str,
+    auto_translate: bool = False,
+    *,
+    remove_from_container: bool | None = None,
+) -> dict:
     """Extract embedded subtitles for a wanted item.
 
     Callable from outside a Flask request context (e.g. from the scanner).
@@ -552,8 +636,11 @@ def extract_embedded_sub(item_id: int, file_path: str, auto_translate: bool = Fa
     Behaviour (rev. with shared embedded_extractor pipeline):
       - Extracts EVERY text-based subtitle stream the container offers,
         not just the "best" one. Image subtitles (PGS/VobSub) are skipped.
-      - Removes all extracted streams from the container in a single
-        mkvmerge pass with a backup in ``remux_trash_dir`` (recoverable).
+      - Container stream removal is OPT-IN (issue #159): only when
+        ``embedded_extract_remove_from_container`` is enabled (or the
+        caller passes ``remove_from_container=True``) are freshly
+        extracted streams remuxed out — with a backup in
+        ``remux_trash_dir``, and never streams in the keep-languages set.
       - Trashes any sidecar whose language is not in the wanted item's
         profile target_languages — also into ``remux_trash_dir``.
       - Returns the "primary" sidecar (the target-lang match, falling
@@ -567,6 +654,9 @@ def extract_embedded_sub(item_id: int, file_path: str, auto_translate: bool = Fa
             extracted SRT after extraction. Translation is a Beta-gated
             feature in production; the scheduler-driven drain passes
             False so it stays manual.
+        remove_from_container: Tri-state opt-in for the container rewrite.
+            None (default) resolves to the
+            ``embedded_extract_remove_from_container`` setting.
     """
     # Lazy imports below are intentional: tests patch these at their source
     # modules (e.g. ``patch("ass_utils.get_media_streams")``,
@@ -602,12 +692,18 @@ def extract_embedded_sub(item_id: int, file_path: str, auto_translate: bool = Fa
 
     probe_data = get_media_streams(file_path, use_cache=True)
 
+    if remove_from_container is None:
+        remove_from_container = bool(
+            getattr(settings, "embedded_extract_remove_from_container", False)
+        )
+
     result = extract_and_cleanup(
         file_path=file_path,
         probe_data=probe_data,
         keep_langs=keep_langs,
         target_language=target_language,
         log_label=f"auto-extract item {item_id}",
+        remove_from_container=remove_from_container,
     )
 
     if not result.any_extracted or result.primary_output_path is None:

--- a/backend/services/subtitle_health/sweep.py
+++ b/backend/services/subtitle_health/sweep.py
@@ -34,7 +34,27 @@ def _is_stable(path: str) -> bool:
     return age > 300  # at least 5 minutes since last write
 
 
+def _sweep_enabled() -> bool:
+    """Honour the feature toggle AND the sweep toggle.
+
+    Both settings existed in config but were never read — a user who
+    disabled the sweep still had sidecars rewritten nightly whenever
+    auto-fix was on.
+    """
+    from config import get_settings
+
+    try:
+        settings = get_settings()
+    except Exception:
+        return False
+    return bool(getattr(settings, "subtitle_health_enabled", True)) and bool(
+        getattr(settings, "subtitle_health_sweep_enabled", True)
+    )
+
+
 def subtitle_health_sweep_tick() -> None:
+    if not _sweep_enabled():
+        return
     client = get_sonarr_client()
     if client is None:
         return

--- a/backend/services/wanted_search_filters.py
+++ b/backend/services/wanted_search_filters.py
@@ -108,6 +108,45 @@ def _filter_eligible(items: list[dict], settings) -> list[dict]:
     return eligible
 
 
+def _enqueue_embedded_items(embedded_items, settings) -> tuple[list[dict], int]:
+    """Enqueue embedded-sub items to the subtitle-automation queue.
+
+    Mirrors the scan-time routing in
+    ``wanted_scanner_sources._maybe_auto_extract``: when automation is on,
+    the drain worker owns extraction. Returns ``(leftover, enqueued)`` —
+    leftovers are items that could not be enqueued (no resolvable target
+    language, or the repository raised); the caller decides whether they
+    fall back to inline extraction or to the normal provider search.
+    """
+    from db.repositories.subtitle_automation_queue import (
+        SubtitleAutomationQueueRepository,
+    )
+
+    leftover: list[dict] = []
+    enqueued = 0
+    repo = SubtitleAutomationQueueRepository()
+    for item in embedded_items:
+        target_lang = item.get("target_language") or getattr(settings, "target_language", "")
+        if not target_lang:
+            leftover.append(item)
+            continue
+        try:
+            repo.enqueue(
+                wanted_item_id=item["id"],
+                file_path=item["file_path"],
+                target_language=target_lang,
+            )
+            enqueued += 1
+        except Exception as exc:  # noqa: BLE001 — enqueue must never break the search tick
+            logger.warning(
+                "[search_all] automation enqueue failed for item %d: %s — falling back",
+                item["id"],
+                exc,
+            )
+            leftover.append(item)
+    return leftover, enqueued
+
+
 def _extract_embedded_items(
     embedded_items, processed, found, failed, total, socketio, settings
 ) -> tuple[int, int, int]:

--- a/backend/services/wanted_search_runner.py
+++ b/backend/services/wanted_search_runner.py
@@ -26,6 +26,7 @@ from db.models.activity import EVENT_SEARCH
 from services.wanted_search_filters import (  # noqa: F401 — re-exported for back-compat
     _EMBEDDED_TYPES,
     _apply_backlog_reserve_gate,
+    _enqueue_embedded_items,
     _extract_embedded_items,
     _filter_eligible,
     _split_local_translate_items,
@@ -304,9 +305,36 @@ def run_wanted_search(
     if not eligible and not local_translate_items:
         return {"total": 0, "processed": 0, "found": 0, "failed": 0, "skipped": 0}
 
-    # Split: embedded subs → extraction, rest → provider search
-    embedded_items = [i for i in eligible if i.get("existing_sub") in _EMBEDDED_TYPES]
-    search_items = [i for i in eligible if i.get("existing_sub") not in _EMBEDDED_TYPES]
+    # Split: embedded subs → extraction, rest → provider search.
+    # Issue #159: the split only happens when the user opted into an
+    # extraction path. With subtitle_automation_enabled and
+    # wanted_auto_extract both off, embedded items stay in the normal
+    # provider search and their files are never touched.
+    automation_on = bool(getattr(settings, "subtitle_automation_enabled", False))
+    auto_extract_on = bool(getattr(settings, "wanted_auto_extract", False))
+
+    if automation_on or auto_extract_on:
+        embedded_items = [i for i in eligible if i.get("existing_sub") in _EMBEDDED_TYPES]
+        search_items = [i for i in eligible if i.get("existing_sub") not in _EMBEDDED_TYPES]
+    else:
+        embedded_items = []
+        search_items = list(eligible)
+
+    enqueued_count = 0
+    if automation_on and embedded_items:
+        # Preferred path: hand embedded items to the automation queue — the
+        # drain worker owns extraction (and respects its own gates). Items
+        # that could not be enqueued fall through to the legacy inline path,
+        # or back to the provider search when that toggle is off too.
+        embedded_items, enqueued_count = _enqueue_embedded_items(embedded_items, settings)
+        if enqueued_count:
+            logger.info(
+                "[search_all] %d items have embedded subs — enqueued for the automation drain",
+                enqueued_count,
+            )
+    if embedded_items and not auto_extract_on:
+        search_items = embedded_items + search_items
+        embedded_items = []
 
     if embedded_items:
         logger.info(
@@ -325,6 +353,10 @@ def run_wanted_search(
     found = 0
     failed = 0
     skipped = 0
+
+    # Enqueued items are handed off to the drain worker, not searched this tick.
+    processed += enqueued_count
+    skipped += enqueued_count
 
     # Translate local-sidecar items first — no provider involved at all.
     processed, found, failed = _translate_local_sidecar_items(

--- a/backend/subtitle_filename.py
+++ b/backend/subtitle_filename.py
@@ -65,6 +65,9 @@ SUBTITLE_EXTS: frozenset[str] = frozenset({"srt", "ass", "ssa", "vtt"})
 # Modifier tokens that may appear between the language and the extension.
 # Order does not matter; the parser collects them all into a sorted list.
 # Keep aligned with the regex in dedup_engine.py.
+# NOTE: deliberately diverges from remux._SIDECAR_MODIFIERS (has bak, lacks
+# sign/signs; stacks unbounded vs. single trailing token there). The remux
+# table's divergences all err toward NOT parsing = never trashing.
 MODIFIERS: frozenset[str] = frozenset({"hi", "bak", "forced", "sdh", "cc"})
 
 # Lowercase ISO-639-1 (2 letters) and ISO-639-2 (3 letters). The lookup

--- a/backend/tests/test_cleanup_signs_seed.py
+++ b/backend/tests/test_cleanup_signs_seed.py
@@ -26,8 +26,10 @@ def test_default_signs_rule_seeded(app_ctx):
     cfg = signs["config_json"]
     assert cfg.get("strip_embedded") is True
     assert cfg.get("permanent_delete") is False
-    assert "de" in cfg.get("keep_languages", [])
-    assert "en" in cfg.get("keep_languages", [])
+    # keep_languages is intentionally NOT seeded: the signs executor never
+    # read it (language-agnostic last-track guard only), and seeding it
+    # implied a protection that does not exist.
+    assert "keep_languages" not in cfg
 
 
 def test_ensure_default_rules_is_idempotent(app_ctx):

--- a/backend/tests/test_embedded_extractor_container_removal.py
+++ b/backend/tests/test_embedded_extractor_container_removal.py
@@ -273,8 +273,13 @@ class TestExtractEmbeddedSubResolvesSetting:
             patch("db.wanted.update_existing_sub"),
             patch("db.wanted.update_wanted_status"),
             patch("ass_utils.get_media_streams", return_value={"streams": []}),
-            patch("services.embedded_extractor.resolve_profile_for_item", return_value={"target_languages": ["de"]}),
-            patch("services.embedded_extractor.extract_and_cleanup", return_value=fake_result) as mock_eac,
+            patch(
+                "services.embedded_extractor.resolve_profile_for_item",
+                return_value={"target_languages": ["de"]},
+            ),
+            patch(
+                "services.embedded_extractor.extract_and_cleanup", return_value=fake_result
+            ) as mock_eac,
             patch("services.embedded_extractor.emit_event"),
             patch("services.embedded_extractor.log_activity"),
         ):

--- a/backend/tests/test_embedded_extractor_container_removal.py
+++ b/backend/tests/test_embedded_extractor_container_removal.py
@@ -1,0 +1,283 @@
+"""Container-removal gating tests for the shared extract pipeline (issue #159).
+
+The container rewrite after extraction used to be unconditional: every
+extracted stream — including target-language ones, duplicates that were
+never extracted, and streams whose sidecar already existed from an earlier
+run — was remuxed out of the MKV. These tests pin the fixed contract:
+
+  - removal is opt-in (``remove_from_container``, default False)
+  - streams in ``keep_langs`` are never removed
+  - empty ``keep_langs`` removes nothing (never strip blind)
+  - only freshly extracted streams are removal candidates
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _probe(*streams):
+    return {"streams": list(streams)}
+
+
+def _sub_stream(index: int, lang: str, codec: str = "ass"):
+    return {
+        "codec_type": "subtitle",
+        "codec_name": codec,
+        "index": index,
+        "tags": {"language": lang},
+    }
+
+
+def _settings_mock(**overrides):
+    s = MagicMock()
+    s.embedded_allow_sdh = True
+    s.remux_use_reflink = False
+    s.remux_trash_dir = ".sublarr"
+    s.cleanup_signs_removal_level = "off"
+    for k, v in overrides.items():
+        setattr(s, k, v)
+    return s
+
+
+def _out_path_for(tmp_path):
+    """get_subtitle_stream_output_path replacement: unique path per stream."""
+
+    def _f(file_path, stream_info):
+        return str(tmp_path / f"Ep.{stream_info['language']}.{stream_info['sub_index']}.ass")
+
+    return _f
+
+
+class TestExtractAndCleanupContainerRemoval:
+    def test_default_never_removes_streams(self, tmp_path):
+        """Without the opt-in, extraction must not touch the container."""
+        from services import embedded_extractor
+
+        video = tmp_path / "Ep.mkv"
+        video.write_bytes(b"fake")
+
+        with (
+            patch("config.get_settings", return_value=_settings_mock()),
+            patch("ass_probe.is_sdh_stream", return_value=False),
+            patch("ass_utils.get_subtitle_stream_output_path", side_effect=_out_path_for(tmp_path)),
+            patch("ass_utils.extract_subtitle_stream"),
+            patch("services.embedded_extractor.remove_streams_from_container") as mock_remove,
+            patch("services.embedded_extractor.trash_unwanted_sidecars", return_value=0),
+        ):
+            result = embedded_extractor.extract_and_cleanup(
+                str(video),
+                _probe(_sub_stream(2, "eng"), _sub_stream(3, "jpn")),
+                keep_langs={"en"},
+            )
+
+        assert result.any_extracted is True
+        mock_remove.assert_not_called()
+
+    def test_opt_in_removal_spares_keep_langs_streams(self, tmp_path):
+        """With the opt-in ON, a stream whose 3-letter tag normalises into
+        keep_langs (eng → en) must survive; only disposable languages go."""
+        from services import embedded_extractor
+
+        video = tmp_path / "Ep.mkv"
+        video.write_bytes(b"fake")
+
+        with (
+            patch("config.get_settings", return_value=_settings_mock()),
+            patch("ass_probe.is_sdh_stream", return_value=False),
+            patch("ass_utils.get_subtitle_stream_output_path", side_effect=_out_path_for(tmp_path)),
+            patch("ass_utils.extract_subtitle_stream"),
+            patch("services.embedded_extractor.remove_streams_from_container") as mock_remove,
+            patch("services.embedded_extractor.trash_unwanted_sidecars", return_value=0),
+        ):
+            embedded_extractor.extract_and_cleanup(
+                str(video),
+                _probe(_sub_stream(2, "eng"), _sub_stream(3, "jpn")),
+                keep_langs={"en"},
+                remove_from_container=True,
+            )
+
+        mock_remove.assert_called_once()
+        removed = mock_remove.call_args.args[1]
+        assert removed == [(3, 1)], "only the jpn stream may be removed, eng is kept"
+
+    def test_opt_in_with_empty_keep_langs_removes_nothing(self, tmp_path):
+        """Empty keep set → no removal at all (mirror of the
+        remove_foreign_subtitle_streams empty-target-set guard)."""
+        from services import embedded_extractor
+
+        video = tmp_path / "Ep.mkv"
+        video.write_bytes(b"fake")
+
+        with (
+            patch("config.get_settings", return_value=_settings_mock()),
+            patch("ass_probe.is_sdh_stream", return_value=False),
+            patch("ass_utils.get_subtitle_stream_output_path", side_effect=_out_path_for(tmp_path)),
+            patch("ass_utils.extract_subtitle_stream"),
+            patch("services.embedded_extractor.remove_streams_from_container") as mock_remove,
+        ):
+            embedded_extractor.extract_and_cleanup(
+                str(video),
+                _probe(_sub_stream(2, "eng"), _sub_stream(3, "jpn")),
+                keep_langs=set(),
+                remove_from_container=True,
+            )
+
+        removed = mock_remove.call_args.args[1]
+        assert removed == []
+
+    def test_unknown_language_tag_is_never_removed(self, tmp_path):
+        from services import embedded_extractor
+
+        video = tmp_path / "Ep.mkv"
+        video.write_bytes(b"fake")
+
+        with (
+            patch("config.get_settings", return_value=_settings_mock()),
+            patch("ass_probe.is_sdh_stream", return_value=False),
+            patch("ass_utils.get_subtitle_stream_output_path", side_effect=_out_path_for(tmp_path)),
+            patch("ass_utils.extract_subtitle_stream"),
+            patch("services.embedded_extractor.remove_streams_from_container") as mock_remove,
+            patch("services.embedded_extractor.trash_unwanted_sidecars", return_value=0),
+        ):
+            embedded_extractor.extract_and_cleanup(
+                str(video),
+                _probe(_sub_stream(2, "und"), _sub_stream(3, "jpn")),
+                keep_langs={"de"},
+                remove_from_container=True,
+            )
+
+        removed = mock_remove.call_args.args[1]
+        assert removed == [(3, 1)], "und stream must be kept"
+
+    def test_preexisting_sidecar_not_requeued_for_removal(self, tmp_path):
+        """A stream whose sidecar already exists was NOT extracted in this
+        pass — repeat runs must not remux the container again."""
+        from services import embedded_extractor
+
+        video = tmp_path / "Ep.mkv"
+        video.write_bytes(b"fake")
+        existing = tmp_path / "Ep.jpn.0.ass"
+        existing.write_text("dialogue", encoding="utf-8")
+
+        with (
+            patch("config.get_settings", return_value=_settings_mock()),
+            patch("ass_probe.is_sdh_stream", return_value=False),
+            patch("ass_utils.get_subtitle_stream_output_path", side_effect=_out_path_for(tmp_path)),
+            patch("ass_utils.extract_subtitle_stream") as mock_extract,
+            patch("services.embedded_extractor.remove_streams_from_container") as mock_remove,
+            patch("services.embedded_extractor.trash_unwanted_sidecars", return_value=0),
+        ):
+            result = embedded_extractor.extract_and_cleanup(
+                str(video),
+                _probe(_sub_stream(2, "jpn")),
+                keep_langs={"de"},
+                remove_from_container=True,
+            )
+
+        mock_extract.assert_not_called()
+        assert result.any_extracted is True
+        removed = mock_remove.call_args.args[1]
+        assert removed == []
+
+    def test_duplicate_lang_fmt_stream_not_removed_without_extraction(self, tmp_path):
+        """Two eng+ass tracks (anime 'Full' + 'Signs') collapse to one output
+        path. The second track is never extracted — it must therefore never
+        be removed from the container (its content exists nowhere else)."""
+        from services import embedded_extractor
+
+        video = tmp_path / "Ep.mkv"
+        video.write_bytes(b"fake")
+
+        def _same_path(file_path, stream_info):
+            return str(tmp_path / f"Ep.{stream_info['language']}.ass")
+
+        with (
+            patch("config.get_settings", return_value=_settings_mock()),
+            patch("ass_probe.is_sdh_stream", return_value=False),
+            patch("ass_utils.get_subtitle_stream_output_path", side_effect=_same_path),
+            patch("ass_utils.extract_subtitle_stream"),
+            patch("services.embedded_extractor.remove_streams_from_container") as mock_remove,
+            patch("services.embedded_extractor.trash_unwanted_sidecars", return_value=0),
+        ):
+            result = embedded_extractor.extract_and_cleanup(
+                str(video),
+                _probe(_sub_stream(2, "eng"), _sub_stream(3, "eng")),
+                keep_langs={"de"},
+                remove_from_container=True,
+            )
+
+        assert len(result.extracted) == 1
+        removed = mock_remove.call_args.args[1]
+        assert removed == [(2, 0)], "the never-extracted duplicate must stay in the container"
+
+
+class TestFilterStreamsSafeToRemove:
+    def test_empty_candidates(self):
+        from services.embedded_extractor import filter_streams_safe_to_remove
+
+        assert filter_streams_safe_to_remove([], [], {"en"}) == []
+
+    def test_three_letter_tag_matches_two_letter_keep(self):
+        from services.embedded_extractor import filter_streams_safe_to_remove
+
+        streams = [
+            {"stream_index": 2, "language": "eng"},
+            {"stream_index": 3, "language": "ger"},
+            {"stream_index": 4, "language": "jpn"},
+        ]
+        candidates = [(2, 0), (3, 1), (4, 2)]
+
+        safe = filter_streams_safe_to_remove(streams, candidates, {"en", "de"})
+
+        assert safe == [(4, 2)]
+
+    def test_empty_keep_langs_never_strips(self):
+        from services.embedded_extractor import filter_streams_safe_to_remove
+
+        streams = [{"stream_index": 2, "language": "jpn"}]
+        assert filter_streams_safe_to_remove(streams, [(2, 0)], set()) == []
+
+
+class TestExtractEmbeddedSubResolvesSetting:
+    @pytest.mark.parametrize("setting_value", [False, True])
+    def test_setting_passthrough(self, tmp_path, setting_value):
+        from services import embedded_extractor
+        from services.embedded_extractor import ExtractResult
+
+        video = tmp_path / "Ep.mkv"
+        video.write_bytes(b"fake")
+
+        settings = _settings_mock(
+            embedded_extract_remove_from_container=setting_value,
+            enable_subtitle_repair=False,
+            target_language="de",
+            media_path=str(tmp_path),
+        )
+
+        item = {"id": 1, "target_language": "de"}
+        fake_result = ExtractResult(
+            any_extracted=True,
+            extracted=[{"language": "de", "format": "srt", "sub_index": 0, "output_path": "x"}],
+            primary_output_path=str(video),
+            primary_format="srt",
+            primary_language="de",
+            sidecars_trashed=0,
+        )
+
+        with (
+            patch("config.get_settings", return_value=settings),
+            patch("db.wanted.get_wanted_item", return_value=item),
+            patch("db.wanted.update_existing_sub"),
+            patch("db.wanted.update_wanted_status"),
+            patch("ass_utils.get_media_streams", return_value={"streams": []}),
+            patch("services.embedded_extractor.resolve_profile_for_item", return_value={"target_languages": ["de"]}),
+            patch("services.embedded_extractor.extract_and_cleanup", return_value=fake_result) as mock_eac,
+            patch("services.embedded_extractor.emit_event"),
+            patch("services.embedded_extractor.log_activity"),
+        ):
+            embedded_extractor.extract_embedded_sub(1, str(video))
+
+        assert mock_eac.call_args.kwargs["remove_from_container"] is setting_value

--- a/backend/tests/test_embedded_extractor_signs.py
+++ b/backend/tests/test_embedded_extractor_signs.py
@@ -181,4 +181,6 @@ def test_extract_and_cleanup_invokes_signs_purge_when_extracted(tmp_path):
             keep_langs={"en"},
         )
 
-    purge_mock.assert_called_once_with(str(video), log_label="extractor")
+    purge_mock.assert_called_once_with(
+        str(video), log_label="extractor", extracted_paths=[str(out)]
+    )

--- a/backend/tests/test_language_normalization_fixes.py
+++ b/backend/tests/test_language_normalization_fixes.py
@@ -64,9 +64,7 @@ class TestComputeKeepLangs:
     def test_und_only_targets_produce_empty_keep_set(self):
         from services.embedded_extractor import compute_keep_langs
 
-        keep = compute_keep_langs(
-            {"target_languages": ["und", "und1", "und2"]}, self._settings()
-        )
+        keep = compute_keep_langs({"target_languages": ["und", "und1", "und2"]}, self._settings())
         assert keep == set(), "an und-only keep set must trigger the empty-set no-op guards"
 
     def test_source_language_added_when_auto_translate(self):
@@ -157,9 +155,7 @@ class TestResolveCombineSources:
             {"language": "eng", "format": "ass", "path": str(tmp_path / "ep.eng.ass")},
         ]
 
-        with patch(
-            "services.sidecar_scan.scan_subtitle_sidecars", return_value=sidecars
-        ):
+        with patch("services.sidecar_scan.scan_subtitle_sidecars", return_value=sidecars):
             present, missing = resolve_combine_sources(str(tmp_path / "ep.mkv"), ["de", "en"])
 
         assert missing == []

--- a/backend/tests/test_language_normalization_fixes.py
+++ b/backend/tests/test_language_normalization_fixes.py
@@ -1,0 +1,167 @@
+"""Unit tests for language-code normalisation on destructive paths.
+
+Audit follow-up to issue #159: several keep-language checks compared raw
+container/filename tags (3-letter "ger"/"eng") against 2-letter keep lists
+without canonicalisation, so target-language tracks and sidecars were
+classified as foreign/disposable.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestGetLanguageTags:
+    def test_three_letter_input_expands_like_two_letter(self):
+        from config_language_data import _get_language_tags
+
+        assert {"de", "deu", "ger"} <= _get_language_tags("ger")
+        assert _get_language_tags("ger") == _get_language_tags("de")
+
+    def test_script_variant_includes_base_language_tags(self):
+        from config_language_data import _get_language_tags
+
+        tags = _get_language_tags("zh-hans")
+        assert {"zh-hans", "zh", "zho", "chi"} <= tags
+
+    def test_unknown_code_returns_itself(self):
+        from config_language_data import _get_language_tags
+
+        assert _get_language_tags("zz") == {"zz"}
+
+
+class TestLanguageTableGaps:
+    def test_bokmal_and_nynorsk_normalize_to_norwegian(self):
+        from config_language_data import normalize_language_code
+
+        assert normalize_language_code("nob") == "no"
+        assert normalize_language_code("nb") == "no"
+        assert normalize_language_code("nno") == "no"
+
+    def test_bazarr_brazilian_portuguese_normalizes_to_pt(self):
+        from config_language_data import normalize_language_code
+
+        assert normalize_language_code("pob") == "pt"
+        assert normalize_language_code("pt-br") == "pt"
+
+
+class TestComputeKeepLangs:
+    def _settings(self, auto_translate=False, source_language=""):
+        s = MagicMock()
+        s.wanted_auto_translate = auto_translate
+        s.source_language = source_language
+        return s
+
+    def test_script_variant_target_keeps_base_code(self):
+        from services.embedded_extractor import compute_keep_langs
+
+        keep = compute_keep_langs({"target_languages": ["zh-hans"]}, self._settings())
+        assert "zh-hans" in keep
+        assert "zh" in keep, "generic chi/zho/zh tags must never be trashed for zh-hans"
+
+    def test_und_only_targets_produce_empty_keep_set(self):
+        from services.embedded_extractor import compute_keep_langs
+
+        keep = compute_keep_langs(
+            {"target_languages": ["und", "und1", "und2"]}, self._settings()
+        )
+        assert keep == set(), "an und-only keep set must trigger the empty-set no-op guards"
+
+    def test_source_language_added_when_auto_translate(self):
+        from services.embedded_extractor import compute_keep_langs
+
+        keep = compute_keep_langs(
+            {"target_languages": ["de"]},
+            self._settings(auto_translate=True, source_language="eng"),
+        )
+        assert keep == {"de", "en"}
+
+
+class TestPickPrimary:
+    def test_three_letter_track_matches_two_letter_target(self):
+        from services.embedded_extractor import _pick_primary
+
+        extracted = [
+            {"language": "jpn", "format": "ass", "sub_index": 0, "output_path": "/a.jpn.ass"},
+            {"language": "ger", "format": "srt", "sub_index": 1, "output_path": "/a.ger.srt"},
+        ]
+        path, fmt, lang = _pick_primary(extracted, "de")
+        assert lang == "ger"
+        assert path == "/a.ger.srt"
+
+    def test_no_prefix_false_positive_estonian_for_spanish(self):
+        from services.embedded_extractor import _pick_primary
+
+        extracted = [
+            {"language": "est", "format": "srt", "sub_index": 0, "output_path": "/a.est.srt"},
+            {"language": "jpn", "format": "ass", "sub_index": 1, "output_path": "/a.jpn.ass"},
+        ]
+        path, fmt, lang = _pick_primary(extracted, "es")
+        # No Spanish track exists — fall back to the first entry, but never
+        # "match" Estonian just because it shares the prefix.
+        assert lang == "est"  # fallback extracted[0], not a target match
+        # The regression: with prefix matching, "est" was treated as a target
+        # match for "es". Verify a real Spanish track wins when present.
+        extracted.append(
+            {"language": "spa", "format": "srt", "sub_index": 2, "output_path": "/a.spa.srt"}
+        )
+        path, fmt, lang = _pick_primary(extracted, "es")
+        assert lang == "spa"
+
+
+class TestRemoveForeignSubtitleStreamsDefense:
+    def test_bare_two_letter_target_spares_three_letter_tagged_stream(self, tmp_path):
+        """Even when a caller (wrongly) passes bare 2-letter codes, the
+        target-language stream must survive."""
+        import remux as remux_mod
+
+        video = tmp_path / "ep.mkv"
+        video.write_bytes(b"fake")
+
+        probe = {
+            "streams": [
+                {
+                    "codec_type": "subtitle",
+                    "index": 2,
+                    "tags": {"language": "ger"},
+                },
+                {
+                    "codec_type": "subtitle",
+                    "index": 3,
+                    "tags": {"language": "jpn"},
+                },
+            ]
+        }
+
+        with (
+            patch("remux.get_media_streams", return_value=probe),
+            patch("remux.remove_subtitle_streams", return_value="/bak") as mock_remove,
+        ):
+            remux_mod.remove_foreign_subtitle_streams(
+                video_path=str(video),
+                target_languages={"de"},
+            )
+
+        streams = mock_remove.call_args.kwargs["streams"]
+        assert streams == [(3, 1)], "ger must not be foreign for target {'de'}"
+
+
+class TestResolveCombineSources:
+    def test_three_letter_sidecar_tags_match_profile_codes(self, tmp_path):
+        from services.combine_service import resolve_combine_sources
+
+        sidecars = [
+            {"language": "ger", "format": "ass", "path": str(tmp_path / "ep.ger.ass")},
+            {"language": "eng", "format": "ass", "path": str(tmp_path / "ep.eng.ass")},
+        ]
+
+        with patch(
+            "services.sidecar_scan.scan_subtitle_sidecars", return_value=sidecars
+        ):
+            present, missing = resolve_combine_sources(str(tmp_path / "ep.mkv"), ["de", "en"])
+
+        assert missing == []
+        assert [p["language"] for p in present] == ["de", "en"]
+        assert present[0]["path"].endswith("ep.ger.ass")

--- a/backend/tests/test_remux_hardlink_policy.py
+++ b/backend/tests/test_remux_hardlink_policy.py
@@ -1,0 +1,160 @@
+"""Tests for the hardlink-aware remux policy (issue #160).
+
+Most *arr setups hardlink the library to the download folder; every
+container rewrite (temp + atomic replace) silently breaks that link. The
+``remux_hardlink_policy`` setting gates all container rewrites centrally:
+skip (default) | warn (proceed + auditable log) | allow (old behaviour).
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _settings(policy: str):
+    s = MagicMock()
+    s.remux_hardlink_policy = policy
+    s.remux_use_reflink = False
+    s.remux_trash_dir = ".sublarr"
+    return s
+
+
+@pytest.fixture
+def hardlinked_video(tmp_path):
+    video = tmp_path / "ep.mkv"
+    video.write_bytes(b"fake video")
+    link = tmp_path / "seed.mkv"
+    os.link(video, link)
+    assert os.stat(video).st_nlink == 2
+    return video
+
+
+@pytest.fixture
+def plain_video(tmp_path):
+    video = tmp_path / "ep.mkv"
+    video.write_bytes(b"fake video")
+    return video
+
+
+class TestCheckHardlinkPolicy:
+    def test_skip_refuses_hardlinked_file(self, hardlinked_video):
+        from remux import check_hardlink_policy
+
+        with patch("config.get_settings", return_value=_settings("skip")):
+            assert check_hardlink_policy(str(hardlinked_video)) is False
+
+    def test_warn_proceeds_on_hardlinked_file(self, hardlinked_video, caplog):
+        import logging
+
+        from remux import check_hardlink_policy
+
+        with (
+            caplog.at_level(logging.WARNING, logger="remux"),
+            patch("config.get_settings", return_value=_settings("warn")),
+        ):
+            assert check_hardlink_policy(str(hardlinked_video)) is True
+        assert any("hardlink" in r.message.lower() for r in caplog.records)
+
+    def test_allow_proceeds_silently(self, hardlinked_video):
+        from remux import check_hardlink_policy
+
+        with patch("config.get_settings", return_value=_settings("allow")):
+            assert check_hardlink_policy(str(hardlinked_video)) is True
+
+    def test_unlinked_file_always_proceeds(self, plain_video):
+        from remux import check_hardlink_policy
+
+        for policy in ("skip", "warn", "allow"):
+            with patch("config.get_settings", return_value=_settings(policy)):
+                assert check_hardlink_policy(str(plain_video)) is True
+
+    def test_missing_file_does_not_block(self, tmp_path):
+        from remux import check_hardlink_policy
+
+        with patch("config.get_settings", return_value=_settings("skip")):
+            assert check_hardlink_policy(str(tmp_path / "gone.mkv")) is True
+
+    def test_settings_failure_defaults_to_skip(self, hardlinked_video):
+        from remux import check_hardlink_policy
+
+        with patch("config.get_settings", side_effect=RuntimeError("no settings")):
+            assert check_hardlink_policy(str(hardlinked_video)) is False
+
+
+class TestRemoveSubtitleStreamsHardlinkGate:
+    def test_skip_policy_returns_none_and_leaves_file_untouched(self, hardlinked_video):
+        import remux as remux_mod
+
+        original = hardlinked_video.read_bytes()
+
+        with (
+            patch("config.get_settings", return_value=_settings("skip")),
+            patch("remux._remux_mkvmerge") as mock_mkv,
+            patch("remux._remux_ffmpeg") as mock_ff,
+        ):
+            result = remux_mod.remove_subtitle_streams(
+                video_path=str(hardlinked_video),
+                streams=[(2, 0)],
+            )
+
+        assert result is None
+        mock_mkv.assert_not_called()
+        mock_ff.assert_not_called()
+        assert hardlinked_video.read_bytes() == original
+        assert os.stat(hardlinked_video).st_nlink == 2, "hardlink must survive"
+
+    def test_allow_policy_rewrites(self, hardlinked_video):
+        import remux as remux_mod
+
+        def _fake_remux(video_path, indices, out):
+            with open(out, "wb") as fh:
+                fh.write(b"remuxed")
+
+        with (
+            patch("config.get_settings", return_value=_settings("allow")),
+            patch("remux._detect_backend", return_value="mkvmerge"),
+            patch("remux._which", return_value=True),
+            patch("remux._remux_mkvmerge", side_effect=_fake_remux),
+            patch("remux._verify"),
+            patch("remux._make_backup", return_value="/bak") as mock_bak,
+        ):
+            result = remux_mod.remove_subtitle_streams(
+                video_path=str(hardlinked_video),
+                streams=[(2, 0)],
+            )
+
+        assert result == "/bak"
+        mock_bak.assert_called_once()
+
+    def test_foreign_streams_skips_before_probe(self, hardlinked_video):
+        import remux as remux_mod
+
+        with (
+            patch("config.get_settings", return_value=_settings("skip")),
+            patch("remux.get_media_streams") as mock_probe,
+        ):
+            result = remux_mod.remove_foreign_subtitle_streams(
+                video_path=str(hardlinked_video),
+                target_languages={"de", "deu", "ger"},
+            )
+
+        assert result is None
+        mock_probe.assert_not_called()
+
+    def test_by_index_skips(self, hardlinked_video):
+        import remux as remux_mod
+
+        with (
+            patch("config.get_settings", return_value=_settings("skip")),
+            patch("remux.get_media_streams") as mock_probe,
+        ):
+            result = remux_mod.remove_subtitle_streams_by_index(
+                video_path=str(hardlinked_video),
+                drop_indices=[0],
+            )
+
+        assert result is None
+        mock_probe.assert_not_called()

--- a/backend/tests/test_routes_tracks.py
+++ b/backend/tests/test_routes_tracks.py
@@ -830,8 +830,8 @@ class TestCleanupSeriesSidecars:
         deleted = _cleanup_series_sidecars(episode_files, {"de"}, "any")
         assert deleted == 0
 
-    def test_handles_os_error_on_unlink(self, tmp_path):
-        """OSError during unlink is caught and does not crash."""
+    def test_handles_trash_failure(self, tmp_path):
+        """A failed trash move is not counted and does not crash."""
         video = tmp_path / "ep.mkv"
         video.write_text("fake video")
 
@@ -844,11 +844,113 @@ class TestCleanupSeriesSidecars:
         with (
             patch("routes.tracks.map_path", side_effect=lambda p: p),
             patch("routes.subtitles.scan_subtitle_sidecars", return_value=sidecars),
-            patch("os.unlink", side_effect=OSError("permission denied")),
+            patch("services.cleanup_executors._trash_path", return_value=False),
         ):
             deleted = _cleanup_series_sidecars(episode_files, {"de"}, "any")
 
-        assert deleted == 0  # unlink failed, so count stays 0
+        assert deleted == 0  # trash failed, so count stays 0
+
+    def test_three_letter_tags_match_two_letter_keep_list(self, tmp_path):
+        """F2 regression: sidecar tags from filenames are often 3-letter
+        ("eng", "ger") while the setting documents 2-letter codes ("de,en").
+        The old raw comparison hard-deleted every file the batch extract had
+        just produced — target language included."""
+        video = tmp_path / "ep.mkv"
+        video.write_text("fake video")
+        eng = tmp_path / "ep.eng.srt"
+        eng.write_text("content")
+        ger = tmp_path / "ep.ger.srt"
+        ger.write_text("content")
+        jpn = tmp_path / "ep.jpn.srt"
+        jpn.write_text("content")
+
+        sidecars = [
+            {"language": "eng", "format": "srt", "path": str(eng)},
+            {"language": "ger", "format": "srt", "path": str(ger)},
+            {"language": "jpn", "format": "srt", "path": str(jpn)},
+        ]
+        episode_files = {1: {"path": str(video)}}
+
+        with (
+            patch("routes.tracks.map_path", side_effect=lambda p: p),
+            patch("routes.subtitles.scan_subtitle_sidecars", return_value=sidecars),
+            patch("services.cleanup_executors._trash_path", return_value=True) as mock_trash,
+        ):
+            deleted = _cleanup_series_sidecars(episode_files, {"de", "en"}, "any")
+
+        assert deleted == 1
+        trashed_paths = [c.args[0] for c in mock_trash.call_args_list]
+        assert trashed_paths == [str(jpn)], "eng/ger must map onto the en/de keep list"
+
+    def test_combined_bilingual_files_are_never_trashed(self, tmp_path):
+        """Combined artefacts (ep.de-en.combined.ass) are produced on purpose
+        by combine_service — the keep-language cleanup must skip them."""
+        video = tmp_path / "ep.mkv"
+        video.write_text("fake video")
+        combined = tmp_path / "ep.de-en.combined.ass"
+        combined.write_text("content")
+
+        sidecars = [
+            {
+                "language": "de-en",
+                "format": "ass",
+                "path": str(combined),
+                "combined": True,
+            },
+        ]
+        episode_files = {1: {"path": str(video)}}
+
+        with (
+            patch("routes.tracks.map_path", side_effect=lambda p: p),
+            patch("routes.subtitles.scan_subtitle_sidecars", return_value=sidecars),
+            patch("services.cleanup_executors._trash_path", return_value=True) as mock_trash,
+        ):
+            deleted = _cleanup_series_sidecars(episode_files, {"de"}, "any")
+
+        assert deleted == 0
+        mock_trash.assert_not_called()
+
+    def test_unknown_language_tags_are_kept(self, tmp_path):
+        video = tmp_path / "ep.mkv"
+        video.write_text("fake video")
+        weird = tmp_path / "ep.zxx.srt"
+        weird.write_text("content")
+
+        sidecars = [
+            {"language": "zxx", "format": "srt", "path": str(weird)},
+        ]
+        episode_files = {1: {"path": str(video)}}
+
+        with (
+            patch("routes.tracks.map_path", side_effect=lambda p: p),
+            patch("routes.subtitles.scan_subtitle_sidecars", return_value=sidecars),
+            patch("services.cleanup_executors._trash_path", return_value=True) as mock_trash,
+        ):
+            deleted = _cleanup_series_sidecars(episode_files, {"de"}, "any")
+
+        assert deleted == 0
+        mock_trash.assert_not_called()
+
+    def test_empty_keep_list_is_a_noop(self, tmp_path):
+        video = tmp_path / "ep.mkv"
+        video.write_text("fake video")
+        fr = tmp_path / "ep.fr.srt"
+        fr.write_text("content")
+
+        episode_files = {1: {"path": str(video)}}
+
+        with (
+            patch("routes.tracks.map_path", side_effect=lambda p: p),
+            patch(
+                "routes.subtitles.scan_subtitle_sidecars",
+                return_value=[{"language": "fr", "format": "srt", "path": str(fr)}],
+            ),
+            patch("services.cleanup_executors._trash_path", return_value=True) as mock_trash,
+        ):
+            deleted = _cleanup_series_sidecars(episode_files, set(), "any")
+
+        assert deleted == 0
+        mock_trash.assert_not_called()
 
 
 # ===================================================================

--- a/backend/tests/test_routes_wanted_extract.py
+++ b/backend/tests/test_routes_wanted_extract.py
@@ -1099,7 +1099,9 @@ class TestRunBatchProbe:
             assert _batch_probe_state["failed"] == 1
 
     def test_existing_output_file_skips_extraction(self, app_client, tmp_path):
-        """When output file already exists, extraction is skipped but stream is scheduled for removal."""
+        """When the output file already exists, extraction is skipped AND the
+        stream stays in the container (issue #159: pre-existing sidecars used
+        to re-trigger a container remux on every run)."""
         app, _ = app_client
         from routes.wanted.batch_probe import _run_batch_probe
 
@@ -1140,8 +1142,9 @@ class TestRunBatchProbe:
 
         # Extraction should NOT have been called (file already exists)
         mock_ext.assert_not_called()
-        # But remux should still be called to remove the stream from the container
-        mock_remux.assert_called_once()
+        # And the container must NOT be rewritten — nothing was extracted in
+        # this pass, so there is nothing that may be removed.
+        mock_remux.assert_not_called()
 
     def test_emits_completion_event_with_duration(self, app_client):
         app, _ = app_client

--- a/backend/tests/test_wanted_search_duplicate_source_cleanup.py
+++ b/backend/tests/test_wanted_search_duplicate_source_cleanup.py
@@ -1,0 +1,170 @@
+"""Regression tests: the translate steps must never delete a pre-existing file.
+
+When ``manager.save_subtitle`` raises ``DuplicateSubtitleError``, the step
+rebinds ``actual_source_path`` to ``dup_err.existing_path`` — a file that was
+already on disk (usually the user's own sidecar). The "temp file cleanup"
+afterwards used to ``os.remove`` that path unconditionally: an automatic
+wanted-search or webhook run hard-deleted user files with no trash and no
+backup. Now only files created in the same run are cleaned up.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from error_handler import DuplicateSubtitleError
+
+
+def _ctx(tmp_path, settings):
+    item = {
+        "id": 1,
+        "title": "Ep",
+        "sonarr_series_id": None,
+    }
+    return {
+        "item": item,
+        "item_id": 1,
+        "item_lang": "de",
+        "settings": settings,
+        "manager": MagicMock(),
+        "_pf": {"must_contain": "", "must_not_contain": ""},
+        "file_path": str(tmp_path / "ep.mkv"),
+        # Pre-built so the step never calls build_query_from_wanted (which
+        # needs a full wanted-item row + *arr metadata).
+        "source_query": MagicMock(),
+    }
+
+
+def _settings():
+    s = MagicMock()
+    s.source_language = "en"
+    s.target_language_name = "German"
+    return s
+
+
+@pytest.fixture
+def preexisting_sidecar(tmp_path):
+    (tmp_path / "ep.mkv").write_bytes(b"fake")
+    sidecar = tmp_path / "ep.en.srt"
+    sidecar.write_text("1\n00:00:01,000 --> 00:00:02,000\nHello\n", encoding="utf-8")
+    return sidecar
+
+
+class TestDuplicateSourceNeverDeleted:
+    def test_srt_step_keeps_existing_sidecar_on_success(self, tmp_path, preexisting_sidecar):
+        from wanted_search.process import _try_source_srt_translation
+
+        ctx = _ctx(tmp_path, _settings())
+        manager = ctx["manager"]
+
+        result = MagicMock()
+        result.content = b"srt-bytes"
+        manager.search_and_download_best.return_value = result
+        manager.save_subtitle.side_effect = DuplicateSubtitleError(
+            "hash", str(preexisting_sidecar), str(tmp_path / "ep.en.srt")
+        )
+
+        with (
+            patch("wanted_search.process.create_job", return_value={"id": 7}),
+            patch("wanted_search.process.update_job"),
+            patch("wanted_search.process.record_stat"),
+            patch("wanted_search.process.record_subtitle_download"),
+            patch("wanted_search.process._build_arr_context", return_value={}),
+            patch(
+                "translator.translate_srt_from_file",
+                return_value={"success": True, "output_path": str(tmp_path / "ep.de.srt")},
+            ),
+            patch("wanted_search.process.delete_wanted_item", create=True),
+            patch("wanted_search.process._finish_found", create=True) as _,
+        ):
+            try:
+                _try_source_srt_translation(ctx)
+            except Exception:
+                # Post-translate bookkeeping may fail in this stripped-down
+                # harness — the invariant under test is filesystem-only.
+                pass
+
+        manager.save_subtitle.assert_called_once()
+        assert preexisting_sidecar.exists(), (
+            "a pre-existing sidecar surfaced via DuplicateSubtitleError must never be deleted"
+        )
+
+    def test_srt_step_keeps_existing_sidecar_on_translate_failure(
+        self, tmp_path, preexisting_sidecar
+    ):
+        from wanted_search.process import _try_source_srt_translation
+
+        ctx = _ctx(tmp_path, _settings())
+        manager = ctx["manager"]
+
+        result = MagicMock()
+        result.content = b"srt-bytes"
+        manager.search_and_download_best.return_value = result
+        manager.save_subtitle.side_effect = DuplicateSubtitleError(
+            "hash", str(preexisting_sidecar), str(tmp_path / "ep.en.srt")
+        )
+
+        with (
+            patch("wanted_search.process.create_job", return_value={"id": 7}),
+            patch("wanted_search.process.update_job"),
+            patch("wanted_search.process.record_stat"),
+            patch("wanted_search.process.record_subtitle_download"),
+            patch("wanted_search.process._build_arr_context", return_value={}),
+            patch(
+                "translator.translate_srt_from_file",
+                side_effect=RuntimeError("translation blew up"),
+            ),
+        ):
+            # The step swallows the translation error in its outer catch and
+            # moves on — only the filesystem invariant matters here.
+            _try_source_srt_translation(ctx)
+
+        manager.save_subtitle.assert_called_once()
+        assert preexisting_sidecar.exists(), (
+            "the error-path cleanup must not delete a pre-existing sidecar either"
+        )
+
+    def test_srt_step_still_cleans_up_own_temp_file(self, tmp_path):
+        """A source file the step downloaded itself IS removed afterwards —
+        the fix must not leave temp artefacts behind."""
+        from wanted_search.process import _try_source_srt_translation
+
+        (tmp_path / "ep.mkv").write_bytes(b"fake")
+        ctx = _ctx(tmp_path, _settings())
+        manager = ctx["manager"]
+
+        downloaded = tmp_path / "ep.en.srt"
+
+        def _save(result, path, series_id=None):
+            downloaded.write_text("1\n00:00:01,000 --> 00:00:02,000\nHi\n", encoding="utf-8")
+            return str(downloaded)
+
+        result = MagicMock()
+        result.content = b"srt-bytes"
+        result.provider_name = "prov"
+        result.subtitle_id = "sid"
+        result.score = 1.0
+        result.format.value = "srt"
+        manager.search_and_download_best.return_value = result
+        manager.save_subtitle.side_effect = _save
+
+        with (
+            patch("wanted_search.process.create_job", return_value={"id": 7}),
+            patch("wanted_search.process.update_job"),
+            patch("wanted_search.process.record_stat"),
+            patch("wanted_search.process.record_subtitle_download"),
+            patch("wanted_search.process._build_arr_context", return_value={}),
+            patch(
+                "translator.translate_srt_from_file",
+                return_value={"success": True, "output_path": str(tmp_path / "ep.de.srt")},
+            ),
+        ):
+            try:
+                _try_source_srt_translation(ctx)
+            except Exception:
+                pass
+
+        manager.save_subtitle.assert_called_once()
+        assert not downloaded.exists(), "self-created temp source must still be cleaned up"

--- a/backend/tests/test_wanted_search_embedded_gating.py
+++ b/backend/tests/test_wanted_search_embedded_gating.py
@@ -1,0 +1,233 @@
+"""Gating tests for the wanted-search embedded-extraction path (issue #159).
+
+Regression coverage: the scheduled wanted search used to route every item
+with ``existing_sub in ("embedded_ass", "embedded_srt")`` into
+``_extract_embedded_items`` unconditionally — extraction (and the container
+remux that followed) ran even with ``subtitle_automation_enabled`` and
+``wanted_auto_extract`` both off. 21 user files were remuxed on a default
+install before the report.
+
+The fix mirrors the scan-time routing (``_maybe_auto_extract``):
+  automation on   → enqueue to subtitle_automation_queue (drain worker owns it)
+  legacy toggle   → inline extract (previous behaviour, now opt-in)
+  both off        → the item stays in the normal provider search; no file I/O
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _item(item_id: int, *, existing_sub: str = "embedded_ass"):
+    return {
+        "id": item_id,
+        "title": f"item-{item_id}",
+        "file_path": f"/media/item-{item_id}.mkv",
+        "target_language": "de",
+        "existing_sub": existing_sub,
+        "priority": "standard",
+        "upgrade_candidate": False,
+        "last_search_at": None,
+        "retry_after": None,
+        "search_count": 0,
+    }
+
+
+def _configure_settings(monkeypatch, *, automation: bool, auto_extract: bool):
+    from config import get_settings
+
+    s = get_settings()
+    monkeypatch.setattr(s, "wanted_search_order", "fair", raising=False)
+    monkeypatch.setattr(s, "wanted_search_max_items_per_run", 50, raising=False)
+    monkeypatch.setattr(s, "wanted_max_search_attempts", 3, raising=False)
+    monkeypatch.setattr(s, "wanted_adaptive_backoff_enabled", True, raising=False)
+    monkeypatch.setattr(s, "wanted_auto_translate", False, raising=False)
+    monkeypatch.setattr(s, "subtitle_automation_enabled", automation, raising=False)
+    monkeypatch.setattr(s, "wanted_auto_extract", auto_extract, raising=False)
+    return s
+
+
+def _run(app_ctx, embedded_item, provider_calls):
+    def _fake_process(item_id: int) -> dict:
+        provider_calls.append(item_id)
+        return {"status": "not_found", "wanted_id": item_id}
+
+    with (
+        patch("db.wanted.get_items_for_scheduled_search", return_value=[embedded_item]),
+        patch("wanted_search.process_wanted_item", side_effect=_fake_process),
+    ):
+        from services.wanted_search_runner import run_wanted_search
+
+        return run_wanted_search(app=app_ctx, include_upgrades=True)
+
+
+class TestWantedSearchEmbeddedGating:
+    def test_both_toggles_off_embedded_items_are_searched_not_extracted(
+        self, app_ctx, monkeypatch
+    ):
+        """THE #159 regression test: with automation and the legacy toggle
+        both off, an embedded-sub item must go through the normal provider
+        search — extract_embedded_sub must never run."""
+        _configure_settings(monkeypatch, automation=False, auto_extract=False)
+        provider_calls: list[int] = []
+
+        with patch(
+            "services.wanted_search_filters.extract_embedded_sub"
+        ) as mock_extract:
+            summary = _run(app_ctx, _item(1), provider_calls)
+
+        mock_extract.assert_not_called()
+        assert provider_calls == [1], "embedded item must reach the provider search"
+        assert summary["total"] == 1
+        assert summary["processed"] == 1
+
+    def test_automation_on_embedded_items_enqueued_not_extracted_not_searched(
+        self, app_ctx, monkeypatch
+    ):
+        _configure_settings(monkeypatch, automation=True, auto_extract=False)
+        provider_calls: list[int] = []
+
+        enqueue_calls: list[dict] = []
+
+        class _FakeRepo:
+            def enqueue(self, **kwargs):
+                enqueue_calls.append(kwargs)
+
+        with (
+            patch("services.wanted_search_filters.extract_embedded_sub") as mock_extract,
+            patch(
+                "db.repositories.subtitle_automation_queue.SubtitleAutomationQueueRepository",
+                return_value=_FakeRepo(),
+            ),
+        ):
+            summary = _run(app_ctx, _item(1), provider_calls)
+
+        mock_extract.assert_not_called()
+        assert provider_calls == [], "enqueued item must not be provider-searched this tick"
+        assert len(enqueue_calls) == 1
+        assert enqueue_calls[0]["wanted_item_id"] == 1
+        assert enqueue_calls[0]["target_language"] == "de"
+        assert summary["processed"] == 1
+        assert summary["skipped"] == 1
+
+    def test_legacy_auto_extract_on_extracts_inline(self, app_ctx, monkeypatch):
+        _configure_settings(monkeypatch, automation=False, auto_extract=True)
+        provider_calls: list[int] = []
+
+        with patch(
+            "services.wanted_search_filters.extract_embedded_sub",
+            return_value={"status": "extracted"},
+        ) as mock_extract:
+            summary = _run(app_ctx, _item(1), provider_calls)
+
+        mock_extract.assert_called_once()
+        assert mock_extract.call_args.args[0] == 1
+        assert provider_calls == []
+        assert summary["found"] == 1
+
+    def test_enqueue_failure_falls_back_to_search_when_legacy_off(
+        self, app_ctx, monkeypatch
+    ):
+        """Automation on but the queue insert raises: the item must not be
+        dropped silently — with the legacy toggle off it falls back to the
+        provider search (and is still never extracted inline)."""
+        _configure_settings(monkeypatch, automation=True, auto_extract=False)
+        provider_calls: list[int] = []
+
+        class _BrokenRepo:
+            def enqueue(self, **kwargs):
+                raise RuntimeError("db locked")
+
+        with (
+            patch("services.wanted_search_filters.extract_embedded_sub") as mock_extract,
+            patch(
+                "db.repositories.subtitle_automation_queue.SubtitleAutomationQueueRepository",
+                return_value=_BrokenRepo(),
+            ),
+        ):
+            summary = _run(app_ctx, _item(1), provider_calls)
+
+        mock_extract.assert_not_called()
+        assert provider_calls == [1]
+        assert summary["processed"] == 1
+
+    def test_non_embedded_items_unaffected_by_toggles(self, app_ctx, monkeypatch):
+        _configure_settings(monkeypatch, automation=False, auto_extract=False)
+        provider_calls: list[int] = []
+
+        summary = _run(app_ctx, _item(1, existing_sub=""), provider_calls)
+
+        assert provider_calls == [1]
+        assert summary["processed"] == 1
+
+
+class TestEnqueueEmbeddedItems:
+    def test_enqueues_with_item_target_language(self):
+        from services.wanted_search_filters import _enqueue_embedded_items
+
+        calls: list[dict] = []
+
+        class _FakeRepo:
+            def enqueue(self, **kwargs):
+                calls.append(kwargs)
+
+        settings = MagicMock()
+        settings.target_language = "en"
+
+        with patch(
+            "db.repositories.subtitle_automation_queue.SubtitleAutomationQueueRepository",
+            return_value=_FakeRepo(),
+        ):
+            leftover, enqueued = _enqueue_embedded_items([_item(1)], settings)
+
+        assert leftover == []
+        assert enqueued == 1
+        assert calls[0]["target_language"] == "de"
+
+    def test_falls_back_to_settings_target_language(self):
+        from services.wanted_search_filters import _enqueue_embedded_items
+
+        calls: list[dict] = []
+
+        class _FakeRepo:
+            def enqueue(self, **kwargs):
+                calls.append(kwargs)
+
+        item = _item(1)
+        item["target_language"] = None
+        settings = MagicMock()
+        settings.target_language = "en"
+
+        with patch(
+            "db.repositories.subtitle_automation_queue.SubtitleAutomationQueueRepository",
+            return_value=_FakeRepo(),
+        ):
+            leftover, enqueued = _enqueue_embedded_items([item], settings)
+
+        assert enqueued == 1
+        assert calls[0]["target_language"] == "en"
+
+    def test_no_language_and_errors_become_leftover(self):
+        from services.wanted_search_filters import _enqueue_embedded_items
+
+        class _BrokenRepo:
+            def enqueue(self, **kwargs):
+                raise RuntimeError("boom")
+
+        no_lang = _item(1)
+        no_lang["target_language"] = None
+        erroring = _item(2)
+
+        settings = MagicMock()
+        settings.target_language = ""
+
+        with patch(
+            "db.repositories.subtitle_automation_queue.SubtitleAutomationQueueRepository",
+            return_value=_BrokenRepo(),
+        ):
+            leftover, enqueued = _enqueue_embedded_items([no_lang, erroring], settings)
+
+        assert enqueued == 0
+        assert [i["id"] for i in leftover] == [1, 2]

--- a/backend/tests/test_wanted_search_embedded_gating.py
+++ b/backend/tests/test_wanted_search_embedded_gating.py
@@ -64,18 +64,14 @@ def _run(app_ctx, embedded_item, provider_calls):
 
 
 class TestWantedSearchEmbeddedGating:
-    def test_both_toggles_off_embedded_items_are_searched_not_extracted(
-        self, app_ctx, monkeypatch
-    ):
+    def test_both_toggles_off_embedded_items_are_searched_not_extracted(self, app_ctx, monkeypatch):
         """THE #159 regression test: with automation and the legacy toggle
         both off, an embedded-sub item must go through the normal provider
         search — extract_embedded_sub must never run."""
         _configure_settings(monkeypatch, automation=False, auto_extract=False)
         provider_calls: list[int] = []
 
-        with patch(
-            "services.wanted_search_filters.extract_embedded_sub"
-        ) as mock_extract:
+        with patch("services.wanted_search_filters.extract_embedded_sub") as mock_extract:
             summary = _run(app_ctx, _item(1), provider_calls)
 
         mock_extract.assert_not_called()
@@ -127,9 +123,7 @@ class TestWantedSearchEmbeddedGating:
         assert provider_calls == []
         assert summary["found"] == 1
 
-    def test_enqueue_failure_falls_back_to_search_when_legacy_off(
-        self, app_ctx, monkeypatch
-    ):
+    def test_enqueue_failure_falls_back_to_search_when_legacy_off(self, app_ctx, monkeypatch):
         """Automation on but the queue insert raises: the item must not be
         dropped silently — with the legacy toggle off it falls back to the
         provider search (and is still never extracted inline)."""

--- a/backend/tests/test_wp5_safety_fixes.py
+++ b/backend/tests/test_wp5_safety_fixes.py
@@ -72,9 +72,7 @@ class TestSubtitleHealthSweepGate:
                     subtitle_health_auto_fix=False,
                 ),
             ),
-            patch(
-                "services.subtitle_health.sweep.get_sonarr_client", return_value=client
-            ),
+            patch("services.subtitle_health.sweep.get_sonarr_client", return_value=client),
         ):
             sweep_mod.subtitle_health_sweep_tick()
 
@@ -124,9 +122,7 @@ class TestSignsPurgeScope:
 
         trashed = [c.args[0] for c in trash.call_args_list]
         assert str(extracted_signs) in trashed
-        assert str(preexisting_forced) not in trashed, (
-            "pre-existing sidecars are not purge fodder"
-        )
+        assert str(preexisting_forced) not in trashed, "pre-existing sidecars are not purge fodder"
 
 
 class TestAutoModsSkipVariants:
@@ -140,6 +136,4 @@ class TestAutoModsSkipVariants:
     def test_combined_file_is_exempt(self, tmp_path):
         from routes.subtitle_processor import _is_processing_exempt_sidecar
 
-        assert (
-            _is_processing_exempt_sidecar(str(tmp_path / "Ep.de-en.combined.ass")) is True
-        )
+        assert _is_processing_exempt_sidecar(str(tmp_path / "Ep.de-en.combined.ass")) is True

--- a/backend/tests/test_wp5_safety_fixes.py
+++ b/backend/tests/test_wp5_safety_fixes.py
@@ -1,0 +1,145 @@
+"""Tests for the smaller safety fixes from the #159 audit.
+
+- Subtitle-health sweep honours its (previously dead) enable settings.
+- GET /library/trash no longer purges expired batches as a side effect.
+- purge_signs_after_extract only touches sidecars produced by this pass.
+- Auto-mods skip modifier variants (.hi/.forced/...) and combined files.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _settings(**overrides):
+    s = MagicMock()
+    for k, v in overrides.items():
+        setattr(s, k, v)
+    return s
+
+
+class TestSubtitleHealthSweepGate:
+    def test_sweep_disabled_is_a_noop(self):
+        from services.subtitle_health import sweep as sweep_mod
+
+        with (
+            patch(
+                "config.get_settings",
+                return_value=_settings(
+                    subtitle_health_enabled=True,
+                    subtitle_health_sweep_enabled=False,
+                    subtitle_health_auto_fix=True,
+                ),
+            ),
+            patch("services.subtitle_health.sweep.get_sonarr_client") as mock_client,
+        ):
+            sweep_mod.subtitle_health_sweep_tick()
+
+        mock_client.assert_not_called()
+
+    def test_feature_disabled_is_a_noop(self):
+        from services.subtitle_health import sweep as sweep_mod
+
+        with (
+            patch(
+                "config.get_settings",
+                return_value=_settings(
+                    subtitle_health_enabled=False,
+                    subtitle_health_sweep_enabled=True,
+                    subtitle_health_auto_fix=True,
+                ),
+            ),
+            patch("services.subtitle_health.sweep.get_sonarr_client") as mock_client,
+        ):
+            sweep_mod.subtitle_health_sweep_tick()
+
+        mock_client.assert_not_called()
+
+    def test_enabled_sweep_proceeds(self):
+        from services.subtitle_health import sweep as sweep_mod
+
+        client = MagicMock()
+        client.get_series.return_value = []
+
+        with (
+            patch(
+                "config.get_settings",
+                return_value=_settings(
+                    subtitle_health_enabled=True,
+                    subtitle_health_sweep_enabled=True,
+                    subtitle_health_auto_fix=False,
+                ),
+            ),
+            patch(
+                "services.subtitle_health.sweep.get_sonarr_client", return_value=client
+            ),
+        ):
+            sweep_mod.subtitle_health_sweep_tick()
+
+        client.get_series.assert_called_once()
+
+
+class TestTrashListNoPurge:
+    def test_get_trash_does_not_auto_purge(self, client):
+        """Opening the Trash page must never rmtree expired batches."""
+        with patch("routes.subtitles.trash._auto_purge_old_trash") as mock_purge:
+            resp = client.get("/api/v1/library/trash")
+
+        assert resp.status_code == 200
+        mock_purge.assert_not_called()
+
+
+class TestSignsPurgeScope:
+    def test_preexisting_forced_sidecar_survives_scoped_purge(self, tmp_path):
+        """Only the sidecars extracted in THIS pass are purge candidates —
+        a user's pre-existing forced sub must survive an unrelated extract."""
+        from services import embedded_extractor
+
+        video = tmp_path / "Ep.mkv"
+        video.write_bytes(b"fake")
+        # Pre-existing, user-supplied forced variant + full peer.
+        preexisting_forced = tmp_path / "Ep.de.forced.srt"
+        preexisting_forced.write_text("forced", encoding="utf-8")
+        full_de = tmp_path / "Ep.de.srt"
+        full_de.write_text("dialogue", encoding="utf-8")
+        # This pass extracted an English signs track + full peer.
+        extracted_signs = tmp_path / "Ep.en.signs.ass"
+        extracted_signs.write_text("signs", encoding="utf-8")
+        full_en = tmp_path / "Ep.en.ass"
+        full_en.write_text("dialogue", encoding="utf-8")
+
+        s = MagicMock()
+        s.cleanup_signs_removal_level = "signs"
+
+        with (
+            patch("config.get_settings", return_value=s),
+            patch("services.embedded_extractor._trash_path", return_value=True) as trash,
+        ):
+            embedded_extractor.purge_signs_after_extract(
+                str(video),
+                extracted_paths=[str(extracted_signs), str(full_en)],
+            )
+
+        trashed = [c.args[0] for c in trash.call_args_list]
+        assert str(extracted_signs) in trashed
+        assert str(preexisting_forced) not in trashed, (
+            "pre-existing sidecars are not purge fodder"
+        )
+
+
+class TestAutoModsSkipVariants:
+    def test_hi_variant_is_exempt(self, tmp_path):
+        from routes.subtitle_processor import _is_processing_exempt_sidecar
+
+        assert _is_processing_exempt_sidecar(str(tmp_path / "Ep.en.hi.srt")) is True
+        assert _is_processing_exempt_sidecar(str(tmp_path / "Ep.en.forced.srt")) is True
+        assert _is_processing_exempt_sidecar(str(tmp_path / "Ep.en.srt")) is False
+
+    def test_combined_file_is_exempt(self, tmp_path):
+        from routes.subtitle_processor import _is_processing_exempt_sidecar
+
+        assert (
+            _is_processing_exempt_sidecar(str(tmp_path / "Ep.de-en.combined.ass")) is True
+        )

--- a/backend/tools/lint_no_new_env_fields.py
+++ b/backend/tools/lint_no_new_env_fields.py
@@ -156,7 +156,7 @@ def main(argv: list[str]) -> int:
     for msg in violations:
         print(f"  - {msg}")
     print()
-    print("UI-first convention (since v0.88.0-beta): only the 11 fields in")
+    print("UI-first convention (since v0.88.0-beta): only the 12 fields in")
     print("_ALLOWED_BOOT_FIELDS are env-loadable. Everything else is UI-only.")
     return 1
 

--- a/backend/wanted_search/post_processor.py
+++ b/backend/wanted_search/post_processor.py
@@ -293,6 +293,7 @@ def download_specific_for_item(
             actual_source_path = manager.save_subtitle(
                 target_result, tmp_source_path, series_id=item.get("sonarr_series_id")
             )
+            source_created_this_run = True
             record_subtitle_download(
                 provider_name,
                 subtitle_id,
@@ -302,7 +303,10 @@ def download_specific_for_item(
                 target_result.score,
             )
         except DuplicateSubtitleError as dup_err:
+            # existing_path is a PRE-EXISTING file on disk (often the user's
+            # own sidecar) — it must never be deleted as "temp cleanup".
             actual_source_path = dup_err.existing_path
+            source_created_this_run = False
         except (OSError, RuntimeError) as e:
             return {"success": False, "error": f"Failed to save subtitle: {e}"}
 
@@ -346,14 +350,16 @@ def download_specific_for_item(
             update_job(job["id"], "failed", error=error_msg)
             record_stat(success=False)
             try:
-                if os.path.exists(actual_source_path):
+                if source_created_this_run and os.path.exists(actual_source_path):
                     os.remove(actual_source_path)
             except OSError as cleanup_err:
                 logger.debug("Temp file cleanup failed: %s", cleanup_err)
             return {"success": False, "error": f"Translation failed: {error_msg}"}
 
+        # Only delete the source file if this run created it — the duplicate
+        # branch above rebinds actual_source_path to a pre-existing user file.
         try:
-            if os.path.exists(actual_source_path):
+            if source_created_this_run and os.path.exists(actual_source_path):
                 os.remove(actual_source_path)
         except OSError as e:
             logger.debug("Temp file cleanup failed: %s", e)

--- a/backend/wanted_search/process.py
+++ b/backend/wanted_search/process.py
@@ -377,6 +377,7 @@ def _try_source_ass_translation(ctx: dict) -> dict | None:
             actual_source_path = manager.save_subtitle(
                 result, tmp_source_path, series_id=item.get("sonarr_series_id")
             )
+            source_created_this_run = True
             record_subtitle_download(
                 result.provider_name,
                 result.subtitle_id,
@@ -391,7 +392,10 @@ def _try_source_ass_translation(ctx: dict) -> dict | None:
                 item_id,
                 dup_err.existing_path,
             )
+            # existing_path is a PRE-EXISTING file on disk (often the user's
+            # own sidecar) — it must never be deleted as "temp cleanup".
             actual_source_path = dup_err.existing_path
+            source_created_this_run = False
         except (OSError, RuntimeError) as save_error:
             logger.error(
                 "Wanted %d: Failed to save source ASS from %s: %s",
@@ -423,15 +427,17 @@ def _try_source_ass_translation(ctx: dict) -> dict | None:
             update_job(job["id"], "failed", error=str(trans_error))
             record_stat(success=False)
             try:
-                if os.path.exists(actual_source_path):
+                if source_created_this_run and os.path.exists(actual_source_path):
                     os.remove(actual_source_path)
             except OSError as e:
                 logger.debug("Temp file cleanup failed: %s", e)
             raise  # skip to next step
 
-        # Clean up temporary source file
+        # Clean up the temporary source file — but only if this run created
+        # it. The DuplicateSubtitleError branch rebinds actual_source_path to
+        # a pre-existing user file which must survive.
         try:
-            if os.path.exists(actual_source_path):
+            if source_created_this_run and os.path.exists(actual_source_path):
                 os.remove(actual_source_path)
         except OSError as e:
             logger.debug("Temp file cleanup failed: %s", e)
@@ -627,6 +633,7 @@ def _try_source_srt_translation(ctx: dict) -> dict | None:
             actual_source_path = manager.save_subtitle(
                 result, tmp_source_path, series_id=item.get("sonarr_series_id")
             )
+            source_created_this_run = True
             record_subtitle_download(
                 result.provider_name,
                 result.subtitle_id,
@@ -641,7 +648,10 @@ def _try_source_srt_translation(ctx: dict) -> dict | None:
                 item_id,
                 dup_err.existing_path,
             )
+            # existing_path is a PRE-EXISTING file on disk (often the user's
+            # own sidecar) — it must never be deleted as "temp cleanup".
             actual_source_path = dup_err.existing_path
+            source_created_this_run = False
         except (OSError, RuntimeError) as save_error:
             logger.error(
                 "Wanted %d: Failed to save source SRT from %s: %s",
@@ -673,15 +683,17 @@ def _try_source_srt_translation(ctx: dict) -> dict | None:
             update_job(job["id"], "failed", error=str(trans_error))
             record_stat(success=False)
             try:
-                if os.path.exists(actual_source_path):
+                if source_created_this_run and os.path.exists(actual_source_path):
                     os.remove(actual_source_path)
             except OSError as e:
                 logger.debug("Temp file cleanup failed: %s", e)
             raise  # skip to next step
 
-        # Clean up temporary source file
+        # Clean up the temporary source file — but only if this run created
+        # it. The DuplicateSubtitleError branch rebinds actual_source_path to
+        # a pre-existing user file which must survive.
         try:
-            if os.path.exists(actual_source_path):
+            if source_created_this_run and os.path.exists(actual_source_path):
                 os.remove(actual_source_path)
         except OSError as e:
             logger.debug("Temp file cleanup failed: %s", e)

--- a/frontend/src/i18n/locales/de/settings.json
+++ b/frontend/src/i18n/locales/de/settings.json
@@ -1194,7 +1194,12 @@
     "cleanup_confirm": "Jetzt löschen",
     "cleanup_cancel": "Abbrechen",
     "cleanup_done": "{{count}} Backup(s) gelöscht.",
-    "cleanup_failed": "Aufräumen fehlgeschlagen."
+    "cleanup_failed": "Aufräumen fehlgeschlagen.",
+    "hardlink_policy": "Hardlink-Policy",
+    "hardlink_policy_desc": "Ein Remux schreibt die Datei neu und bricht Hardlinks (das empfohlene *arr-Setup): Speicherverbrauch verdoppelt sich und die Seeding-Kopie weicht ab. \"Skip\" remuxt hardlinked Dateien nie; \"Warn\" remuxt, loggt aber eine Warnung; \"Allow\" ist das alte Verhalten.",
+    "hardlink_skip": "Skip (hardlinked Dateien nie remuxen)",
+    "hardlink_warn": "Warn (remuxen, aber Warnung loggen)",
+    "hardlink_allow": "Allow (immer remuxen)"
   },
   "standalone_tab": {
     "scan_interval": "Scan-Intervall (Stunden)",
@@ -1908,6 +1913,8 @@
     "cleanup": {
       "title": "Fremdspur-Cleanup",
       "description": "Nach erfolgreicher Extraktion die nicht benötigten Untertitel-Sprachspuren aus dem Container entfernen. Backups landen im Trash — nichts wird endgültig gelöscht.",
+      "remove_extracted": "Extrahierte Spuren aus dem Container entfernen",
+      "remove_extracted_help": "Nach der Extraktion in ein Sidecar die Spur per Remux aus der Videodatei entfernen (Backup landet im Trash). Standardmäßig aus — Keep-Sprachen werden nie entfernt, und hardlinked Dateien folgen der Remux-Hardlink-Policy.",
       "default": "Standardmäßig entfernen",
       "default_help": "Globaler Standard; Serien-spezifische Overrides gibt es im Serien-Einstellungspanel.",
       "keep_und": "Undetermined (und) behalten",

--- a/frontend/src/i18n/locales/en/settings.json
+++ b/frontend/src/i18n/locales/en/settings.json
@@ -1194,7 +1194,12 @@
     "cleanup_confirm": "Delete now",
     "cleanup_cancel": "Cancel",
     "cleanup_done": "Deleted {{count}} backup(s).",
-    "cleanup_failed": "Cleanup failed."
+    "cleanup_failed": "Cleanup failed.",
+    "hardlink_policy": "Hardlink policy",
+    "hardlink_policy_desc": "Remuxing rewrites the file and breaks hardlinks (the recommended *arr setup): disk usage doubles and the seeding copy diverges. \"Skip\" never remuxes hardlinked files; \"Warn\" remuxes but logs it; \"Allow\" is the old behaviour.",
+    "hardlink_skip": "Skip (never remux hardlinked files)",
+    "hardlink_warn": "Warn (remux, but log a warning)",
+    "hardlink_allow": "Allow (always remux)"
   },
   "standalone_tab": {
     "scan_interval": "Scan Interval (hours)",
@@ -1908,6 +1913,8 @@
     "cleanup": {
       "title": "Foreign-Track Cleanup",
       "description": "After extraction succeeds, remove non-target-language subtitle tracks from the container. Backups go to the trash folder — nothing is permanently deleted.",
+      "remove_extracted": "Remove extracted streams from container",
+      "remove_extracted_help": "After extracting a stream to a sidecar, remux it out of the video file (backup goes to the trash folder). Off by default — keep-language streams are never removed, and hardlinked files follow the remux hardlink policy.",
       "default": "Strip by default",
       "default_help": "Global default; per-series overrides live on the series settings panel.",
       "keep_und": "Keep undetermined (und)",

--- a/frontend/src/pages/Settings/RemuxTab.tsx
+++ b/frontend/src/pages/Settings/RemuxTab.tsx
@@ -140,6 +140,30 @@ export function RemuxTab() {
       </SettingRow>
 
       <SettingRow
+        label={t('remux_tab.hardlink_policy', 'Hardlink policy')}
+        description={t(
+          'remux_tab.hardlink_policy_desc',
+          'Remuxing rewrites the file and breaks hardlinks (the recommended *arr setup): disk usage doubles and the seeding copy diverges. "Skip" never remuxes hardlinked files; "Warn" remuxes but logs it; "Allow" is the old behaviour.'
+        )}
+      >
+        <select
+          value={String((config as Record<string, unknown> | undefined)?.['remux_hardlink_policy'] ?? 'skip')}
+          onChange={(e) => saveField('remux_hardlink_policy', e.target.value)}
+          className="px-3 py-2 rounded-md text-sm"
+          style={{
+            backgroundColor: 'var(--bg-primary)',
+            border: '1px solid var(--border)',
+            color: 'var(--text-primary)',
+            fontSize: '13px',
+          }}
+        >
+          <option value="skip">{t('remux_tab.hardlink_skip', 'Skip (never remux hardlinked files)')}</option>
+          <option value="warn">{t('remux_tab.hardlink_warn', 'Warn (remux, but log a warning)')}</option>
+          <option value="allow">{t('remux_tab.hardlink_allow', 'Allow (always remux)')}</option>
+        </select>
+      </SettingRow>
+
+      <SettingRow
         label={t('remux_tab.cleanup')}
         description={t('remux_tab.cleanup_desc')}
       >

--- a/frontend/src/pages/Settings/SubtitleAutomationPage.tsx
+++ b/frontend/src/pages/Settings/SubtitleAutomationPage.tsx
@@ -31,6 +31,7 @@ type AutomationKeys =
   | 'subtitle_automation_drain_interval_minutes'
   | 'embedded_allow_sdh'
   | 'embedded_sdh_penalty'
+  | 'embedded_extract_remove_from_container'
   | 'cleanup_foreign_tracks_default'
   | 'cleanup_foreign_tracks_keep_und'
 
@@ -205,6 +206,21 @@ export function SubtitleAutomationPage() {
           'After extraction succeeds, remove non-target-language subtitle tracks from the container. Backups go to the trash folder — nothing is permanently deleted.'
         )}
       >
+        <SettingRow
+          label={t(
+            'subtitle_automation_page.cleanup.remove_extracted',
+            'Remove extracted streams from container'
+          )}
+          description={t(
+            'subtitle_automation_page.cleanup.remove_extracted_help',
+            'After extracting a stream to a sidecar, remux it out of the video file (backup goes to the trash folder). Off by default — keep-language streams are never removed, and hardlinked files follow the remux hardlink policy.'
+          )}
+        >
+          <Toggle
+            checked={Boolean(cfg.embedded_extract_remove_from_container)}
+            onChange={(v) => set('embedded_extract_remove_from_container', v)}
+          />
+        </SettingRow>
         <SettingRow
           label={t('subtitle_automation_page.cleanup.default', 'Strip by default')}
           description={t(

--- a/frontend/src/pages/Settings/__tests__/SubtitleAutomationPage.test.tsx
+++ b/frontend/src/pages/Settings/__tests__/SubtitleAutomationPage.test.tsx
@@ -139,12 +139,13 @@ describe('SubtitleAutomationPage', () => {
     expect(screen.getByText('Allow SDH as source')).toBeInTheDocument()
     expect(screen.getByText('SDH score penalty')).toBeInTheDocument()
     // Cleanup section
+    expect(screen.getByText('Remove extracted streams from container')).toBeInTheDocument()
     expect(screen.getByText('Strip by default')).toBeInTheDocument()
     expect(screen.getByText('Keep undetermined (und)')).toBeInTheDocument()
 
-    // 5 toggles (master + queue + SDH + 2x cleanup) — interval + penalty are numbers
+    // 6 toggles (master + queue + SDH + 3x cleanup) — interval + penalty are numbers
     const toggles = screen.getAllByRole('switch')
-    expect(toggles).toHaveLength(5)
+    expect(toggles).toHaveLength(6)
   })
 
   it('shows queue counts, last_run_at and last_error', () => {

--- a/frontend/src/pages/Settings/settingsFields.ts
+++ b/frontend/src/pages/Settings/settingsFields.ts
@@ -142,6 +142,13 @@ export const FIELDS: FieldConfig[] = [
   { key: 'remux_arr_pause_enabled', label: 'Pause *arr during Remux', type: 'toggle', tab: 'Automation',
     description: 'Sonarr/Radarr-Ordner-Monitoring während des Remux pausieren.',
     advanced: true },
+  { key: 'remux_hardlink_policy', label: 'Hardlink Policy', type: 'select', tab: 'Automation',
+    options: [
+      { value: 'skip', label: 'Skip (hardlinked Dateien nie remuxen)' },
+      { value: 'warn', label: 'Warn (remuxen, aber Warnung loggen)' },
+      { value: 'allow', label: 'Allow (immer remuxen)' },
+    ],
+    description: 'Jeder Remux bricht Hardlinks (Standard bei *arr-Setups mit Torrent-Seeding): Speicherverbrauch verdoppelt sich und die Seeding-Kopie weicht ab. "Skip" (Standard) überspringt Container-Remuxe für Dateien mit mehreren Links.' },
   // Automation — Search Scheduler
   { key: 'wanted_search_interval_hours', label: 'Search Interval (hours, 0=disabled)', type: 'number', placeholder: '24', tab: 'Automation',
     description: 'Interval für automatische Provider-Suche. 0 = deaktiviert.',


### PR DESCRIPTION
Fixes #159
Closes #160

## Summary

Issue #159 reported that the scheduled wanted search extracted embedded subs and then remuxed the streams out of the MKV — including the target-language (eng) stream — with `subtitle_automation_enabled`, `wanted_auto_extract`, and every cleanup rule disabled. While fixing it, two deep audits of all automatic file-modification paths and all keep-language logic surfaced several more data-loss defects; everything found is fixed here.

## #159 — the reported bug

- **Gate the wanted-search extraction path** (`wanted_search_runner` / `wanted_search_filters`): it now mirrors the scan-time routing — automation on → enqueue to the subtitle-automation queue; legacy `wanted_auto_extract` on → inline extract; **both off → items go through the normal provider search and no file is ever touched**. This path previously ran unconditionally, and `wanted_search_on_startup=true` meant it fired on every container start.
- **Container stream removal is now opt-in** via the new `embedded_extract_remove_from_container` setting (default **off**). Even when enabled: streams whose language is in the keep set are never removed, unknown/`und` tags are kept, and an empty keep set removes nothing.
- **Repeat-remux fixed**: streams whose sidecar already exists are no longer removal candidates (each search cycle used to remux again).
- **Silent track loss fixed**: duplicate (lang, fmt) tracks (anime "Full" + "Signs", both tagged `eng`) collapse to one sidecar path; the second track was removed from the container *without ever being extracted*. It now stays in the container.

## #160 — hardlink-aware remux

New `remux_hardlink_policy` setting (`skip` | `warn` | `allow`, default **skip**), enforced centrally at every container-rewrite entry point in `remux/`. A skip propagates as a no-op, not an error. One `stat` per file. README documents the setting and the hardlink pitfall.

## Additional data-loss bugs found by the audit

- **Post-batch-extract auto-cleanup hard-deleted target-language sidecars** (`routes/tracks.py`): raw filename tags (`eng`, `ger`) were compared against the documented 2-letter keep list (`de,en`) with no normalisation, then `os.unlink`ed — unrecoverable, and it also deleted combined `de-en` files. Now: canonicalised comparison, combined/unknown-tag files skipped, recoverable trash instead of unlink.
- **Duplicate-translation cleanup deleted pre-existing user files** (`wanted_search/process.py`, `post_processor.py`): on `DuplicateSubtitleError` the "temp source" path was rebound to an existing file on disk and later `os.remove`d. Deletion now only happens for files created in the same run.
- **Language normalisation on every destructive path**: `_get_language_tags` canonicalises input (`ger` expands like `de`); table gaps closed (Bokmål/Nynorsk → `no`, `pob`/`pt-br` → `pt`, `zh-hans`/`zh-hant` keep base `zh` tags); the post-download foreign-track cleanup now uses the profile's full target set instead of only the language that downloaded first (a de+ja profile lost its embedded Japanese track); `_pick_primary` uses canonical equality instead of a 2-char prefix match (`de` now finds `ger`; `es` no longer matches Estonian); `remove_foreign_subtitle_streams` defensively compares canonical forms; an `und`-only keep set no longer bypasses the empty-set no-op guards; auto-combine works with 3-letter sidecar tags.
- **Smaller fixes**: `subtitle_health_enabled`/`subtitle_health_sweep_enabled` were never read (sweep now honours them); `GET /library/trash` purged expired batches as a side effect of opening the page (removed; retention fallbacks unified to 30 days); `purge_signs_after_extract` no longer trashes pre-existing sidecars (scoped to the current pass); auto HI-removal skips `.hi`/`.sdh`/`.cc`/`.forced` variants and combined files; container language tags are sanitised before path interpolation; signs-cleanup docs/seed no longer promise an unread `keep_languages` option.

## Intentional behavior changes

- User-initiated wanted extract routes (`/wanted/<id>/extract`, batch-extract, batch-probe) now strip container streams only when `embedded_extract_remove_from_container` is on (default off). The library "Batch extract tracks" route keeps its explicit strip behavior (its UI promises it).
- `remux_hardlink_policy` defaults to `skip` — users who intentionally remux hardlinked files must set `warn`/`allow` once.

## Tests

- ~60 new regression tests across 6 new/extended test files, including the direct #159 regression (both toggles off → provider search, no extraction), keep-language stream filtering with 3-letter tags, hardlink policy matrix, hard-delete regressions, and normalisation units.
- Full backend suite: **5792 passed, 2 skipped**; the only remaining failure (`test_scheduler_listeners`) also fails on unmodified `origin/master` (pre-existing, unrelated); the perf test passes standalone (load flake during the 1h11m full run).
- Frontend: build green, Settings component tests updated and green (new toggle + hardlink select, en/de i18n).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RDTbfzpnSahFSie1oCSaU