### PR TITLE
feat(ui): copy-file-path action on episodes and movie detail

### DIFF
--- a/frontend/src/components/episodes/EpisodeActionMenu.tsx
+++ b/frontend/src/components/episodes/EpisodeActionMenu.tsx
@@ -1,9 +1,11 @@
 import { useState, useRef, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
-  Search, MoreHorizontal, Columns2, Database, ScanSearch, Clock, Loader2, ChevronUp, Layers,
+  Search, MoreHorizontal, Columns2, Database, ScanSearch, Clock, Loader2, ChevronUp, Layers, Copy,
 } from 'lucide-react'
 import type { EpisodeInfo } from '@/lib/types'
+import { copyToClipboard } from '@/lib/clipboard'
+import { toast } from '@/components/shared/Toast'
 
 interface EpisodeActionMenuProps {
   ep: EpisodeInfo
@@ -157,6 +159,20 @@ export function EpisodeActionMenu({
                 label={t('episode_actions.history')}
                 onClick={() => { onHistory(); setDropdownOpen(false) }}
                 active={isExpanded && mode === 'history'}
+              />
+            )}
+
+            {/* Copy file path — for jumping to the file in external tools */}
+            {ep.has_file && ep.file_path && (
+              <DropdownItem
+                icon={<Copy size={13} />}
+                label={t('episode_actions.copy_path')}
+                onClick={() => {
+                  void copyToClipboard(ep.file_path).then((ok) => {
+                    toast(ok ? t('episode_actions.path_copied') : t('episode_actions.copy_failed'), ok ? 'success' : 'error')
+                  })
+                  setDropdownOpen(false)
+                }}
               />
             )}
           </div>

--- a/frontend/src/i18n/locales/de/library.json
+++ b/frontend/src/i18n/locales/de/library.json
@@ -152,7 +152,10 @@
     "search_subtitle": "Untertitel suchen",
     "interactive_search": "Interaktive Suche",
     "history": "Verlauf",
-    "back_to_library": "Zurück zur Bibliothek"
+    "back_to_library": "Zurück zur Bibliothek",
+    "copy_path": "Dateipfad kopieren",
+    "path_copied": "Dateipfad in Zwischenablage kopiert",
+    "copy_failed": "Kopieren in Zwischenablage fehlgeschlagen"
   },
   "sync_compare": {
     "title": "Sync vergleichen",

--- a/frontend/src/i18n/locales/en/library.json
+++ b/frontend/src/i18n/locales/en/library.json
@@ -152,7 +152,10 @@
     "search_subtitle": "Search Subtitle",
     "interactive_search": "Interactive Search",
     "history": "History",
-    "back_to_library": "Back to Library"
+    "back_to_library": "Back to Library",
+    "copy_path": "Copy File Path",
+    "path_copied": "File path copied to clipboard",
+    "copy_failed": "Could not copy to clipboard"
   },
   "sync_compare": {
     "title": "Compare sync",

--- a/frontend/src/lib/clipboard.ts
+++ b/frontend/src/lib/clipboard.ts
@@ -1,0 +1,31 @@
+/**
+ * Copy text to the clipboard.
+ *
+ * Uses the async Clipboard API where available (secure contexts) and falls
+ * back to a hidden textarea + execCommand for plain-HTTP LAN deployments,
+ * which is the common self-hosted setup.
+ */
+export async function copyToClipboard(text: string): Promise<boolean> {
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text)
+      return true
+    } catch {
+      // fall through to the legacy path
+    }
+  }
+  const textarea = document.createElement('textarea')
+  textarea.value = text
+  textarea.setAttribute('readonly', '')
+  textarea.style.position = 'fixed'
+  textarea.style.opacity = '0'
+  document.body.appendChild(textarea)
+  textarea.select()
+  try {
+    return document.execCommand('copy')
+  } catch {
+    return false
+  } finally {
+    document.body.removeChild(textarea)
+  }
+}

--- a/frontend/src/pages/MovieDetail.tsx
+++ b/frontend/src/pages/MovieDetail.tsx
@@ -3,7 +3,7 @@
  * Shows poster, metadata, and subtitle wanted items.
  */
 import { useParams, useNavigate } from 'react-router-dom'
-import { Loader2, FileVideo, ArrowLeft, Film, Search, SkipForward, RotateCcw } from 'lucide-react'
+import { Loader2, FileVideo, ArrowLeft, Film, Search, SkipForward, RotateCcw, Copy } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { useMovieDetail, useWantedItems, useSearchWantedItem, useUpdateWantedStatus, useLanguageProfiles, useAssignProfile } from '@/hooks/useApi'
 import { useMovieSubtitles } from '@/hooks/useLibraryApi'
@@ -11,6 +11,8 @@ import { Breadcrumb } from '@/components/shared/Breadcrumb'
 import { SubtitleActionsMenu } from '@/components/processing/SubtitleActionsMenu'
 import type { MovieDetail, WantedItem } from '@/lib/types'
 import type { SidecarSubtitle } from '@/types/library'
+import { copyToClipboard } from '@/lib/clipboard'
+import { toast } from '@/components/shared/Toast'
 
 // ─── MovieHero ────────────────────────────────────────────────────────────────
 
@@ -262,6 +264,20 @@ export function MovieDetailPage() {
             >
               {movie.file_path}
             </span>
+            <button
+              onClick={() => {
+                void copyToClipboard(movie.file_path).then((ok) => {
+                  toast(ok ? t('episode_actions.path_copied') : t('episode_actions.copy_failed'), ok ? 'success' : 'error')
+                })
+              }}
+              className="p-1 rounded transition-colors flex-shrink-0"
+              style={{ color: 'var(--text-muted)' }}
+              title={t('episode_actions.copy_path')}
+              onMouseEnter={(e) => { e.currentTarget.style.color = 'var(--accent)' }}
+              onMouseLeave={(e) => { e.currentTarget.style.color = 'var(--text-muted)' }}
+            >
+              <Copy size={13} />
+            </button>
           </div>
           {movie.tmdb_id && (
             <div className="flex items-center gap-2">


### PR DESCRIPTION
## What

Adds a small quality-of-life feature: copying the media file path to the clipboard directly from the UI.

- **Episode action menu** (`⋯` dropdown): new "Copy File Path" entry (shown when the episode has a file)
- **Movie detail page**: copy icon-button next to the displayed file path
- New shared helper `frontend/src/lib/clipboard.ts` — uses the async Clipboard API and falls back to the hidden-textarea/`execCommand` path so it also works on plain-HTTP LAN deployments (the typical self-hosted setup, where `navigator.clipboard` is unavailable)
- Success/failure feedback via the existing toast system
- EN + DE translations

## Why

When working with external tools (MKVToolNix, Aegisub, file manager, SSH), you constantly need the exact file path. Until now that meant selecting and copying the text manually from the detail page.

## Testing

- `tsc -b` clean
- `vitest` for the touched areas (29 tests) passing
- ESLint: no new errors (only the pre-existing inline-style warnings that are all over these files)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4Ddyni8nZwS5M9pEzMMdZ)_