### PR TITLE
feat(wanted): export wanted list as CSV or JSON download

### DIFF
--- a/backend/config_settings.py
+++ b/backend/config_settings.py
@@ -67,6 +67,9 @@ _ALLOWED_BOOT_FIELDS: frozenset[str] = frozenset(
         "log_format",
         "cors_origins",
         "redis_url",
+        # Anonymous-stats kill-switch/redirect — must be env-overridable
+        # pre-DB so self-hosters can disable sending before first boot.
+        "stats_endpoint",
     }
 )
 

--- a/backend/providers/plugins/template/README.md
+++ b/backend/providers/plugins/template/README.md
@@ -78,11 +78,11 @@ Each config field is a dict with these keys:
 
 ```python
 {
-    "key": "api_key",          # Internal key, passed as kwarg to __init__
-    "label": "API Key",        # Human-readable label in the Settings UI
-    "type": "password",        # "text", "password", or "number"
-    "required": True,          # If True, provider needs this to function
-    "default": "",             # Default value (optional)
+    "key": "api_key",  # Internal key, passed as kwarg to __init__
+    "label": "API Key",  # Human-readable label in the Settings UI
+    "type": "password",  # "text", "password", or "number"
+    "required": True,  # If True, provider needs this to function
+    "default": "",  # Default value (optional)
 }
 ```
 
@@ -93,8 +93,20 @@ Config values are stored in the database under `plugin.<name>.<key>` namespace. 
 ```python
 config_fields = [
     {"key": "api_key", "label": "API Key", "type": "password", "required": True},
-    {"key": "base_url", "label": "Base URL", "type": "text", "required": False, "default": "https://api.example.com"},
-    {"key": "results_per_page", "label": "Results Per Page", "type": "number", "required": False, "default": "50"},
+    {
+        "key": "base_url",
+        "label": "Base URL",
+        "type": "text",
+        "required": False,
+        "default": "https://api.example.com",
+    },
+    {
+        "key": "results_per_page",
+        "label": "Results Per Page",
+        "type": "number",
+        "required": False,
+        "default": "50",
+    },
 ]
 ```
 
@@ -201,9 +213,9 @@ result.matches = {"series", "season", "episode"}
 Set `rate_limit = (max_requests, window_seconds)` on your class. The `ProviderManager` enforces this limit across all search and download calls. Example:
 
 ```python
-rate_limit = (5, 1)    # 5 requests per second (OpenSubtitles-style)
-rate_limit = (100, 60) # 100 requests per minute
-rate_limit = (0, 0)    # No rate limiting
+rate_limit = (5, 1)  # 5 requests per second (OpenSubtitles-style)
+rate_limit = (100, 60)  # 100 requests per minute
+rate_limit = (0, 0)  # No rate limiting
 ```
 
 The `RetryingSession` from `create_session()` also handles HTTP 429 responses automatically (reads `Retry-After` header).
@@ -220,10 +232,10 @@ Sublarr provides three specialized exceptions in `providers.base`:
 
 ```python
 from providers.base import (
-    ProviderAuthError,       # 401/403 -- authentication failed
+    ProviderAuthError,  # 401/403 -- authentication failed
     ProviderRateLimitError,  # 429 -- rate limit exceeded
-    ProviderTimeoutError,    # Request timed out
-    ProviderError,           # Generic provider error (base class)
+    ProviderTimeoutError,  # Request timed out
+    ProviderError,  # Generic provider error (base class)
 )
 ```
 
@@ -252,10 +264,11 @@ Use `create_session()` from `providers.http_session` for HTTP calls:
 ```python
 from providers.http_session import create_session
 
+
 def initialize(self):
     self.session = create_session(
-        max_retries=self.max_retries,   # From class attribute
-        timeout=self.timeout,           # From class attribute
+        max_retries=self.max_retries,  # From class attribute
+        timeout=self.timeout,  # From class attribute
         user_agent="Sublarr-Plugin/1.0",
     )
     # Set authentication headers
@@ -276,17 +289,18 @@ The session provides:
 import zipfile
 import io
 
+
 def download(self, result):
     resp = self.session.get(result.download_url)
     resp.raise_for_status()
     content = resp.content
 
-    if content[:4] == b'PK\x03\x04':  # ZIP magic bytes
+    if content[:4] == b"PK\x03\x04":  # ZIP magic bytes
         with zipfile.ZipFile(io.BytesIO(content)) as zf:
             for name in zf.namelist():
-                if name.endswith(('.srt', '.ass', '.ssa')):
+                if name.endswith((".srt", ".ass", ".ssa")):
                     content = zf.read(name)
-                    if name.endswith(('.ass', '.ssa')):
+                    if name.endswith((".ass", ".ssa")):
                         result.format = SubtitleFormat.ASS
                     break
 
@@ -299,12 +313,13 @@ def download(self, result):
 ```python
 import lzma
 
+
 def download(self, result):
     resp = self.session.get(result.download_url)
     resp.raise_for_status()
     content = resp.content
 
-    if content[:6] == b'\xfd7zXZ\x00':  # XZ magic bytes
+    if content[:6] == b"\xfd7zXZ\x00":  # XZ magic bytes
         content = lzma.decompress(content)
 
     result.content = content
@@ -317,15 +332,16 @@ def download(self, result):
 import rarfile
 import io
 
+
 def download(self, result):
     resp = self.session.get(result.download_url)
     resp.raise_for_status()
     content = resp.content
 
-    if content[:4] == b'Rar!':  # RAR magic bytes
+    if content[:4] == b"Rar!":  # RAR magic bytes
         with rarfile.RarFile(io.BytesIO(content)) as rf:
             for name in rf.namelist():
-                if name.endswith(('.srt', '.ass', '.ssa')):
+                if name.endswith((".srt", ".ass", ".ssa")):
                     content = rf.read(name)
                     break
 
@@ -342,6 +358,7 @@ def search(self, query):
     elif query.is_movie:
         return self._search_movie(query)
     return []
+
 
 def _search_episode(self, query):
     params = {

--- a/backend/routes/wanted/__init__.py
+++ b/backend/routes/wanted/__init__.py
@@ -1,4 +1,4 @@
-"""Wanted routes package — list, search, extract, batch-extract, batch-probe, providers."""
+"""Wanted routes package — list, search, export, extract, batch-extract, batch-probe, providers."""
 
 from flask import Blueprint
 
@@ -8,6 +8,7 @@ import routes.wanted.automation  # noqa: E402, F401
 import routes.wanted.batch_extract  # noqa: E402, F401
 import routes.wanted.batch_probe  # noqa: E402, F401
 import routes.wanted.bulk_actions  # noqa: E402, F401
+import routes.wanted.export  # noqa: E402, F401
 import routes.wanted.extract  # noqa: E402, F401
 import routes.wanted.list  # noqa: E402, F401
 import routes.wanted.mt_pending  # noqa: E402, F401

--- a/backend/routes/wanted/export.py
+++ b/backend/routes/wanted/export.py
@@ -1,0 +1,142 @@
+"""Wanted list export — GET /wanted/export as CSV or JSON download."""
+
+import csv
+import io
+import json
+import logging
+from datetime import UTC, datetime
+
+from flask import Response, jsonify, request
+
+from routes.wanted import bp
+
+logger = logging.getLogger(__name__)
+
+# Stable, documented column order for both formats.
+_EXPORT_FIELDS = [
+    "id",
+    "item_type",
+    "title",
+    "season_episode",
+    "target_language",
+    "subtitle_type",
+    "status",
+    "existing_sub",
+    "upgrade_candidate",
+    "current_score",
+    "search_count",
+    "last_search_at",
+    "added_at",
+    "error",
+    "file_path",
+]
+
+_EXPORT_ROW_CAP = 50000
+
+
+def _export_row(item: dict) -> dict:
+    """Project a wanted-item dict onto the stable export columns."""
+    row = {}
+    for field in _EXPORT_FIELDS:
+        value = item.get(field)
+        if isinstance(value, datetime):
+            value = value.isoformat()
+        row[field] = "" if value is None else value
+    return row
+
+
+@bp.route("/wanted/export", methods=["GET"])
+def export_wanted():
+    """Export the wanted list as a CSV or JSON file download.
+    ---
+    get:
+      tags:
+        - Wanted
+      summary: Export wanted items
+      description: Exports wanted items (optionally filtered like the list endpoint) as a downloadable CSV or JSON file.
+      security:
+        - apiKeyAuth: []
+      parameters:
+        - in: query
+          name: format
+          schema:
+            type: string
+            enum: [csv, json]
+            default: csv
+          description: Export file format
+        - in: query
+          name: item_type
+          schema:
+            type: string
+            enum: [episode, movie]
+          description: Filter by item type
+        - in: query
+          name: status
+          schema:
+            type: string
+            enum: [wanted, ignored, failed, found, extracted]
+          description: Filter by item status
+        - in: query
+          name: subtitle_type
+          schema:
+            type: string
+            enum: [full, forced]
+          description: Filter by subtitle type
+        - in: query
+          name: search
+          schema:
+            type: string
+          description: Text search in title and file_path
+      responses:
+        200:
+          description: Export file
+          content:
+            text/csv:
+              schema:
+                type: string
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+        400:
+          description: Invalid format value
+    """
+    from db.wanted import get_wanted_items
+
+    export_format = request.args.get("format", "csv").lower()
+    if export_format not in ("csv", "json"):
+        return jsonify({"error": f"Invalid format: {export_format}. Use: csv, json"}), 400
+
+    result = get_wanted_items(
+        page=1,
+        per_page=_EXPORT_ROW_CAP,
+        item_type=request.args.get("item_type"),
+        status=request.args.get("status"),
+        subtitle_type=request.args.get("subtitle_type"),
+        sort_by="added_at",
+        sort_dir="desc",
+        search=request.args.get("search") or None,
+    )
+    rows = [_export_row(item) for item in result.get("data", [])]
+
+    stamp = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
+    filename = f"sublarr-wanted-{stamp}.{export_format}"
+
+    if export_format == "json":
+        body = json.dumps(rows, ensure_ascii=False, indent=2)
+        mimetype = "application/json"
+    else:
+        buf = io.StringIO()
+        writer = csv.DictWriter(buf, fieldnames=_EXPORT_FIELDS, extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(rows)
+        body = buf.getvalue()
+        mimetype = "text/csv"
+
+    logger.info("Exported %d wanted items as %s", len(rows), export_format)
+    return Response(
+        body,
+        mimetype=mimetype,
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )

--- a/backend/tests/test_routes_wanted_export.py
+++ b/backend/tests/test_routes_wanted_export.py
@@ -1,0 +1,95 @@
+"""HTTP tests for GET /api/v1/wanted/export — CSV/JSON download."""
+
+import csv
+import io
+
+import pytest
+from sqlalchemy import text
+
+from app import create_app
+from db import get_db
+
+
+def _insert_wanted_item(client_app, title="Test Episode", status="wanted", target_language="de"):
+    """Insert a minimal wanted_item row via the app's context and return its id."""
+    with client_app.app_context():
+        db = get_db()
+        db.execute(
+            text(
+                "INSERT INTO wanted_items"
+                " (title, file_path, item_type, target_language, status, priority,"
+                "  error_count, added_at, updated_at)"
+                " VALUES (:t, :fp, 'episode', :tl, :s, 'standard',"
+                "  0, datetime('now'), datetime('now'))"
+            ),
+            {"t": title, "fp": "/media/ep.mkv", "s": status, "tl": target_language},
+        )
+        db.commit()
+        row = db.execute(text("SELECT id FROM wanted_items ORDER BY id DESC LIMIT 1")).fetchone()
+        return row[0]
+
+
+@pytest.fixture
+def app_and_client(temp_db):
+    """Provide both Flask app and test client sharing the same DB."""
+    app = create_app(testing=True)
+    app.config["TESTING"] = True
+    app.config["WTF_CSRF_ENABLED"] = False
+    with app.test_client() as client:
+        yield app, client
+
+
+def test_export_invalid_format(client):
+    resp = client.get("/api/v1/wanted/export?format=xml")
+    assert resp.status_code == 400
+    assert "Invalid format" in resp.get_json()["error"]
+
+
+def test_export_csv_empty(client):
+    resp = client.get("/api/v1/wanted/export")
+    assert resp.status_code == 200
+    assert resp.mimetype == "text/csv"
+    assert "attachment" in resp.headers["Content-Disposition"]
+    rows = list(csv.reader(io.StringIO(resp.get_data(as_text=True))))
+    assert rows[0][0] == "id"  # header row only
+    assert len(rows) == 1
+
+
+def test_export_csv_populated(app_and_client):
+    app, client = app_and_client
+    _insert_wanted_item(app, "Episode A")
+    _insert_wanted_item(app, "Episode B", status="ignored")
+
+    resp = client.get("/api/v1/wanted/export?format=csv")
+    assert resp.status_code == 200
+    rows = list(csv.DictReader(io.StringIO(resp.get_data(as_text=True))))
+    assert len(rows) == 2
+    titles = {r["title"] for r in rows}
+    assert titles == {"Episode A", "Episode B"}
+    assert all(r["file_path"] == "/media/ep.mkv" for r in rows)
+
+
+def test_export_csv_respects_status_filter(app_and_client):
+    app, client = app_and_client
+    _insert_wanted_item(app, "Episode A")
+    _insert_wanted_item(app, "Episode B", status="ignored")
+
+    resp = client.get("/api/v1/wanted/export?format=csv&status=ignored")
+    rows = list(csv.DictReader(io.StringIO(resp.get_data(as_text=True))))
+    assert len(rows) == 1
+    assert rows[0]["title"] == "Episode B"
+
+
+def test_export_json(app_and_client):
+    app, client = app_and_client
+    _insert_wanted_item(app, "Episode A")
+
+    resp = client.get("/api/v1/wanted/export?format=json")
+    assert resp.status_code == 200
+    assert resp.mimetype == "application/json"
+    assert resp.headers["Content-Disposition"].endswith('.json"')
+    payload = resp.get_json()
+    assert isinstance(payload, list)
+    assert len(payload) == 1
+    assert payload[0]["title"] == "Episode A"
+    assert payload[0]["target_language"] == "de"

--- a/frontend/src/api/wanted.ts
+++ b/frontend/src/api/wanted.ts
@@ -323,3 +323,35 @@ export async function rejectMtPending(itemId: number): Promise<{ status: string;
   const { data } = await api.post(`/wanted/${itemId}/mt-pending/reject`)
   return data
 }
+
+// ─── Export ─────────────────────────────────────────────────────────────
+
+/** Downloads the wanted list (with the given filters applied) as CSV or JSON. */
+export async function exportWantedItems(opts: {
+  format: 'csv' | 'json'
+  itemType?: string
+  status?: string
+  subtitleType?: string
+  search?: string
+}): Promise<void> {
+  const params: Record<string, unknown> = { format: opts.format }
+  if (opts.itemType) params.item_type = opts.itemType
+  if (opts.status) params.status = opts.status
+  if (opts.subtitleType) params.subtitle_type = opts.subtitleType
+  if (opts.search) params.search = opts.search
+  const { data, headers } = await api.get('/wanted/export', {
+    params,
+    responseType: 'blob',
+  })
+  const disposition: string = headers['content-disposition'] ?? ''
+  const match = disposition.match(/filename[^;=\n]*=["']?([^"';\n]+)["']?/)
+  const filename = match ? match[1].trim() : `sublarr-wanted.${opts.format}`
+  const url = URL.createObjectURL(data as Blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  URL.revokeObjectURL(url)
+}

--- a/frontend/src/i18n/locales/de/library.json
+++ b/frontend/src/i18n/locales/de/library.json
@@ -126,7 +126,11 @@
       "last_search_at": "Zuletzt gesucht",
       "current_score": "Score",
       "search_count": "Anzahl Suchen"
-    }
+    },
+    "export": "Export",
+    "export_csv": "Als CSV exportieren",
+    "export_json": "Als JSON exportieren",
+    "export_failed": "Export fehlgeschlagen"
   },
   "auto_sync": "Auto-Sync",
   "more_actions": "Weitere Aktionen",

--- a/frontend/src/i18n/locales/en/library.json
+++ b/frontend/src/i18n/locales/en/library.json
@@ -126,7 +126,11 @@
       "last_search_at": "Last searched",
       "current_score": "Score",
       "search_count": "Search count"
-    }
+    },
+    "export": "Export",
+    "export_csv": "Export as CSV",
+    "export_json": "Export as JSON",
+    "export_failed": "Export failed"
   },
   "auto_sync": "Auto-sync",
   "more_actions": "More actions",

--- a/frontend/src/pages/Wanted.tsx
+++ b/frontend/src/pages/Wanted.tsx
@@ -22,6 +22,7 @@ import { useSelectionStore } from '@/stores/selectionStore'
 import { useWebSocket } from '@/hooks/useWebSocket'
 import { useQueryClient, useQuery } from '@tanstack/react-query'
 import { getConfig } from '@/api/settings'
+import { exportWantedItems } from '@/api/wanted'
 import { WantedToolbar } from './wanted/WantedToolbar'
 import { MtPendingModal } from './wanted/MtPendingModal'
 import { WantedFilterPanel } from './wanted/WantedFilterPanel'
@@ -306,6 +307,18 @@ export function WantedPage() {
     startBatch.mutate(undefined)
   }
 
+  const handleExport = (format: 'csv' | 'json') => {
+    exportWantedItems({
+      format,
+      itemType: typeFilter,
+      status: statusFilter,
+      subtitleType: subtitleTypeFilter,
+      search: debouncedSearch || undefined,
+    }).catch(() => {
+      toast(t('wanted.export_failed'), 'error')
+    })
+  }
+
   const handleCleanup = () => {
     cleanupSidecars.mutate(undefined, {
       onSuccess: (result) => {
@@ -438,6 +451,7 @@ export function WantedPage() {
         onShowCleanupConfirm={() => setShowCleanupConfirm(true)}
         onBatchTranslate={() => batchTranslate.mutate([])}
         onOpenMtPending={() => setShowMtPendingModal(true)}
+        onExport={handleExport}
       />
 
       {/* Filter Panel: Summary Cards + Filters + Search + Sort + FilterBar */}

--- a/frontend/src/pages/wanted/WantedToolbar.tsx
+++ b/frontend/src/pages/wanted/WantedToolbar.tsx
@@ -1,5 +1,6 @@
+import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { RefreshCw, Search, ScanSearch, Download, Languages, Bell } from 'lucide-react'
+import { RefreshCw, Search, ScanSearch, Download, Languages, Bell, FileDown } from 'lucide-react'
 
 export interface WantedToolbarProps {
   summaryTotal: number
@@ -21,6 +22,8 @@ export interface WantedToolbarProps {
   onBatchTranslate: () => void
   /** Opens the pending-original review modal. Omit if the feature is not wired up. */
   onOpenMtPending?: () => void
+  /** Downloads the wanted list (current filters applied) as CSV or JSON. */
+  onExport: (format: 'csv' | 'json') => void
 }
 
 export function WantedToolbar({
@@ -41,9 +44,23 @@ export function WantedToolbar({
   onShowCleanupConfirm,
   onBatchTranslate,
   onOpenMtPending,
+  onExport,
 }: WantedToolbarProps) {
   const { t } = useTranslation('library')
   const { t: tc } = useTranslation('common')
+  const [exportOpen, setExportOpen] = useState(false)
+  const exportRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!exportOpen) return
+    const handle = (e: MouseEvent) => {
+      if (exportRef.current && !exportRef.current.contains(e.target as Node)) {
+        setExportOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handle)
+    return () => document.removeEventListener('mousedown', handle)
+  }, [exportOpen])
 
   return (
     <div className="flex items-center justify-between flex-wrap gap-4">
@@ -85,6 +102,42 @@ export function WantedToolbar({
           <ScanSearch size={14} />
           {probeRunning ? t('wanted.scanning') : t('wanted.scan_embedded')}
         </button>
+        <div className="relative" ref={exportRef}>
+          <button
+            onClick={() => setExportOpen((v) => !v)}
+            className="flex items-center gap-2 px-4 py-2 rounded-md text-sm font-medium hover:opacity-90"
+            title={t('wanted.export')}
+            data-testid="wanted-export-btn"
+            style={{
+              backgroundColor: 'var(--bg-surface)',
+              color: 'var(--text-primary)',
+              border: '1px solid var(--border)',
+            }}
+          >
+            <FileDown size={14} />
+            {t('wanted.export')}
+          </button>
+          {exportOpen && (
+            <div
+              className="absolute right-0 top-11 z-50 rounded-lg shadow-lg py-1 min-w-36"
+              style={{ backgroundColor: 'var(--bg-surface)', border: '1px solid var(--border)' }}
+            >
+              {(['csv', 'json'] as const).map((format) => (
+                <button
+                  key={format}
+                  data-testid={`wanted-export-${format}`}
+                  onClick={() => { onExport(format); setExportOpen(false) }}
+                  className="w-full flex items-center gap-2 px-3 py-1.5 text-xs text-left transition-colors"
+                  style={{ color: 'var(--text-secondary)' }}
+                  onMouseEnter={(e) => { e.currentTarget.style.backgroundColor = 'var(--bg-surface-hover)'; e.currentTarget.style.color = 'var(--text-primary)' }}
+                  onMouseLeave={(e) => { e.currentTarget.style.backgroundColor = ''; e.currentTarget.style.color = 'var(--text-secondary)' }}
+                >
+                  {t(`wanted.export_${format}`)}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
         <button
           onClick={onShowCleanupConfirm}
           disabled={cleanupPending}


### PR DESCRIPTION
## What

Adds an export feature for the Wanted list:

- **Backend**: new `GET /api/v1/wanted/export?format=csv|json` (in `backend/routes/wanted/export.py`) with OpenAPI docs. Honours the same filters as the list endpoint (`item_type`, `status`, `subtitle_type`, `search`) and streams a downloadable file (`Content-Disposition: attachment`, timestamped filename). Stable column set: id, item_type, title, season_episode, target_language, subtitle_type, status, existing_sub, upgrade_candidate, current_score, search_count, last_search_at, added_at, error, file_path.
- **Frontend**: "Export" dropdown (CSV / JSON) in the Wanted toolbar. The export applies the currently active filters and search text, so what you see is what you export. Blob-download follows the existing series-ZIP-export pattern.
- EN + DE translations.

## Why

Lets you process the missing-subtitles backlog outside Sublarr — share it in an issue/Discord, diff it over time, or feed it into scripts.

## Testing

- New backend tests `backend/tests/test_routes_wanted_export.py` (invalid format → 400, CSV empty/populated, status filter, JSON payload) — 5 passed; full `test_routes_wanted.py` suite still green (41 passed total)
- Frontend: `tsc -b` clean, all 447 page tests passing, ESLint no new errors
- Ruff clean on the new backend files

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4Ddyni8nZwS5M9pEzMMdZ)_