### PR TITLE
feat(waveform): loop-audition of the selected cue with pre-/post-roll

### DIFF
--- a/frontend/src/components/editor/waveform/WaveformEditor.tsx
+++ b/frontend/src/components/editor/waveform/WaveformEditor.tsx
@@ -24,6 +24,7 @@ import {
   Headphones,
   Film,
   Gauge,
+  Repeat,
   List as ListIcon,
   Undo2,
   Redo2,
@@ -140,6 +141,7 @@ const SPEECH_LANE_LS_KEY = 'sublarr.waveform.speechLane'
 const AMP_ZOOM_LS_KEY = 'sublarr.waveform.ampZoom'
 const PLAYBACK_RATE_LS_KEY = 'sublarr.waveform.playbackRate'
 const CUE_LIST_COLLAPSED_LS_KEY = 'sublarr.waveform.cueListCollapsed'
+const LOOP_ROLL_LS_KEY = 'sublarr.waveform.loopRollSec'
 
 /** Vertical amplitude (bar-height) zoom — 1× default, up to 5× for quiet audio. */
 const AMP_MIN = 1
@@ -150,6 +152,10 @@ const AMP_DEFAULT = 1
 const RATE_MIN = 0.5
 const RATE_MAX = 2.0
 const RATE_DEFAULT = 1.0
+
+/** Loop-audition pre-/post-roll around the cue, in seconds. */
+const LOOP_ROLL_OPTIONS = [0, 0.25, 0.5, 1] as const
+const LOOP_ROLL_DEFAULT = 0.25
 
 function readNumberPref(key: string, fallback: number, min: number, max: number): number {
   if (typeof window === 'undefined') return fallback
@@ -243,6 +249,10 @@ export function WaveformEditor({
   const [playbackRate, setPlaybackRate] = useState<number>(() =>
     readNumberPref(PLAYBACK_RATE_LS_KEY, RATE_DEFAULT, RATE_MIN, RATE_MAX),
   )
+  // Loop-audition pre-/post-roll (seconds of context played around the cue).
+  const [loopRollSec, setLoopRollSec] = useState<number>(() =>
+    readNumberPref(LOOP_ROLL_LS_KEY, LOOP_ROLL_DEFAULT, 0, LOOP_ROLL_OPTIONS[LOOP_ROLL_OPTIONS.length - 1]),
+  )
   // 0-based audio-position to extract; the backend route picks `0:a:<idx>`.
   const [selectedAudioIdx, setSelectedAudioIdx] = useState<number>(0)
   // Stacked-Lanes layout: persisted collapse for the cue list under the wave.
@@ -319,6 +329,11 @@ export function WaveformEditor({
     writeNumberPref(PLAYBACK_RATE_LS_KEY, value)
   }, [])
 
+  const updateLoopRoll = useCallback((value: number) => {
+    setLoopRollSec(value)
+    writeNumberPref(LOOP_ROLL_LS_KEY, value)
+  }, [])
+
   const { data: parseData } = useSubtitleParse(subtitlePath)
   const { data: keyframesData } = useKeyframes(videoPath || null)
   const { data: audioTracksData } = useAudioTracks(videoPath || null)
@@ -377,6 +392,9 @@ export function WaveformEditor({
     isReady,
     isPlaying,
     playPause,
+    startLoop,
+    stopLoop,
+    isLooping,
     setStartAtPlayhead,
     setEndAtPlayhead,
     seekBy,
@@ -453,6 +471,17 @@ export function WaveformEditor({
         case 'playPause':
           playPause()
           return
+        case 'loopCue': {
+          if (isLooping) {
+            stopLoop()
+            return
+          }
+          if (selectedCueIdx === null) return
+          const cue = cues[selectedCueIdx]
+          if (!cue) return
+          startLoop(cue.start - loopRollSec, cue.end + loopRollSec)
+          return
+        }
         case 'setStart':
           setStartAtPlayhead()
           return
@@ -537,6 +566,11 @@ export function WaveformEditor({
     [
       ws,
       playPause,
+      isLooping,
+      startLoop,
+      stopLoop,
+      cues,
+      loopRollSec,
       setStartAtPlayhead,
       setEndAtPlayhead,
       seekBy,
@@ -594,6 +628,38 @@ export function WaveformEditor({
         {isPlaying ? <Pause size={12} /> : <Play size={12} />}
         {isPlaying ? t('waveform.pause') : t('waveform.play')}
       </button>
+
+      {/* Loop-audition (`L`): repeat the selected cue with pre-/post-roll. */}
+      <div className="flex items-center gap-1">
+        <button
+          type="button"
+          onClick={() => handleAction('loopCue')}
+          disabled={!isLooping && selectedCueIdx === null}
+          aria-pressed={isLooping}
+          className={`flex items-center gap-1.5 px-3 py-1.5 rounded text-xs font-medium transition-colors border disabled:opacity-40 disabled:cursor-not-allowed ${
+            isLooping
+              ? 'bg-accent-bg text-accent border-accent-dim'
+              : 'bg-surface text-primary border-border'
+          }`}
+          title={t('waveform.loop_tooltip')}
+        >
+          <Repeat size={12} />
+          {t('waveform.loop')}
+        </button>
+        <select
+          value={loopRollSec}
+          onChange={(e) => updateLoopRoll(Number(e.target.value))}
+          className="px-1 py-1.5 rounded text-xs bg-surface text-primary border border-border"
+          title={t('waveform.loop_roll_tooltip')}
+          aria-label={t('waveform.loop_roll_tooltip')}
+        >
+          {LOOP_ROLL_OPTIONS.map((sec) => (
+            <option key={sec} value={sec}>
+              ±{sec}s
+            </option>
+          ))}
+        </select>
+      </div>
 
       {onCueChange && (
         <button

--- a/frontend/src/components/editor/waveform/WaveformHotkeys.tsx
+++ b/frontend/src/components/editor/waveform/WaveformHotkeys.tsx
@@ -26,6 +26,7 @@ export function WaveformHotkeys({ enabled, onAction }: WaveformHotkeysProps) {
   const opts = { enabled, preventDefault: true } as const
 
   useHotkeys('space', () => onAction('playPause'), opts)
+  useHotkeys('l', () => onAction('loopCue'), opts)
   useHotkeys('s', () => onAction('setStart'), opts)
   useHotkeys('d', () => onAction('setEnd'), opts)
   useHotkeys('f', () => onAction('splitAtCursor'), opts)

--- a/frontend/src/components/editor/waveform/__tests__/WaveformHotkeys.test.tsx
+++ b/frontend/src/components/editor/waveform/__tests__/WaveformHotkeys.test.tsx
@@ -52,6 +52,15 @@ describe('WaveformHotkeys', () => {
     expect(onAction).toHaveBeenCalledWith('playPause')
   })
 
+  it('dispatches "loopCue" on L keypress', async () => {
+    const onAction = vi.fn()
+    render(<WaveformHotkeys enabled={true} onAction={onAction} />)
+
+    await userEvent.keyboard('l')
+
+    expect(onAction).toHaveBeenCalledWith('loopCue')
+  })
+
   it('dispatches "seekBack1s" on Shift+Left', async () => {
     const onAction = vi.fn()
     render(<WaveformHotkeys enabled={true} onAction={onAction} />)

--- a/frontend/src/components/editor/waveform/__tests__/useWaveformRegions.test.tsx
+++ b/frontend/src/components/editor/waveform/__tests__/useWaveformRegions.test.tsx
@@ -822,4 +822,125 @@ describe('useWaveformRegions', () => {
       expect(fakeWsWrapperEl.querySelectorAll('[data-sublarr-scene-marker="1"]')).toHaveLength(0)
     })
   })
+
+  // ─── Loop audition (L key) ────────────────────────────────────────────
+
+  describe('loop audition', () => {
+    interface LoopApi {
+      startLoop: (from: number, to: number) => void
+      stopLoop: () => void
+      playPause: () => void
+      isLooping: boolean
+    }
+
+    function LoopHarness({ apiRef }: { apiRef: { current: LoopApi | null } }) {
+      const containerRef = useRef<HTMLDivElement>(null)
+      const result = useWaveformRegions({
+        container: containerRef,
+        audioUrl: '/fake.wav',
+        cues: SAMPLE_CUES,
+        onCueChange: vi.fn(),
+      })
+      apiRef.current = result
+      return <div ref={containerRef} />
+    }
+
+    it('startLoop plays the window and restarts when playback pauses at its end', () => {
+      const apiRef = { current: null as LoopApi | null }
+      render(<LoopHarness apiRef={apiRef} />)
+      act(() => {
+        fireWs('ready')
+      })
+
+      act(() => {
+        apiRef.current!.startLoop(1.0, 2.0)
+      })
+      expect(fakeWs.play).toHaveBeenCalledWith(1.0, 2.0)
+      expect(apiRef.current!.isLooping).toBe(true)
+
+      // WaveSurfer pauses at the window end -> the hook restarts the loop.
+      fakeWs.play.mockClear()
+      fakeWs.getCurrentTime.mockReturnValue(2.0)
+      act(() => {
+        fireWs('pause')
+      })
+      expect(fakeWs.play).toHaveBeenCalledWith(1.0, 2.0)
+      fakeWs.getCurrentTime.mockReturnValue(0)
+    })
+
+    it('does not restart on a manual pause mid-window', () => {
+      const apiRef = { current: null as LoopApi | null }
+      render(<LoopHarness apiRef={apiRef} />)
+      act(() => {
+        fireWs('ready')
+      })
+
+      act(() => {
+        apiRef.current!.startLoop(1.0, 2.0)
+      })
+      fakeWs.play.mockClear()
+      fakeWs.getCurrentTime.mockReturnValue(1.4)
+      act(() => {
+        fireWs('pause')
+      })
+      expect(fakeWs.play).not.toHaveBeenCalled()
+      fakeWs.getCurrentTime.mockReturnValue(0)
+    })
+
+    it('stopLoop pauses and clears the looping flag', () => {
+      const apiRef = { current: null as LoopApi | null }
+      render(<LoopHarness apiRef={apiRef} />)
+      act(() => {
+        fireWs('ready')
+      })
+
+      act(() => {
+        apiRef.current!.startLoop(1.0, 2.0)
+      })
+      act(() => {
+        apiRef.current!.stopLoop()
+      })
+      expect(fakeWs.pause).toHaveBeenCalled()
+      expect(apiRef.current!.isLooping).toBe(false)
+
+      // A pause event at the old window end must NOT restart the loop.
+      fakeWs.play.mockClear()
+      fakeWs.getCurrentTime.mockReturnValue(2.0)
+      act(() => {
+        fireWs('pause')
+      })
+      expect(fakeWs.play).not.toHaveBeenCalled()
+      fakeWs.getCurrentTime.mockReturnValue(0)
+    })
+
+    it('other transport actions cancel a running loop', () => {
+      const apiRef = { current: null as LoopApi | null }
+      render(<LoopHarness apiRef={apiRef} />)
+      act(() => {
+        fireWs('ready')
+      })
+
+      act(() => {
+        apiRef.current!.startLoop(1.0, 2.0)
+      })
+      act(() => {
+        apiRef.current!.playPause()
+      })
+      expect(apiRef.current!.isLooping).toBe(false)
+    })
+
+    it('rejects a degenerate window', () => {
+      const apiRef = { current: null as LoopApi | null }
+      render(<LoopHarness apiRef={apiRef} />)
+      act(() => {
+        fireWs('ready')
+      })
+
+      act(() => {
+        apiRef.current!.startLoop(2.0, 2.0)
+      })
+      expect(apiRef.current!.isLooping).toBe(false)
+      expect(fakeWs.play).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/frontend/src/components/editor/waveform/keymap.ts
+++ b/frontend/src/components/editor/waveform/keymap.ts
@@ -18,6 +18,7 @@
 
 export type WaveformAction =
   | 'playPause'
+  | 'loopCue'
   | 'setStart'
   | 'setEnd'
   | 'splitAtCursor'
@@ -60,6 +61,7 @@ export interface WaveformShortcut {
 
 export const WAVEFORM_SHORTCUTS: readonly WaveformShortcut[] = [
   { keys: 'space', display: 'Space', action: 'playPause', labelKey: 'playPause', group: 'playback' },
+  { keys: 'l', display: 'L', action: 'loopCue', labelKey: 'loopCue', group: 'playback' },
   { keys: 's', display: 'S', action: 'setStart', labelKey: 'setStart', group: 'timing' },
   { keys: 'd', display: 'D', action: 'setEnd', labelKey: 'setEnd', group: 'timing' },
   { keys: 'f', display: 'F', action: 'splitAtCursor', labelKey: 'splitAtCursor', group: 'timing' },

--- a/frontend/src/components/editor/waveform/useWaveformRegions.ts
+++ b/frontend/src/components/editor/waveform/useWaveformRegions.ts
@@ -151,6 +151,16 @@ export interface UseWaveformRegionsResult {
   pause: () => void
   playPause: () => void
   /**
+   * Loop-audition (`L` key): repeat the [fromSec, toSec] window until
+   * stopped. Any other transport action (play/pause/seek) cancels the loop
+   * so the user never gets "stuck" inside it.
+   */
+  startLoop: (fromSec: number, toSec: number) => void
+  /** Stop a running loop-audition and pause playback. */
+  stopLoop: () => void
+  /** True while a loop-audition window is active. */
+  isLooping: boolean
+  /**
    * Snap-and-set the selected cue's start to the current playhead. Used by
    * the keyboard `S` hotkey (Aegisub convention).
    */
@@ -264,9 +274,13 @@ export function useWaveformRegions({
   scrubWindowSecRef.current = scrubWindowSec
   // Last scrub timestamp (ms epoch); used by the throttle gate.
   const lastScrubAtRef = useRef<number>(0)
+  // Loop-audition window in seconds; null when no loop is active. Read by
+  // the long-lived pause/finish listeners to decide whether to restart.
+  const loopRef = useRef<{ from: number; to: number } | null>(null)
 
   const [isReady, setIsReady] = useState(false)
   const [isPlaying, setIsPlaying] = useState(false)
+  const [isLooping, setIsLooping] = useState(false)
   const [visibleRange, setVisibleRange] = useState<[number, number] | null>(null)
   const [playheadSec, setPlayheadSec] = useState<number>(0)
 
@@ -315,8 +329,26 @@ export function useWaveformRegions({
     wsRef.current = ws
 
     const onPlay = () => setIsPlaying(true)
-    const onPause = () => setIsPlaying(false)
-    const onFinish = () => setIsPlaying(false)
+    // WaveSurfer's play(from, to) pauses when the window ends; if a
+    // loop-audition is active and the playhead landed at (or past) the
+    // window's end, restart it. A manual pause mid-window falls through
+    // and just pauses — the loop flag stays set until explicitly cleared.
+    const restartLoopIfEnded = () => {
+      const loop = loopRef.current
+      const ws2 = wsRef.current
+      if (!loop || !ws2) return false
+      if (ws2.getCurrentTime() < loop.to - 0.05) return false
+      void ws2.play(loop.from, loop.to)
+      return true
+    }
+    const onPause = () => {
+      if (restartLoopIfEnded()) return
+      setIsPlaying(false)
+    }
+    const onFinish = () => {
+      if (restartLoopIfEnded()) return
+      setIsPlaying(false)
+    }
     const onReady = () => {
       setIsReady(true)
     }
@@ -427,8 +459,10 @@ export function useWaveformRegions({
       ws.destroy()
       wsRef.current = null
       regionsRef.current = null
+      loopRef.current = null
       setIsReady(false)
       setIsPlaying(false)
+      setIsLooping(false)
       setVisibleRange(null)
       setPlayheadSec(0)
     }
@@ -927,15 +961,44 @@ export function useWaveformRegions({
     }
   }, [container, isReady, enableDrag, applySetStart, applySetEnd])
 
+  /** Drop the loop window without touching playback. Called by every other
+   *  transport action so a running loop never "captures" them. */
+  const clearLoop = useCallback(() => {
+    if (loopRef.current === null) return
+    loopRef.current = null
+    setIsLooping(false)
+  }, [])
+
   const play = useCallback(() => {
+    clearLoop()
     void wsRef.current?.play()
-  }, [])
+  }, [clearLoop])
   const pause = useCallback(() => {
+    clearLoop()
     wsRef.current?.pause()
-  }, [])
+  }, [clearLoop])
   const playPause = useCallback(() => {
+    clearLoop()
     void wsRef.current?.playPause()
+  }, [clearLoop])
+
+  const startLoop = useCallback((fromSec: number, toSec: number) => {
+    const ws = wsRef.current
+    if (!ws) return
+    const dur = ws.getDuration()
+    if (!Number.isFinite(dur) || dur <= 0) return
+    const from = Math.max(0, Math.min(dur, fromSec))
+    const to = Math.max(0, Math.min(dur, toSec))
+    if (to - from < 0.01) return
+    loopRef.current = { from, to }
+    setIsLooping(true)
+    void ws.play(from, to)
   }, [])
+
+  const stopLoop = useCallback(() => {
+    clearLoop()
+    wsRef.current?.pause()
+  }, [clearLoop])
 
   /** Set the start of the currently selected cue at the playhead position. */
   const setStartAtPlayhead = useCallback(() => {
@@ -983,6 +1046,9 @@ export function useWaveformRegions({
     play,
     pause,
     playPause,
+    startLoop,
+    stopLoop,
+    isLooping,
     setStartAtPlayhead,
     setEndAtPlayhead,
     seekBy,

--- a/frontend/src/i18n/locales/de/editor.json
+++ b/frontend/src/i18n/locales/de/editor.json
@@ -101,7 +101,8 @@
       "nextScene": "Zum nächsten Szenenwechsel springen",
       "zoomIn": "Vergrößern",
       "zoomOut": "Verkleinern",
-      "showHelp": "Diese Hilfe anzeigen"
+      "showHelp": "Diese Hilfe anzeigen",
+      "loopCue": "Ausgewählte Cue loopen (mit Vor-/Nachlauf)"
     },
     "shortcut_group": {
       "playback": "Wiedergabe",
@@ -150,7 +151,10 @@
     "issues_tooltip": "{{overlaps}} Überlappungen · {{gaps}} enge Abstände · {{fast}} zu schnell · {{short}} zu kurz — klicken, um zum ersten zu springen",
     "extracting_audio": "Audio wird extrahiert…",
     "drawing": "Wellenform wird gezeichnet…",
-    "loading_hint": "Bei langen Folgen kann das einen Moment dauern — das Audio wird aus dem Video extrahiert und die Welle gezeichnet."
+    "loading_hint": "Bei langen Folgen kann das einen Moment dauern — das Audio wird aus dem Video extrahiert und die Welle gezeichnet.",
+    "loop": "Loop",
+    "loop_tooltip": "Ausgewählte Cue in Schleife abspielen, mit Vor-/Nachlauf (L)",
+    "loop_roll_tooltip": "Vor-/Nachlauf um die Cue herum"
   },
   "sync_preview": {
     "before_start": "Vor Start",

--- a/frontend/src/i18n/locales/en/editor.json
+++ b/frontend/src/i18n/locales/en/editor.json
@@ -101,7 +101,8 @@
       "nextScene": "Jump to next scene cut",
       "zoomIn": "Zoom in",
       "zoomOut": "Zoom out",
-      "showHelp": "Show this help"
+      "showHelp": "Show this help",
+      "loopCue": "Loop selected cue (with pre-/post-roll)"
     },
     "shortcut_group": {
       "playback": "Playback",
@@ -150,7 +151,10 @@
     "issues_tooltip": "{{overlaps}} overlaps · {{gaps}} tight gaps · {{fast}} too fast · {{short}} too short — click to jump to the first",
     "extracting_audio": "Extracting audio…",
     "drawing": "Drawing waveform…",
-    "loading_hint": "For long episodes this can take a moment — extracting the audio from the video and drawing the wave."
+    "loading_hint": "For long episodes this can take a moment — extracting the audio from the video and drawing the wave.",
+    "loop": "Loop",
+    "loop_tooltip": "Loop the selected cue with pre-/post-roll (L)",
+    "loop_roll_tooltip": "Pre-/post-roll played around the cue"
   },
   "sync_preview": {
     "before_start": "Before Start",


### PR DESCRIPTION
## What

Implements **loop audition** — the last-but-one open item from Phase 1 of the waveform expansion roadmap (`docs/specs/2026-07-19-waveform-expansion-roadmap.md`):

- **`L` key** (and a toolbar `Loop` button) repeats the selected cue in a loop, with a configurable **pre-/post-roll** (±0s / ±0.25s / ±0.5s / ±1s, persisted in localStorage like the other toolbar prefs). Default ±0.25s.
- The loop restarts via the WaveSurfer `pause`/`finish` events: `play(from, to)` pauses at the window end; if the playhead is at/past the loop end, the hook restarts it. A manual pause mid-window just pauses.
- **Any other transport action (play/pause/space/stop) cancels the loop**, so you can never get "stuck" inside it.
- Registered in the keymap + `?` shortcut-help overlay (group *playback*), EN + DE translations.

## Why

Catching breaths, mouth-close and hard cuts around very short lines needs repeated listening of the same 1–2 seconds; without a loop that means hammering Space + seek. Roadmap rated it "S/M effort, high value".

## Testing

- 6 new tests: `L` hotkey dispatch + 5 loop-behaviour tests on the hook (restart at window end, no restart on manual mid-window pause, stopLoop clears, transport actions cancel, degenerate window rejected)
- All 182 waveform tests green, `tsc -b` clean, no new ESLint errors

## Notes

Touches the hook's playback surface only additively — no changes to region drag/snap/commit paths (the locked surfaces).

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4Ddyni8nZwS5M9pEzMMdZ)_