### PR TITLE
feat(waveform): one-click "fix safe defects" with preview and atomic undo

### DIFF
--- a/frontend/src/components/editor/SubtitleEditorModal.tsx
+++ b/frontend/src/components/editor/SubtitleEditorModal.tsx
@@ -23,6 +23,8 @@ import {
   applyCueText,
   CueTextHasStylingError,
 } from '@/components/editor/waveform/applyCueText'
+import type { CueTimingFix } from '@/components/editor/waveform/fixSafeDefects'
+import type { SubtitleParseResult } from '@/types/system'
 
 // Lazy-loaded editor components -- CodeMirror stays in separate chunks
 const SubtitlePreview = lazy(() => import('@/components/editor/SubtitlePreview'))
@@ -171,6 +173,54 @@ export default function SubtitleEditorModal({
       }
     },
     [content, format, t],
+  )
+
+  // One-click "fix safe defects": apply the whole batch as ONE atomic edit —
+  // a single undo-stack entry restores the pre-batch content. Also patches
+  // the cached parse result so regions, defect lanes, and the issue chip
+  // reflect the fixed timings immediately (the parse query reads from disk
+  // and would otherwise stay stale until save).
+  const handleApplyTimingFixes = useCallback(
+    (fixes: CueTimingFix[]) => {
+      if (!content || !format || fixes.length === 0) return
+      try {
+        let next = content
+        for (const fix of fixes) {
+          next = applyCueTiming({
+            content: next,
+            format,
+            cueIndex: fix.cueIndex,
+            start: fix.after.start,
+            end: fix.after.end,
+          })
+        }
+        if (next === content) return
+        setWaveformUndoStack((stack) => [...stack, content])
+        setWaveformRedoStack([])
+        setContent(next)
+        queryClient.setQueryData<SubtitleParseResult>(
+          ['subtitle-parse', filePath],
+          (old) => {
+            if (!old) return old
+            const cues = [...old.cues]
+            for (const fix of fixes) {
+              const cue = cues[fix.cueIndex]
+              if (cue) cues[fix.cueIndex] = { ...cue, start: fix.after.start, end: fix.after.end }
+            }
+            return { ...old, cues }
+          },
+        )
+        toast(t('editor_modal.fix_defects_applied', { count: fixes.length }))
+      } catch (err) {
+        if (err instanceof UnsupportedFormatError) {
+          toast(t('editor_modal.waveform_unsupported_format', { format }), 'info')
+          return
+        }
+        const msg = err instanceof Error ? err.message : t('editor_modal.cue_update_failed')
+        toast(msg, 'error')
+      }
+    },
+    [content, format, filePath, queryClient, t],
   )
 
   const handleWaveformUndo = useCallback(() => {
@@ -641,6 +691,7 @@ export default function SubtitleEditorModal({
                 onSave={handleWaveformSave}
                 hasUnsavedChanges={hasUnsavedChanges}
                 saveInFlight={saveInFlight}
+                onApplyTimingFixes={handleApplyTimingFixes}
               />
             )}
           </Suspense>

--- a/frontend/src/components/editor/waveform/WaveformEditor.tsx
+++ b/frontend/src/components/editor/waveform/WaveformEditor.tsx
@@ -30,6 +30,7 @@ import {
   Save,
   AlertTriangle,
   Mic,
+  Wrench,
 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
@@ -40,8 +41,10 @@ import { useWaveformRegions, type CuePatch, type WaveformCue } from './useWavefo
 import { detectGapsAndOverlaps } from './gapOverlap'
 import { findAdjacentMarker } from './waveformNavigation'
 import { summarizeIssues } from './issueSummary'
+import { planSafeDefectFixes, type CueTimingFix } from './fixSafeDefects'
 import { WaveformHotkeys } from './WaveformHotkeys'
 import { WaveformShortcutHelp } from './WaveformShortcutHelp'
+import { WaveformFixDefectsDialog } from './WaveformFixDefectsDialog'
 import { WaveformAudioTrackPicker } from './WaveformAudioTrackPicker'
 import { AssKaraokeOverlay } from './AssKaraokeOverlay'
 import { WaveformActiveCueBar } from './WaveformActiveCueBar'
@@ -116,6 +119,12 @@ interface WaveformEditorProps {
   hasUnsavedChanges?: boolean
   /** Spinner indicator while a save round-trip is in flight. */
   saveInFlight?: boolean
+  /**
+   * Apply a batch of safe timing fixes (one-click "fix safe defects") as a
+   * single atomic edit. The toolbar shows the Fix button only when this is
+   * set, the editor is unlocked, and at least one safe fix exists.
+   */
+  onApplyTimingFixes?: (fixes: CueTimingFix[]) => void
 }
 
 /** Minimum cue duration enforced by the snap helper, in ms. */
@@ -210,6 +219,7 @@ export function WaveformEditor({
   onSave,
   hasUnsavedChanges = false,
   saveInFlight = false,
+  onApplyTimingFixes,
 }: WaveformEditorProps) {
   const { t } = useTranslation('editor')
 
@@ -223,6 +233,7 @@ export function WaveformEditor({
   // unlock dragging, click-set, S/D hotkeys.
   const [editingEnabled, setEditingEnabled] = useState<boolean>(false)
   const [helpOpen, setHelpOpen] = useState(false)
+  const [fixDialogOpen, setFixDialogOpen] = useState(false)
   const [zoomPxPerSec, setZoomPxPerSec] = useState<number>(ZOOM_DEFAULT_PX_PER_SEC)
   const [autoCenter, setAutoCenter] = useState<boolean>(true)
   const [spectrogramEnabled, setSpectrogramEnabled] = useState<boolean>(() =>
@@ -569,6 +580,20 @@ export function WaveformEditor({
   // per-cue signals as the cue-list dots, aggregated across the whole file.
   const issueSummary = useMemo(() => summarizeIssues(cueListRows), [cueListRows])
 
+  // One-click "fix safe defects": planned fixes for the fixable defect
+  // classes (overlaps, tight gaps, too-short). CPS-only issues are never
+  // timing-fixable and don't count toward `fixSkippedCount`.
+  const fixPlan = useMemo(() => planSafeDefectFixes(cueListRows), [cueListRows])
+  const fixSkippedCount = Math.max(
+    0,
+    issueSummary.overlaps + issueSummary.tightGaps + issueSummary.tooShort - fixPlan.length,
+  )
+
+  const handleApplyFixes = useCallback(() => {
+    setFixDialogOpen(false)
+    if (fixPlan.length > 0) onApplyTimingFixes?.(fixPlan)
+  }, [fixPlan, onApplyTimingFixes])
+
   if (extractError) {
     return (
       <div className="flex items-center justify-center h-full">
@@ -854,6 +879,19 @@ export function WaveformEditor({
           {t('waveform.issues_button', { count: issueSummary.total })}
         </button>
       )}
+
+      {editingEnabled && onApplyTimingFixes && fixPlan.length > 0 && (
+        <button
+          type="button"
+          data-testid="fix-defects-open"
+          onClick={() => setFixDialogOpen(true)}
+          className="flex items-center gap-1.5 px-2.5 py-1.5 rounded text-xs font-medium border bg-surface text-accent border-accent-dim"
+          title={t('waveform.fix.button_tooltip')}
+        >
+          <Wrench size={12} aria-hidden="true" />
+          {t('waveform.fix.button', { count: fixPlan.length })}
+        </button>
+      )}
     </div>
   )
 
@@ -923,8 +961,15 @@ export function WaveformEditor({
         />
       )}
 
-      <WaveformHotkeys enabled={isReady && !helpOpen} onAction={handleAction} />
+      <WaveformHotkeys enabled={isReady && !helpOpen && !fixDialogOpen} onAction={handleAction} />
       <WaveformShortcutHelp open={helpOpen} onClose={() => setHelpOpen(false)} />
+      <WaveformFixDefectsDialog
+        open={fixDialogOpen}
+        fixes={fixPlan}
+        skippedCount={fixSkippedCount}
+        onApply={handleApplyFixes}
+        onClose={() => setFixDialogOpen(false)}
+      />
     </div>
   )
 }

--- a/frontend/src/components/editor/waveform/WaveformFixDefectsDialog.tsx
+++ b/frontend/src/components/editor/waveform/WaveformFixDefectsDialog.tsx
@@ -1,0 +1,135 @@
+/**
+ * WaveformFixDefectsDialog — preview + confirm for the one-click
+ * "fix safe defects" batch (waveform-expansion roadmap, Phase 1).
+ *
+ * Lists every proposed timing fix (overlap trim / tight-gap widening /
+ * too-short extension) as a before → after row so the editor can inspect
+ * the batch before it touches the cue list. Applying is a single atomic
+ * edit on the modal's undo stack. Closes on ESC, X, or backdrop click —
+ * same interaction contract as WaveformShortcutHelp.
+ */
+
+import { X, Wrench } from 'lucide-react'
+import { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import type { CueTimingFix } from './fixSafeDefects'
+
+export interface WaveformFixDefectsDialogProps {
+  open: boolean
+  fixes: CueTimingFix[]
+  /** Defects detected in the file but not safely auto-fixable. */
+  skippedCount: number
+  onApply: () => void
+  onClose: () => void
+}
+
+/** "M:SS.mmm" — compact but unambiguous for sub-second timing diffs. */
+function fmtTime(sec: number): string {
+  const total = Math.max(0, Math.round(sec * 1000))
+  const ms = total % 1000
+  const s = Math.floor(total / 1000) % 60
+  const m = Math.floor(total / 60_000)
+  return `${m}:${String(s).padStart(2, '0')}.${String(ms).padStart(3, '0')}`
+}
+
+export function WaveformFixDefectsDialog({
+  open,
+  fixes,
+  skippedCount,
+  onApply,
+  onClose,
+}: WaveformFixDefectsDialogProps) {
+  const { t } = useTranslation('editor')
+
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation()
+        onClose()
+      }
+    }
+    window.addEventListener('keydown', onKey, true)
+    return () => window.removeEventListener('keydown', onKey, true)
+  }, [open, onClose])
+
+  if (!open) return null
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="waveform-fix-defects-title"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      onClick={onClose}
+    >
+      <div
+        className="bg-secondary border border-border rounded-md shadow-xl w-[min(560px,92vw)] max-h-[85vh] overflow-y-auto"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-start justify-between gap-3 p-4 border-b border-border">
+          <div>
+            <h2
+              id="waveform-fix-defects-title"
+              className="text-base font-semibold text-primary"
+            >
+              {t('waveform.fix.title')}
+            </h2>
+            <p className="text-xs text-muted mt-1">
+              {t('waveform.fix.subtitle', { count: fixes.length })}
+              {skippedCount > 0 && ` ${t('waveform.fix.skipped', { count: skippedCount })}`}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label={t('waveform.fix.cancel')}
+            className="text-muted hover:text-primary transition-colors p-1 rounded"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        <ul className="p-4 flex flex-col gap-1.5" data-testid="fix-defects-list">
+          {fixes.map((fix) => (
+            <li
+              key={`${fix.cueIndex}-${fix.kind}`}
+              className="flex items-center justify-between gap-3 text-xs"
+            >
+              <span className="text-primary">
+                #{fix.cueIndex + 1} · {t(`waveform.fix.kind_${fix.kind}`)}
+              </span>
+              <span className="font-mono text-[11px] text-muted whitespace-nowrap">
+                {fmtTime(fix.before.start)}–{fmtTime(fix.before.end)}
+                {' → '}
+                <span className="text-accent">
+                  {fmtTime(fix.after.start)}–{fmtTime(fix.after.end)}
+                </span>
+              </span>
+            </li>
+          ))}
+        </ul>
+
+        <div className="flex items-center justify-end gap-2 p-4 border-t border-border">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-3 py-1.5 rounded text-xs font-medium bg-surface text-primary border border-border"
+          >
+            {t('waveform.fix.cancel')}
+          </button>
+          <button
+            type="button"
+            onClick={onApply}
+            data-testid="fix-defects-apply"
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded text-xs font-medium bg-accent-bg text-accent border border-accent-dim"
+          >
+            <Wrench size={12} />
+            {t('waveform.fix.apply', { count: fixes.length })}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/editor/waveform/__tests__/fixSafeDefects.test.ts
+++ b/frontend/src/components/editor/waveform/__tests__/fixSafeDefects.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Unit tests for `planSafeDefectFixes` — the pure planner behind the
+ * one-click "fix safe defects" batch.
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { planSafeDefectFixes, type FixableCue } from '../fixSafeDefects'
+import { detectGapsAndOverlaps } from '../gapOverlap'
+
+/** Short readable text — never trips the CPS guard at ≥0.7 s. */
+const TXT = 'Hallo!'
+
+function cue(start: number, end: number, text = TXT): FixableCue {
+  return { start, end, text }
+}
+
+/** Apply fixes to a copy of the cue list. */
+function applied(cues: FixableCue[], fixes = planSafeDefectFixes(cues)): FixableCue[] {
+  const out = cues.map((c) => ({ ...c }))
+  for (const f of fixes) {
+    out[f.cueIndex].start = f.after.start
+    out[f.cueIndex].end = f.after.end
+  }
+  return out
+}
+
+describe('planSafeDefectFixes', () => {
+  it('returns no fixes for a clean file', () => {
+    const cues = [cue(0, 1.5), cue(2, 3.5), cue(4, 5.5)]
+    expect(planSafeDefectFixes(cues)).toEqual([])
+  })
+
+  it('trims the earlier cue of a small overlap to the target gap', () => {
+    const cues = [cue(0, 2.05), cue(2, 4)]
+    const fixes = planSafeDefectFixes(cues)
+
+    expect(fixes).toHaveLength(1)
+    expect(fixes[0]).toMatchObject({ cueIndex: 0, kind: 'overlap' })
+    expect(fixes[0].after.end).toBeCloseTo(2 - 0.12, 5)
+    // The batch fully resolves the defect set.
+    const after = applied(cues, fixes)
+    const det = detectGapsAndOverlaps(after.map((c, i) => ({ id: String(i), ...c })))
+    expect(det.overlaps).toHaveLength(0)
+    expect(det.tightGaps).toHaveLength(0)
+  })
+
+  it('widens a tight gap', () => {
+    const cues = [cue(0, 1.98), cue(2, 4)]
+    const fixes = planSafeDefectFixes(cues)
+
+    expect(fixes).toHaveLength(1)
+    expect(fixes[0]).toMatchObject({ cueIndex: 0, kind: 'tightGap' })
+    expect(fixes[0].after.end).toBeCloseTo(1.88, 5)
+  })
+
+  it('skips an overlap fix that would make the earlier cue too short', () => {
+    // Cue 0 is only 0.75 s; trimming 0.17 s would drop it below 0.7 s.
+    const cues = [cue(0, 0.75), cue(0.7, 2)]
+    expect(planSafeDefectFixes(cues)).toEqual([])
+  })
+
+  it('skips an overlap fix that would push CPS into too-fast', () => {
+    // Long text over 1.5 s ⇒ trimming to ~0.98 s would exceed 21 CPS.
+    const longText = 'Das ist ein wirklich sehr langer Beispielsatz!' // 46 chars
+    const cues = [cue(0, 1.6, longText), cue(1.5, 3)]
+    expect(planSafeDefectFixes(cues)).toEqual([])
+  })
+
+  it('never touches layered/contained ASS cues (signs, karaoke)', () => {
+    // Same start (layered) and full containment.
+    const layered = [cue(0, 2), cue(0, 5)]
+    expect(planSafeDefectFixes(layered)).toEqual([])
+    const contained = [cue(0, 5), cue(1, 3)]
+    expect(planSafeDefectFixes(contained)).toEqual([])
+  })
+
+  it('extends a too-short cue to the minimum display window', () => {
+    const cues = [cue(0, 0.3), cue(5, 6)]
+    const fixes = planSafeDefectFixes(cues)
+
+    expect(fixes).toHaveLength(1)
+    expect(fixes[0]).toMatchObject({ cueIndex: 0, kind: 'tooShort' })
+    expect(fixes[0].after.end).toBeCloseTo(0.7, 5)
+  })
+
+  it('skips a too-short extension when the next cue is in the way', () => {
+    const cues = [cue(0, 0.3), cue(0.5, 2)]
+    const fixes = planSafeDefectFixes(cues)
+    expect(fixes.filter((f) => f.kind === 'tooShort')).toEqual([])
+  })
+
+  it('ignores too-short cues without text', () => {
+    const cues = [cue(0, 0.2, '   '), cue(5, 6)]
+    expect(planSafeDefectFixes(cues)).toEqual([])
+  })
+
+  it('combines independent fixes of different kinds in one batch', () => {
+    // Cue 0 gets a too-short extension; cue 1 overlaps cue 2 and gets an
+    // overlap trim. Both land in the same plan, sorted by cue index.
+    const cues = [cue(0, 0.4), cue(5, 7.05, TXT), cue(7, 9)]
+    const fixes = planSafeDefectFixes(cues)
+
+    expect(fixes).toHaveLength(2)
+    expect(fixes[0]).toMatchObject({ cueIndex: 0, kind: 'tooShort' })
+    expect(fixes[1]).toMatchObject({ cueIndex: 1, kind: 'overlap' })
+  })
+
+  it('reports fixes against original indices for an unsorted input list', () => {
+    const cues = [cue(5, 7.05), cue(0, 1), cue(7, 9)]
+    const fixes = planSafeDefectFixes(cues)
+
+    expect(fixes).toHaveLength(1)
+    expect(fixes[0].cueIndex).toBe(0) // the 5–7.05 cue, index 0 in input order
+    expect(fixes[0].kind).toBe('overlap')
+  })
+
+  it('applying the batch leaves no fixable defects behind (property)', () => {
+    const cues = [
+      cue(0, 1.02), // tight gap to next
+      cue(1.1, 2.5),
+      cue(2.4, 3.6), // overlapped by prev
+      cue(4, 4.2), // too short
+      cue(6, 7),
+    ]
+    const fixes = planSafeDefectFixes(cues)
+    expect(fixes.length).toBeGreaterThan(0)
+
+    const after = applied(cues, fixes)
+    // Re-planning on the fixed list must be a no-op.
+    expect(planSafeDefectFixes(after)).toEqual([])
+  })
+})

--- a/frontend/src/components/editor/waveform/fixSafeDefects.ts
+++ b/frontend/src/components/editor/waveform/fixSafeDefects.ts
@@ -1,0 +1,145 @@
+/**
+ * fixSafeDefects — plan one-click timing fixes for the "safe" defect classes
+ * the waveform editor already detects: overlaps, tight gaps and too-short
+ * cues (waveform-expansion roadmap, Phase 1 last open item).
+ *
+ * "Safe" means a fix is only proposed when it fully resolves the defect
+ * WITHOUT creating a new one:
+ *   - Overlaps / tight gaps are resolved by shortening the earlier cue's end
+ *     to leave `targetGapMs` before the next cue — but only if the shortened
+ *     cue keeps a readable window (≥ minDisplaySec for text cues) and does
+ *     not become too fast to read (CPS ≤ warnMax).
+ *   - Too-short cues are extended to `minDisplaySec` — but only if there is
+ *     room before the next cue (again keeping `targetGapMs`).
+ * Anything that cannot be fixed under these constraints is skipped and left
+ * for manual editing. Pure module: no React, no wavesurfer.
+ *
+ * Text is never modified; only cue start/end timings (and in fact only ends —
+ * starts are audio-sync anchors and are never moved).
+ */
+
+import { classifyReadingSpeed, CPS_WARN_MAX, MIN_DISPLAY_SEC } from './readingSpeed'
+
+export interface FixableCue {
+  /** Start time in seconds. */
+  start: number
+  /** End time in seconds. */
+  end: number
+  text: string
+}
+
+export type SafeDefectKind = 'overlap' | 'tightGap' | 'tooShort'
+
+export interface CueTimingFix {
+  /** 0-based index into the original (unsorted) cue list. */
+  cueIndex: number
+  kind: SafeDefectKind
+  before: { start: number; end: number }
+  after: { start: number; end: number }
+}
+
+export interface FixSafeDefectsOptions {
+  /** Gap (ms) at or below which an inter-cue gap counts as a defect. Default 80. */
+  gapToleranceMs?: number
+  /** Gap (ms) fixes aim for between cues. Must exceed gapToleranceMs. Default 120. */
+  targetGapMs?: number
+  /** Minimum on-screen window (s) for cues with text. Default MIN_DISPLAY_SEC. */
+  minDisplaySec?: number
+  /** CPS above which a shortened cue would become unreadable. Default CPS_WARN_MAX. */
+  cpsWarnMax?: number
+  /** Minimum duration (s) kept on text-free cues when shortening. Default 0.1. */
+  minBareDurationSec?: number
+}
+
+const DEFAULT_GAP_TOLERANCE_MS = 80
+const DEFAULT_TARGET_GAP_MS = 120
+const DEFAULT_MIN_BARE_DURATION_SEC = 0.1
+
+/** Round to whole milliseconds so float noise can't produce 79.999 ms gaps. */
+function roundMs(sec: number): number {
+  return Math.round(sec * 1000) / 1000
+}
+
+/**
+ * Compute the list of safe, fully-resolving timing fixes for `cues`.
+ * The returned fixes reference cues by their index in the input list and
+ * are internally consistent: applying all of them together neither leaves
+ * the targeted defects in place nor introduces new overlaps/tight gaps.
+ */
+export function planSafeDefectFixes(
+  cues: readonly FixableCue[],
+  opts: FixSafeDefectsOptions = {},
+): CueTimingFix[] {
+  const gapTolSec = (opts.gapToleranceMs ?? DEFAULT_GAP_TOLERANCE_MS) / 1000
+  const targetGapSec = Math.max(
+    (opts.targetGapMs ?? DEFAULT_TARGET_GAP_MS) / 1000,
+    gapTolSec + 0.001,
+  )
+  const minDisplaySec = opts.minDisplaySec ?? MIN_DISPLAY_SEC
+  const cpsWarnMax = opts.cpsWarnMax ?? CPS_WARN_MAX
+  const minBareSec = opts.minBareDurationSec ?? DEFAULT_MIN_BARE_DURATION_SEC
+
+  // Work on a mutable copy sorted by start (same ordering the detector uses)
+  // so later checks see the effect of earlier fixes.
+  const working = cues.map((c, i) => ({ index: i, start: c.start, end: c.end, text: c.text }))
+  working.sort((a, b) => a.start - b.start || a.end - b.end)
+
+  const fixes: CueTimingFix[] = []
+
+  const isSafeDuration = (cue: { start: number; text: string }, newEnd: number): boolean => {
+    const dur = newEnd - cue.start
+    if (cue.text.trim().length === 0) return dur >= minBareSec
+    if (dur < minDisplaySec) return false
+    const rs = classifyReadingSpeed(cue.text, cue.start, newEnd, { warnMax: cpsWarnMax })
+    return rs.cps !== null && rs.cps <= cpsWarnMax
+  }
+
+  // Pass 1 — overlaps and tight gaps: shorten the earlier cue's end.
+  for (let i = 0; i < working.length - 1; i++) {
+    const prev = working[i]
+    const next = working[i + 1]
+    const gap = next.start - prev.end
+    if (gap > gapTolSec) continue
+
+    // Layered/contained cues (same start, or next ends inside prev) are a
+    // deliberate ASS pattern — signs, karaoke, top+bottom dialogue. Never
+    // "fix" those; only trim genuine sequential collisions.
+    if (next.start <= prev.start || next.end <= prev.end) continue
+
+    const kind: SafeDefectKind = gap < 0 ? 'overlap' : 'tightGap'
+    const newEnd = roundMs(next.start - targetGapSec)
+    if (newEnd >= prev.end) continue // would lengthen — not this defect's fix
+    if (!isSafeDuration(prev, newEnd)) continue
+
+    fixes.push({
+      cueIndex: prev.index,
+      kind,
+      before: { start: prev.start, end: prev.end },
+      after: { start: prev.start, end: newEnd },
+    })
+    prev.end = newEnd
+  }
+
+  // Pass 2 — too-short cues: extend the end to the minimum display window,
+  // as long as the target gap to the (possibly already fixed) next cue holds.
+  for (let i = 0; i < working.length; i++) {
+    const cue = working[i]
+    if (cue.text.trim().length === 0) continue
+    if (cue.end - cue.start >= minDisplaySec) continue
+
+    const newEnd = roundMs(cue.start + minDisplaySec)
+    const next = working[i + 1]
+    if (next && newEnd > next.start - targetGapSec) continue
+
+    fixes.push({
+      cueIndex: cue.index,
+      kind: 'tooShort',
+      before: { start: cue.start, end: cue.end },
+      after: { start: cue.start, end: newEnd },
+    })
+    cue.end = newEnd
+  }
+
+  fixes.sort((a, b) => a.cueIndex - b.cueIndex)
+  return fixes
+}

--- a/frontend/src/i18n/locales/de/editor.json
+++ b/frontend/src/i18n/locales/de/editor.json
@@ -150,7 +150,19 @@
     "issues_tooltip": "{{overlaps}} Überlappungen · {{gaps}} enge Abstände · {{fast}} zu schnell · {{short}} zu kurz — klicken, um zum ersten zu springen",
     "extracting_audio": "Audio wird extrahiert…",
     "drawing": "Wellenform wird gezeichnet…",
-    "loading_hint": "Bei langen Folgen kann das einen Moment dauern — das Audio wird aus dem Video extrahiert und die Welle gezeichnet."
+    "loading_hint": "Bei langen Folgen kann das einen Moment dauern — das Audio wird aus dem Video extrahiert und die Welle gezeichnet.",
+    "fix": {
+      "title": "Sichere Defekte beheben",
+      "subtitle": "{{count}} sichere Timing-Korrekturen vorgeschlagen — prüfen und als eine rückgängig machbare Änderung anwenden.",
+      "skipped": "{{count}} Defekte sind nicht sicher automatisch behebbar und bleiben zur manuellen Bearbeitung.",
+      "kind_overlap": "Überlappung — frühere Cue kürzen",
+      "kind_tightGap": "Enger Abstand — vergrößern",
+      "kind_tooShort": "Zu kurz — verlängern",
+      "apply": "{{count}} Korrekturen anwenden",
+      "cancel": "Abbrechen",
+      "button": "Fix ({{count}})",
+      "button_tooltip": "Sichere Timing-Korrekturen prüfen und anwenden (Überlappungen, enge Abstände, zu kurze Cues)"
+    }
   },
   "sync_preview": {
     "before_start": "Vor Start",
@@ -207,7 +219,8 @@
     "convert_failed": "Konvertierung fehlgeschlagen",
     "convert_button": "Konvertieren",
     "loading_editor": "Editor wird geladen…",
-    "loading_content": "Inhalt wird geladen…"
+    "loading_content": "Inhalt wird geladen…",
+    "fix_defects_applied": "{{count}} Timing-Korrekturen angewendet"
   },
   "enable_translation_modal": {
     "title": "Übersetzung aktivieren",

--- a/frontend/src/i18n/locales/en/editor.json
+++ b/frontend/src/i18n/locales/en/editor.json
@@ -150,7 +150,19 @@
     "issues_tooltip": "{{overlaps}} overlaps · {{gaps}} tight gaps · {{fast}} too fast · {{short}} too short — click to jump to the first",
     "extracting_audio": "Extracting audio…",
     "drawing": "Drawing waveform…",
-    "loading_hint": "For long episodes this can take a moment — extracting the audio from the video and drawing the wave."
+    "loading_hint": "For long episodes this can take a moment — extracting the audio from the video and drawing the wave.",
+    "fix": {
+      "title": "Fix safe defects",
+      "subtitle": "{{count}} safe timing fixes proposed — review, then apply as one undoable edit.",
+      "skipped": "{{count}} defects are not safely auto-fixable and stay for manual editing.",
+      "kind_overlap": "Overlap — trim earlier cue",
+      "kind_tightGap": "Tight gap — widen",
+      "kind_tooShort": "Too short — extend",
+      "apply": "Apply {{count}} fixes",
+      "cancel": "Cancel",
+      "button": "Fix ({{count}})",
+      "button_tooltip": "Preview and apply safe timing fixes (overlaps, tight gaps, too-short cues)"
+    }
   },
   "sync_preview": {
     "before_start": "Before Start",
@@ -207,7 +219,8 @@
     "convert_failed": "Convert failed",
     "convert_button": "Convert",
     "loading_editor": "Loading editor…",
-    "loading_content": "Loading content…"
+    "loading_content": "Loading content…",
+    "fix_defects_applied": "{{count}} timing fixes applied"
   },
   "enable_translation_modal": {
     "title": "Enable Translation",


### PR DESCRIPTION
## What

Implements the last open item from Phase 1 of the waveform expansion roadmap: **one-click "fix safe defects" with preview**, built directly on the existing `gapOverlap.ts` / `issueSummary.ts` detection.

- **`fixSafeDefects.ts`** (pure planner, unit-tested): proposes fully-resolving timing fixes for the three fixable defect classes:
  - *Overlap* → trim the earlier cue's end to leave a 120 ms gap
  - *Tight gap* (< 80 ms) → same widening
  - *Too short* (< 0.7 s with text) → extend the end to the minimum display window
- **Safety guards** — a fix is only proposed when it cannot create a new defect:
  - shortened cues keep ≥ 0.7 s display window and stay under the 21-CPS too-fast ceiling
  - extensions keep the target gap to the next cue
  - **layered/contained ASS cues (signs, karaoke, top+bottom dialogue) are never touched**
  - starts are never moved (audio-sync anchors); only ends change, text never
  - anything not safely fixable is skipped and reported as "left for manual editing"
- **Preview dialog**: toolbar `Fix (n)` button (only when unlocked) opens a per-cue before→after list with the defect kind; Apply/Cancel.
- **Atomic undo**: the whole batch is one entry on the waveform undo stack — one Undo restores the pre-batch content.
- The cached `subtitle-parse` query is patched after applying, so the regions, defect lanes and the issue chip reflect the fixed timings immediately instead of staying stale until save.
- EN + DE translations.

## Testing

- 12 new planner unit tests, including a property-style test (re-planning after applying a batch is a no-op) and guards (CPS ceiling, too-short trim rejection, layered-cue protection, unsorted input indices)
- All 191 editor tests green, `tsc -b` clean, no new ESLint errors

## Notes

- The existing server-side quick fixes (Tools → Overlaps/Timing) stay untouched; this is the interactive, preview-first path inside the waveform editor.
- Known limitation (same as existing single-cue edits): Undo restores the text content but the patched parse cache keeps the fixed timings until save/reload.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4Ddyni8nZwS5M9pEzMMdZ)_