### PR TITLE
docs(roadmap): rewrite around consolidation, transparency, and AI guardrails

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,63 +1,201 @@
 # Sublarr — Roadmap
 
-> The current release is **v1.0.0**. This page describes direction, not a
+> The current release line is **v1.9.x**. This page describes direction, not a
 > commitment — items may shift, merge, or drop. The full release history lives
 > in the [CHANGELOG](CHANGELOG.md).
 
 ---
 
-## ✅ v1.0.0 — Stable Release
+## Where Sublarr stands
 
-Sublarr 1.0 marks the point where the core subtitle-management pipeline is
-considered stable for everyday use.
+The core pipeline — search, scoring, download, *arr integration, standalone
+mode, subtitle tooling — has been stable since 1.0 and has grown steadily
+through the 1.x line. Sublarr is now leaving the pure "feature phase": the
+most-requested capabilities either exist, or exist as open pull requests.
 
-**What's stable**
+The next chapter is therefore **not 50 new features**. It is finishing,
+surfacing, and documenting what is already built — with four themes:
+**transparency, monitoring, extensibility, and developer experience** — on top
+of an uncompromising reliability baseline.
 
-- **Subtitle search & download** — 21 providers + embedded extraction, parallel
-  search, per-provider circuit breakers, API-budget-aware key pooling
-- **ASS-first scoring** — format / dialect / sync-quality / uploader-trust
-  scoring with transparent per-component breakdowns
-- **Language profiles** — `mustContain` / `mustNotContain`, cutoff, audioExclude,
-  per-series/film overrides
-- **\*arr & media-server integration** — Sonarr/Radarr webhooks, multi-instance,
-  Jellyfin/Emby/Plex/Kodi library refresh, AniDB absolute-order handling
-- **Standalone mode** — filesystem watching + NFO metadata, no *arr required
-- **Subtitle tools** — Aegisub-class waveform editor, ffsubsync/alass sync,
-  format conversion, post-processing pipeline, batch OCR, safe stream removal
-- **Wanted & automation** — event-driven scanning, APScheduler-backed job admin
-  (run-now / pause / resume / edit-trigger / history), upgrade system
-- **Operations** — PostgreSQL & Redis support, Prometheus metrics, structured
-  JSON logging, OpenAPI/Swagger at `/api/docs`, multi-arch Docker (amd64+arm64),
-  Unraid Community Applications templates
-- **Security** — path-traversal guards on all file endpoints, SSRF validation,
-  ZIP-bomb/ZIP-slip protection, subtitle sanitization (Lua/HTML stripping),
-  bcrypt auth + rate limiting, hardened CSP, atomic subtitle writes
+## Guiding principles
 
-**Experimental in 1.0**
-
-- **LLM translation** (Ollama / DeepL / Google / LibreTranslate / OpenAI-compatible)
-  remains experimental — quality varies by model, language pair, and content.
-  Disabled by default; EN→DE anime is the best-tested path.
+1. **Reliability before features.** A subtitle manager must never damage a
+   library. Data-integrity bugs preempt all feature work (see #156, #159).
+2. **A deterministic, explainable core.** Scoring and selection stay
+   rule-based and reproducible. Every automatic decision must be inspectable
+   after the fact.
+3. **Quality over quantity.** Prefer consolidating existing mechanisms over
+   adding parallel ones. New configuration surface needs to earn its
+   maintenance cost.
+4. **AI assists, it never acts.** AI features explain, flag, and suggest —
+   they never modify files or influence scores on their own (see
+   [AI direction](#ai-direction) below).
 
 ---
 
-## 🔭 Beyond 1.0
+## 🧱 Now — Consolidation
 
-Direction for the 1.x line, roughly in priority order. Concrete scope is decided
-per release.
+Roughly in priority order. Several items are open PRs that need review,
+rebasing, and merge coordination rather than new code.
 
-- **Reliability & polish** — continued hardening of the most-used paths, edge-case
-  fixes surfaced by real-world libraries, and test-coverage growth
-- **Provider maintenance** — keep existing providers working as upstream APIs and
-  sites change; add high-value providers on request
-- **Performance at scale** — smoother behaviour on very large libraries
-  (500+ series), faster scans, leaner resource use
-- **Translation maturity** — improving translation quality and reliability until
-  it can graduate from "experimental"
-- **Quality-of-life UI** — ongoing accessibility, mobile, and workflow
-  improvements; organic migration of legacy inline styles to the design-token system
-- **Community-requested features** — prioritised from GitHub Issues / Discussions
-  and Discord feedback
+### Data integrity first
+
+- **Ungated remux in the wanted search** (#159) and **hardlink-aware remux**
+  (#160) — fixed by #171; the top-priority merge.
+- **Repair tool for HI-removal damage** (#156) — promised, still open.
+- **Migration discipline** — unify the diverged Alembic heads (a merge
+  revision ships with the decision-log PR) so startup auto-upgrade works
+  reliably again, and keep the chain linear from here on.
+
+### Transparency: the decision log stack
+
+Answering *"why was exactly this subtitle chosen?"* end-to-end:
+
+- **Decision log** (#172) — record the full selection pipeline per search
+  (provider skips/hits, filter funnel with per-candidate rejection reasons,
+  download attempts, final pick) and expose it in History and Wanted.
+- **Score breakdown everywhere** (#173) — persist the per-component breakdown
+  and surface it consistently; no score points outside the breakdown.
+- **History reasons, rollback & dry run** (#170) — "why is this entry here"
+  column, one-click rollback, and a wanted **dry-run preview** (what *would*
+  Sublarr do, without touching disk or DB).
+
+Follow-ups once landed: retention/pruning for stored decision logs, docs.
+
+### Profiles & scoring rules — then freeze
+
+The "different strategies for anime / movies / TV" request, solved with
+profile- and rule-mechanics in the proven *arr style rather than a generic
+rule engine:
+
+- **Per-profile provider selection + scoring presets** (#168)
+- **Release-group tier ranking** (#164)
+- **User-defined regex scoring rules** (#166) — Sonarr-release-profile-style
+- **Per-series format requirement (ASS-only)** (#169)
+
+After these land, rule mechanics are intentionally **frozen**: global weights,
+presets, tiers, regex rules, fansub preferences and the penalty pipeline
+already interact — the decision log exists precisely to keep that debuggable.
+New rule surface only when decision logs demonstrate a real, recurring need.
+
+### Monitoring in the app
+
+- **Library & provider health dashboard** (#170) — missing/failed/unmatched
+  totals plus per-provider health (circuit-breaker state ⋈ hit rate) as an
+  in-app `/health` page; no Grafana required.
+- Follow-up: surface queue depths (whisper, translation) on the same page.
+- Historical trends (success rate over time, latency) stay in the bundled
+  Grafana dashboards (`monitoring/grafana`) — the app shows *state*, Grafana
+  shows *history*.
+
+---
+
+## 🔭 Next — Extensibility & developer experience
+
+### Integrations & API
+
+Outgoing webhooks (HMAC-signed, retried), a machine-readable event catalog,
+WebSockets, health/statistics endpoints and OpenAPI already exist. Remaining:
+
+- **Generated event reference** — the event catalog
+  (`backend/events/catalog.py`) is the single source of truth; generate the
+  public event/payload documentation from it instead of writing it by hand.
+- **Wanted list export** (#175) — CSV/JSON export for external tooling.
+- Explicit non-goal: **SSE**. WebSockets already cover live updates; a second
+  streaming channel is maintenance without benefit.
+
+### Extensibility
+
+- **Custom HTTP/JSON provider** (#165) — connect private subtitle servers or
+  any REST API through pure configuration, no plugin code required. Expected
+  to absorb much of the raw "provider plugin" demand.
+- **Plugin system: prove it before growing it.** Loader, manifest validation,
+  hot reload, template and marketplace routes exist — but the official
+  registry is empty. Before extending plugins to translators/notifiers/sync
+  modules: publish real provider plugins, write the tutorial, fill the
+  registry. If the custom HTTP provider satisfies the demand instead, keep
+  the plugin surface deliberately small.
+- Plugins run unsandboxed (same trust model as Bazarr) — any marketplace
+  promotion must state this prominently. This is a security posture, not a
+  feature gap.
+
+### Developer experience
+
+- Generated event reference (above) and the documented custom-provider
+  contract (`docs/CUSTOM_PROVIDER_API.md`, #165).
+- A plugin tutorial that goes beyond the bundled template.
+- An architecture overview diagram for contributors.
+- Explicit non-goal: hand-maintained **SDKs** — the OpenAPI spec is the
+  contract; client code can be generated from it.
+
+---
+
+## 🤖 AI direction
+
+AI stays a complement, never the core. The role that fits Sublarr is an
+**explanation and suggestion layer on top of the deterministic pipeline** —
+making the app more understandable and the tools more accessible, without
+ever touching files or scores on its own.
+
+### Guardrails (non-negotiable)
+
+1. **AI reads, AI never writes.** Output is a badge, a hint, or a diff
+   proposal the user applies — never an automatic file modification. (#156 is
+   the standing reminder of why.)
+2. **Local-first.** Ollama by default; cloud backends opt-in, routed through
+   the existing cost tracker and prompt-safety layer.
+3. **Advisory, never blocking.** A negative AI verdict flags, it never
+   discards — the `dubtitle_verify` pattern.
+4. **No chatbot.** AI results surface in existing UI patterns (badges,
+   tooltips, diff views, modals).
+
+### Candidate features, in order
+
+1. **"Explain this" on the decision log** — turn the structured decision log
+   (#172) into a localized plain-language explanation on demand. Read-only,
+   zero risk, the single best synergy between transparency and AI.
+2. **Subtitle quality badge** — sample ~30 cues per downloaded file; a local
+   LLM rates MT likelihood, OCR artifacts, grammar density, encoding damage →
+   green/yellow/red badge next to the existing MT/trust badges. The upgrade
+   system keeps deciding by its own rules; at most, a red verdict marks the
+   item as wanting an upgrade (the `mt_provisional` pattern: keep + keep
+   seeking).
+3. **OCR review as diffs** — after batch OCR, an LLM pass proposes
+   corrections for suspect lines, shown in the editor's existing diff view;
+   the user applies them.
+4. **Glossary bootstrap** — propose per-series glossary entries (character
+   names, honorifics, recurring terms) for the user to confirm; the most
+   direct lever for graduating LLM translation from "experimental".
+5. **Sync plausibility** — Whisper spot-checks at a few points of the file,
+   flag "likely wrong cut / offset ~1.2 s" with a one-click ffsubsync/alass
+   action.
+6. **Title-match assistant** — LLM as a tie-breaker for ambiguous provider
+   matches (romaji/alternate titles, season collapse) — in **manual search
+   only**, never in the automatic path.
+
+### Explicit AI non-goals
+
+- AI-adjusted scoring — it would destroy the explainability the decision log
+  provides; the score stays deterministic.
+- Fully automatic AI correction pipelines — advisory diffs only.
+- LLM-generated dashboard summaries — the health statistics speak for
+  themselves.
+
+---
+
+## Ongoing
+
+- **Provider maintenance** — keep the 21+ providers working as upstream APIs
+  and sites change; add high-value providers on request.
+- **Performance at scale** — smooth behaviour on very large libraries,
+  faster scans, leaner resource use.
+- **Translation maturity** — improve quality and reliability (glossaries,
+  context windows) until LLM translation can graduate from "experimental".
+- **Quality-of-life UI** — accessibility, mobile, waveform-editor polish,
+  organic migration of legacy styles to the design-token system.
+- **Community-requested features** — prioritised from GitHub
+  Issues/Discussions and Discord feedback.
 
 Have an idea? Open a
 [Discussion](https://github.com/Abrechen2/sublarr/discussions) or

--- a/backend/app.py
+++ b/backend/app.py
@@ -233,6 +233,16 @@ def create_app(testing=False):
                 # weeks: the chain was pinned one revision behind head and
                 # every subsequent migration silently skipped.
                 logger.warning("Alembic auto-upgrade failed (non-fatal): %s", _e, exc_info=True)
+        # ai_quality_results is created idempotently instead of via a migration:
+        # the migration chain currently has diverged heads (upgrade head fails
+        # on them), and a checkfirst create works on both fresh and tracked DBs.
+        # TODO: fold into a real migration once the heads are merged (ROADMAP).
+        try:
+            from db.models.quality import AIQualityResult
+
+            AIQualityResult.__table__.create(bind=sa_db.engine, checkfirst=True)
+        except Exception as _e:
+            logger.warning("Could not ensure ai_quality_results table: %s", _e)
         # Enable SQLite WAL mode if using SQLite (match existing behavior)
         if not settings.database_url or settings.database_url.startswith("sqlite"):
             from sqlalchemy import text

--- a/backend/config_settings.py
+++ b/backend/config_settings.py
@@ -342,6 +342,17 @@ class UISettings(BaseModel):
     # is unavailable.
     dubtitle_verify_on_download: bool = False
 
+    # AI subtitle-quality badge (advisory, experimental). After a download, an
+    # LLM samples ~ai_quality_max_cues cues from the saved sidecar and rates
+    # machine-translation likelihood, OCR artifacts and grammar; the verdict is
+    # shown as a green/yellow/red badge in History. Read-only by design: the
+    # verdict never modifies files and never feeds into scoring or upgrades.
+    # Uses the configured Ollama instance (local-first); ai_quality_model
+    # empty = reuse ollama_model.
+    ai_quality_enabled: bool = False
+    ai_quality_model: str = ""
+    ai_quality_max_cues: int = 30
+
     # Foreign-track cleanup. Destructive (remuxes the MKV with backup-to-trash).
     cleanup_foreign_tracks_default: bool = False
     cleanup_foreign_tracks_keep_und: bool = False

--- a/backend/db/models/__init__.py
+++ b/backend/db/models/__init__.py
@@ -50,7 +50,7 @@ from db.models.providers import (
     ScoringWeights,
     SubtitleDownload,
 )
-from db.models.quality import SubtitleHealthResult
+from db.models.quality import AIQualityResult, SubtitleHealthResult
 from db.models.repair import SubtitleRepair  # noqa: F401
 from db.models.scheduler import JobRun  # noqa: F401
 from db.models.standalone import (
@@ -114,6 +114,7 @@ __all__ = [
     "AnidbMapping",
     # quality
     "SubtitleHealthResult",
+    "AIQualityResult",
     # scheduler
     "JobRun",
     # filter presets

--- a/backend/db/models/quality.py
+++ b/backend/db/models/quality.py
@@ -28,3 +28,30 @@ class SubtitleHealthResult(db.Model):
         Index("idx_health_results_path", "file_path"),
         Index("idx_health_results_score", "score"),
     )
+
+
+class AIQualityResult(db.Model):
+    """Advisory LLM language-quality verdict for a subtitle sidecar file.
+
+    One row per (sidecar path) — re-analysis replaces the previous row.
+    Purely advisory: nothing in the pipeline reads this to make decisions.
+    """
+
+    __tablename__ = "ai_quality_results"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    # Path of the subtitle sidecar that was sampled (not the video file).
+    file_path: Mapped[str] = mapped_column(Text, nullable=False)
+    language: Mapped[str] = mapped_column(Text, default="")
+    # "green" | "yellow" | "red" — derived deterministically from the scores.
+    verdict: Mapped[str] = mapped_column(Text, nullable=False, default="green")
+    # {"machine_translation": 0-3, "ocr_artifacts": 0-3, "grammar": 0-3,
+    #  "encoding_damage": 0-3} — higher is worse.
+    scores_json: Mapped[str] = mapped_column(Text, default="{}")
+    # Short free-text findings from the model (capped list of strings).
+    reasons_json: Mapped[str] = mapped_column(Text, default="[]")
+    model: Mapped[str] = mapped_column(Text, default="")
+    sampled_cues: Mapped[int] = mapped_column(Integer, default=0)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+
+    __table_args__ = (Index("idx_ai_quality_path", "file_path"),)

--- a/backend/db/providers.py
+++ b/backend/db/providers.py
@@ -123,6 +123,14 @@ def record_subtitle_download(
             record_stat(success=True, fmt=fmt, source=provider_name)
         except Exception:
             logger.debug("Could not record download in daily_stats", exc_info=True)
+    # Advisory AI quality spot-check of the saved sidecar (no-op unless
+    # ai_quality_enabled; runs in the background pool; never raises).
+    try:
+        from services.ai_quality import maybe_queue_analysis
+
+        maybe_queue_analysis(file_path, language, fmt)
+    except Exception:
+        logger.debug("Could not queue AI quality analysis", exc_info=True)
     return result
 
 

--- a/backend/db/quality.py
+++ b/backend/db/quality.py
@@ -43,3 +43,36 @@ def get_quality_trends(days: int = 30) -> list:
 def delete_health_results(file_path: str) -> int:
     """Delete all health results for a file path."""
     return _get_repo().delete_health_results(file_path)
+
+
+# ---- AI quality verdicts (advisory) ------------------------------------------
+
+
+def save_ai_quality_result(
+    file_path: str,
+    language: str,
+    verdict: str,
+    scores_json: str,
+    reasons_json: str,
+    model: str,
+    sampled_cues: int,
+) -> dict:
+    """Save the AI quality verdict for a sidecar, replacing any previous row."""
+    return _get_repo().save_ai_quality_result(
+        file_path, language, verdict, scores_json, reasons_json, model, sampled_cues
+    )
+
+
+def get_ai_quality_result(file_path: str):
+    """Get the AI quality verdict for a sidecar path, or None."""
+    return _get_repo().get_ai_quality_result(file_path)
+
+
+def get_ai_quality_results_for_paths(paths: list) -> dict:
+    """Batch-fetch AI verdicts keyed by sidecar path."""
+    return _get_repo().get_ai_quality_results_for_paths(paths)
+
+
+def delete_ai_quality_result(file_path: str) -> int:
+    """Delete AI verdicts for a sidecar path."""
+    return _get_repo().delete_ai_quality_result(file_path)

--- a/backend/db/repositories/quality.py
+++ b/backend/db/repositories/quality.py
@@ -9,7 +9,7 @@ from datetime import UTC, datetime, timedelta
 
 from sqlalchemy import func, select
 
-from db.models.quality import SubtitleHealthResult
+from db.models.quality import AIQualityResult, SubtitleHealthResult
 from db.repositories.base import BaseRepository
 
 logger = logging.getLogger(__name__)
@@ -108,6 +108,74 @@ class QualityRepository(BaseRepository):
                 }
             )
         return trends
+
+    # ---- AI quality verdicts (advisory) --------------------------------------
+
+    def save_ai_quality_result(
+        self,
+        file_path: str,
+        language: str,
+        verdict: str,
+        scores_json: str,
+        reasons_json: str,
+        model: str,
+        sampled_cues: int,
+    ) -> dict:
+        """Save the AI quality verdict for a sidecar, replacing any previous row."""
+        stmt = select(AIQualityResult).where(AIQualityResult.file_path == file_path)
+        for old in self.session.execute(stmt).scalars().all():
+            self.session.delete(old)
+        entry = AIQualityResult(
+            file_path=file_path,
+            language=language,
+            verdict=verdict,
+            scores_json=scores_json,
+            reasons_json=reasons_json,
+            model=model,
+            sampled_cues=sampled_cues,
+            created_at=datetime.now(UTC),
+        )
+        self.session.add(entry)
+        self._commit()
+        return self._to_dict(entry)
+
+    def get_ai_quality_result(self, file_path: str) -> dict | None:
+        """Get the AI quality verdict for a sidecar path, or None."""
+        stmt = (
+            select(AIQualityResult)
+            .where(AIQualityResult.file_path == file_path)
+            .order_by(AIQualityResult.id.desc())
+            .limit(1)
+        )
+        return self._to_dict(self.session.execute(stmt).scalar_one_or_none())
+
+    def get_ai_quality_results_for_paths(self, paths: list[str]) -> dict[str, dict]:
+        """Batch-fetch AI verdicts for a list of sidecar paths.
+
+        Returns:
+            Dict keyed by file_path (paths without a verdict are absent).
+        """
+        if not paths:
+            return {}
+        stmt = (
+            select(AIQualityResult)
+            .where(AIQualityResult.file_path.in_(paths))
+            .order_by(AIQualityResult.id)
+        )
+        results: dict[str, dict] = {}
+        for entry in self.session.execute(stmt).scalars().all():
+            results[entry.file_path] = self._to_dict(entry)
+        return results
+
+    def delete_ai_quality_result(self, file_path: str) -> int:
+        """Delete AI verdicts for a sidecar path. Returns deleted count."""
+        stmt = select(AIQualityResult).where(AIQualityResult.file_path == file_path)
+        entries = self.session.execute(stmt).scalars().all()
+        for entry in entries:
+            self.session.delete(entry)
+        if entries:
+            self._commit()
+        return len(entries)
 
     def delete_health_results(self, file_path: str) -> int:
         """Delete all health results for a file path.

--- a/backend/routes/__init__.py
+++ b/backend/routes/__init__.py
@@ -8,6 +8,7 @@ register_blueprints() which imports and registers all blueprints.
 def register_blueprints(app):
     """Import and register all API blueprints on the Flask app."""
     from routes.activity import bp as activity_bp
+    from routes.ai_quality import bp as ai_quality_bp
     from routes.anidb_mapping import bp as anidb_mapping_bp
     from routes.api_keys import bp as api_keys_bp
     from routes.audio import bp as audio_bp
@@ -60,6 +61,7 @@ def register_blueprints(app):
 
     for blueprint in [
         activity_bp,
+        ai_quality_bp,
         translate_bp,
         providers_bp,
         providers_keys_bp,

--- a/backend/routes/ai_quality.py
+++ b/backend/routes/ai_quality.py
@@ -1,0 +1,142 @@
+"""AI subtitle-quality routes — advisory LLM verdicts for downloaded sidecars.
+
+GET  /api/v1/quality/ai         — fetch the stored verdict for one sidecar path
+POST /api/v1/quality/ai/analyze — queue (re-)analysis of a sidecar (202)
+"""
+
+import logging
+import os
+
+from flask import Blueprint, jsonify, request
+
+from config import get_settings
+from security_utils import is_safe_path
+
+bp = Blueprint("ai_quality", __name__, url_prefix="/api/v1")
+
+logger = logging.getLogger(__name__)
+
+
+@bp.route("/quality/ai", methods=["GET"])
+def get_ai_quality():
+    """Get the stored AI quality verdict for a subtitle sidecar.
+    ---
+    get:
+      security:
+        - apiKeyAuth: []
+      tags:
+        - Quality
+      summary: Get AI quality verdict
+      description: Returns the stored advisory LLM verdict for a subtitle sidecar path, or result null if none exists.
+      parameters:
+        - in: query
+          name: path
+          required: true
+          schema:
+            type: string
+          description: Absolute path of the subtitle sidecar file
+      responses:
+        200:
+          description: Verdict (result is null when not analyzed)
+        400:
+          description: Missing path
+        403:
+          description: Path outside the media directory
+    """
+    path = request.args.get("path", "")
+    if not path:
+        return jsonify({"error": "path parameter required"}), 400
+    if not is_safe_path(path, get_settings().media_path):
+        return jsonify({"error": "Access denied"}), 403
+
+    import json
+
+    from db.quality import get_ai_quality_result
+
+    row = get_ai_quality_result(path)
+    if not row:
+        return jsonify({"result": None})
+    try:
+        scores = json.loads(row.get("scores_json") or "{}")
+        reasons = json.loads(row.get("reasons_json") or "[]")
+    except ValueError:
+        scores, reasons = {}, []
+    return jsonify(
+        {
+            "result": {
+                "verdict": row.get("verdict"),
+                "scores": scores,
+                "reasons": reasons,
+                "model": row.get("model") or "",
+                "sampled_cues": row.get("sampled_cues") or 0,
+                "created_at": row.get("created_at"),
+            }
+        }
+    )
+
+
+@bp.route("/quality/ai/analyze", methods=["POST"])
+def analyze_ai_quality():
+    """Queue AI quality analysis for a subtitle sidecar.
+    ---
+    post:
+      security:
+        - apiKeyAuth: []
+      tags:
+        - Quality
+      summary: Queue AI quality analysis
+      description: Runs the advisory LLM quality check for a sidecar in the background. Requires ai_quality_enabled.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [path]
+              properties:
+                path:
+                  type: string
+                  description: Absolute path of the subtitle sidecar file
+                language:
+                  type: string
+                  description: Language code of the subtitle (used in the prompt)
+      responses:
+        202:
+          description: Analysis queued
+        400:
+          description: Missing path
+        403:
+          description: Path outside the media directory
+        404:
+          description: Sidecar not found
+        503:
+          description: Feature disabled
+    """
+    settings = get_settings()
+    if not getattr(settings, "ai_quality_enabled", False):
+        return jsonify({"error": "AI quality check is disabled"}), 503
+
+    data = request.get_json(silent=True) or {}
+    path = data.get("path", "")
+    language = (data.get("language") or "").strip()
+    if not path:
+        return jsonify({"error": "path required"}), 400
+    if not is_safe_path(path, settings.media_path):
+        return jsonify({"error": "Access denied"}), 403
+    if not os.path.isfile(path):
+        return jsonify({"error": "File not found"}), 404
+
+    from flask import current_app
+
+    from services.background_tasks import submit_background
+
+    app = current_app._get_current_object()
+
+    def _run():
+        with app.app_context():
+            from services.ai_quality import analyze_and_store
+
+            analyze_and_store(path, language)
+
+    submit_background(_run)
+    return jsonify({"status": "queued"}), 202

--- a/backend/routes/blacklist/history.py
+++ b/backend/routes/blacklist/history.py
@@ -123,6 +123,13 @@ def list_history():
         sort_by=sort_by,
         sort_dir=sort_dir,
     )
+    # Attach advisory AI quality verdicts (one batch query; best-effort).
+    try:
+        from services.ai_quality import attach_ai_quality
+
+        attach_ai_quality(result.get("data") or [])
+    except Exception:
+        logger.debug("Could not attach AI quality verdicts", exc_info=True)
     return jsonify(result)
 
 

--- a/backend/services/ai_quality.py
+++ b/backend/services/ai_quality.py
@@ -1,0 +1,314 @@
+"""AI subtitle-quality verdict — advisory LLM spot-check of downloaded sidecars.
+
+Samples a handful of cues from a saved subtitle file, asks the configured
+Ollama instance to rate machine-translation likelihood, OCR artifacts and
+grammar, and stores a green/yellow/red verdict for display in History.
+
+Guardrails (ROADMAP "AI direction" — non-negotiable):
+- Read-only: the verdict never modifies files and never feeds into scoring,
+  selection, or the upgrade system.
+- Advisory: analysis failures are silent (logged at debug) — nothing in the
+  download pipeline waits on or reacts to this module.
+- Local-first: talks only to the configured Ollama URL.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+# Higher is worse, 0-3 per axis. Encoding damage is measured in Python (it is
+# deterministic); the LLM rates only the language-level axes.
+_LLM_AXES = ("machine_translation", "ocr_artifacts", "grammar")
+_ALL_AXES = (*_LLM_AXES, "encoding_damage")
+
+_MAX_CUE_CHARS = 200
+_MAX_CUES_HARD = 60
+_MAX_REASONS = 5
+_MAX_REASON_CHARS = 160
+
+# Mojibake / replacement-character fingerprints for the encoding axis.
+_ENCODING_DAMAGE_RE = re.compile(r"�|Ã[\x80-\xbf]|â€[\x9c\x9d\x98\x99\x93\x94\xa6]")
+
+_SYSTEM_PROMPT = (
+    "You are a subtitle quality inspector. You receive sampled subtitle lines "
+    "in language '{language}'. Rate each axis from 0 (none) to 3 (severe):\n"
+    "- machine_translation: does the text read like unedited machine "
+    "translation (wrong idioms, literal word order, inconsistent pronouns)?\n"
+    "- ocr_artifacts: OCR-typical damage (l/I and rn/m confusions, stray "
+    "pipes, broken diacritics, merged words)?\n"
+    "- grammar: grammar/spelling errors a native speaker would notice?\n"
+    "Reply with ONLY a JSON object, no prose:\n"
+    '{{"machine_translation": 0, "ocr_artifacts": 0, "grammar": 0, '
+    '"reasons": ["short finding", "..."]}}\n'
+    "reasons: at most 3 short findings quoting a problematic phrase; empty "
+    "list if the text is clean. Never invent problems."
+)
+
+
+def sidecar_path_for(video_path: str, language: str, fmt: str) -> str:
+    """Derive the subtitle sidecar path the way the rest of the app does."""
+    base, _ = os.path.splitext(video_path)
+    return f"{base}.{language}.{fmt}"
+
+
+def sample_cues(subtitle_path: str, max_cues: int) -> list[str]:
+    """Load a subtitle file and return up to max_cues evenly-spaced plaintext cues."""
+    import pysubs2
+
+    subs = pysubs2.load(subtitle_path)
+    texts: list[str] = []
+    seen: set[str] = set()
+    for ev in subs.events:
+        if getattr(ev, "is_comment", False):
+            continue
+        text = ev.plaintext.replace("\n", " ").strip()
+        if len(text) < 3 or text in seen:
+            continue
+        seen.add(text)
+        texts.append(text[:_MAX_CUE_CHARS])
+
+    max_cues = max(1, min(int(max_cues), _MAX_CUES_HARD))
+    if len(texts) <= max_cues:
+        return texts
+    step = len(texts) / max_cues
+    return [texts[int(i * step)] for i in range(max_cues)]
+
+
+def _measure_encoding_damage(cues: list[str]) -> int:
+    """Deterministic 0-3 rating of mojibake/replacement-char density."""
+    if not cues:
+        return 0
+    damaged = sum(1 for c in cues if _ENCODING_DAMAGE_RE.search(c))
+    ratio = damaged / len(cues)
+    if ratio >= 0.3:
+        return 3
+    if damaged >= 2 and ratio >= 0.1:
+        return 2
+    if damaged:
+        return 1
+    return 0
+
+
+def _call_ollama(cues: list[str], language: str, settings) -> tuple[dict, str]:
+    """Single Ollama /api/chat call. Returns (parsed_json, model_name).
+
+    Raises on transport errors / unparseable output — the caller treats any
+    exception as "no verdict".
+    """
+    from translation.prompt_safety import escape_for_prompt
+
+    model = (getattr(settings, "ai_quality_model", "") or settings.ollama_model).strip()
+    numbered = "\n".join(f"{i + 1}. {escape_for_prompt(c)}" for i, c in enumerate(cues))
+    payload = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": _SYSTEM_PROMPT.format(language=language or "unknown")},
+            {"role": "user", "content": numbered},
+        ],
+        "stream": False,
+        "format": "json",
+        "options": {"temperature": 0, "num_predict": 400},
+    }
+    resp = requests.post(
+        f"{settings.ollama_url}/api/chat",
+        json=payload,
+        timeout=getattr(settings, "request_timeout", 90),
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    if "error" in data:
+        raise RuntimeError(f"Ollama error: {data['error']}")
+    content = (data.get("message") or {}).get("content", "")
+    return _parse_verdict_json(content), model
+
+
+def _parse_verdict_json(content: str) -> dict:
+    """Parse the model reply into a dict, tolerating prose around the JSON."""
+    try:
+        return json.loads(content)
+    except ValueError:
+        match = re.search(r"\{.*\}", content, re.DOTALL)
+        if not match:
+            raise ValueError(f"no JSON object in model reply: {content[:120]!r}") from None
+        return json.loads(match.group(0))
+
+
+def _clamp_scores(raw: dict, encoding_damage: int) -> dict[str, int]:
+    """Clamp LLM axis scores to 0-3 ints; missing/garbage values become 0."""
+    scores: dict[str, int] = {}
+    for axis in _LLM_AXES:
+        try:
+            scores[axis] = max(0, min(3, int(raw.get(axis, 0))))
+        except (TypeError, ValueError):
+            scores[axis] = 0
+    scores["encoding_damage"] = max(0, min(3, int(encoding_damage)))
+    return scores
+
+
+def _derive_verdict(scores: dict[str, int]) -> str:
+    """Deterministic verdict from the clamped scores (worst axis wins)."""
+    worst = max(scores.values(), default=0)
+    total = sum(scores.values())
+    if worst >= 3 or total >= 6:
+        return "red"
+    if worst >= 2 or total >= 3:
+        return "yellow"
+    return "green"
+
+
+def _clean_reasons(raw) -> list[str]:
+    """Sanitise the model's reasons list: strings only, capped count/length."""
+    if not isinstance(raw, list):
+        return []
+    reasons = []
+    for item in raw:
+        if isinstance(item, str) and item.strip():
+            reasons.append(item.strip()[:_MAX_REASON_CHARS])
+        if len(reasons) >= _MAX_REASONS:
+            break
+    return reasons
+
+
+def analyze_file(subtitle_path: str, language: str) -> dict | None:
+    """Analyze one sidecar and return the verdict dict, or None on any failure.
+
+    Does not persist anything — see analyze_and_store(). Never raises.
+    """
+    from config import get_settings
+
+    settings = get_settings()
+    try:
+        cues = sample_cues(subtitle_path, getattr(settings, "ai_quality_max_cues", 30))
+        if len(cues) < 5:
+            logger.debug("[ai-quality] %s: too few cues (%d), skipping", subtitle_path, len(cues))
+            return None
+        encoding_damage = _measure_encoding_damage(cues)
+        raw, model = _call_ollama(cues, language, settings)
+        scores = _clamp_scores(raw, encoding_damage)
+        return {
+            "verdict": _derive_verdict(scores),
+            "scores": scores,
+            "reasons": _clean_reasons(raw.get("reasons")),
+            "model": model,
+            "sampled_cues": len(cues),
+        }
+    except Exception as e:
+        logger.debug("[ai-quality] analysis failed for %s: %s", subtitle_path, e)
+        return None
+
+
+def analyze_and_store(subtitle_path: str, language: str) -> dict | None:
+    """Analyze a sidecar and persist the verdict. Never raises."""
+    result = analyze_file(subtitle_path, language)
+    if result is None:
+        return None
+    try:
+        from db.quality import save_ai_quality_result
+
+        saved = save_ai_quality_result(
+            file_path=subtitle_path,
+            language=language,
+            verdict=result["verdict"],
+            scores_json=json.dumps(result["scores"]),
+            reasons_json=json.dumps(result["reasons"], ensure_ascii=False),
+            model=result["model"],
+            sampled_cues=result["sampled_cues"],
+        )
+        logger.info(
+            "[ai-quality] %s → %s (cues=%d, model=%s)",
+            subtitle_path,
+            result["verdict"],
+            result["sampled_cues"],
+            result["model"],
+        )
+        return saved
+    except Exception:
+        logger.debug("[ai-quality] could not persist verdict for %s", subtitle_path, exc_info=True)
+        return None
+
+
+def maybe_queue_analysis(video_path: str, language: str, fmt: str) -> None:
+    """Fire-and-forget analysis of a freshly-downloaded sidecar.
+
+    No-op unless ai_quality_enabled. Called from the download-recording path,
+    so it must never raise and never block.
+    """
+    try:
+        from config import get_settings
+
+        if not getattr(get_settings(), "ai_quality_enabled", False):
+            return
+        if not (video_path and language and fmt):
+            return
+        sidecar = sidecar_path_for(video_path, language, fmt)
+        if not os.path.isfile(sidecar):
+            # Some sources save the bare "<base>.<fmt>" sidecar.
+            base, _ = os.path.splitext(video_path)
+            alt = f"{base}.{fmt}"
+            if not os.path.isfile(alt):
+                return
+            sidecar = alt
+
+        from flask import current_app
+
+        app = current_app._get_current_object()
+
+        def _run():
+            with app.app_context():
+                analyze_and_store(sidecar, language)
+
+        from services.background_tasks import submit_background
+
+        submit_background(_run)
+    except Exception:
+        logger.debug("[ai-quality] could not queue analysis", exc_info=True)
+
+
+def attach_ai_quality(entries: list[dict]) -> None:
+    """Attach ``ai_quality`` to history row dicts in place (batch lookup).
+
+    Each entry needs file_path/language/format keys. Rows without a stored
+    verdict get ai_quality = None.
+    """
+    paths: dict[int, str] = {}
+    for i, entry in enumerate(entries):
+        video = entry.get("file_path") or ""
+        lang = entry.get("language") or ""
+        fmt = entry.get("format") or ""
+        if video and lang and fmt:
+            paths[i] = sidecar_path_for(video, lang, fmt)
+
+    results: dict[str, dict] = {}
+    if paths:
+        try:
+            from db.quality import get_ai_quality_results_for_paths
+
+            results = get_ai_quality_results_for_paths(list(set(paths.values())))
+        except Exception:
+            logger.debug("[ai-quality] batch lookup failed", exc_info=True)
+
+    for i, entry in enumerate(entries):
+        row = results.get(paths.get(i, ""))
+        if not row:
+            entry["ai_quality"] = None
+            continue
+        try:
+            scores = json.loads(row.get("scores_json") or "{}")
+            reasons = json.loads(row.get("reasons_json") or "[]")
+        except ValueError:
+            scores, reasons = {}, []
+        entry["ai_quality"] = {
+            "verdict": row.get("verdict"),
+            "scores": scores,
+            "reasons": reasons,
+            "model": row.get("model") or "",
+            "sampled_cues": row.get("sampled_cues") or 0,
+            "created_at": row.get("created_at"),
+        }

--- a/backend/tests/test_ai_quality.py
+++ b/backend/tests/test_ai_quality.py
@@ -1,0 +1,281 @@
+"""Tests for the advisory AI subtitle-quality verdict (services.ai_quality)."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+import services.ai_quality as aq
+
+# ---- Cue sampling ---------------------------------------------------------------
+
+
+def _write_srt(path: Path, lines: list[str]) -> str:
+    blocks = []
+    for i, text in enumerate(lines, start=1):
+        start = f"00:00:{i:02d},000"
+        end = f"00:00:{i:02d},900"
+        blocks.append(f"{i}\n{start} --> {end}\n{text}\n")
+    path.write_text("\n".join(blocks), encoding="utf-8")
+    return str(path)
+
+
+def test_sample_cues_dedupes_and_skips_short(tmp_path):
+    path = _write_srt(
+        tmp_path / "a.de.srt",
+        ["Hallo Welt!", "Hallo Welt!", "OK", "Wie geht es dir heute?"],
+    )
+    cues = aq.sample_cues(path, 30)
+    # duplicate removed, "OK" (<3 chars) removed
+    assert cues == ["Hallo Welt!", "Wie geht es dir heute?"]
+
+
+def test_sample_cues_caps_and_spreads(tmp_path):
+    path = _write_srt(tmp_path / "a.de.srt", [f"Zeile Nummer {i} im Test" for i in range(50)])
+    cues = aq.sample_cues(path, 10)
+    assert len(cues) == 10
+    # even spread: first sample is from the start, samples strictly ordered
+    assert cues[0] == "Zeile Nummer 0 im Test"
+    indexes = [int(c.split()[2]) for c in cues]
+    assert indexes == sorted(indexes)
+
+
+def test_sample_cues_truncates_long_lines(tmp_path):
+    path = _write_srt(tmp_path / "a.de.srt", ["x" * 500, "kurze Zeile hier"])
+    cues = aq.sample_cues(path, 30)
+    assert max(len(c) for c in cues) <= aq._MAX_CUE_CHARS
+
+
+# ---- Deterministic scoring pieces -----------------------------------------------
+
+
+def test_encoding_damage_thresholds():
+    clean = ["Alles gut hier"] * 10
+    assert aq._measure_encoding_damage(clean) == 0
+    one_bad = clean[:9] + ["kaputt � hier"]
+    assert aq._measure_encoding_damage(one_bad) == 1
+    two_bad = clean[:8] + ["kaputt � hier", "Ã¤rgerlich"]
+    assert aq._measure_encoding_damage(two_bad) == 2
+    mostly_bad = ["â€œZitatâ€\x9d"] * 4 + clean[:6]
+    assert aq._measure_encoding_damage(mostly_bad) == 3
+    assert aq._measure_encoding_damage([]) == 0
+
+
+def test_clamp_scores_tolerates_garbage():
+    scores = aq._clamp_scores(
+        {"machine_translation": "7", "ocr_artifacts": None, "grammar": -2}, encoding_damage=1
+    )
+    assert scores == {
+        "machine_translation": 3,
+        "ocr_artifacts": 0,
+        "grammar": 0,
+        "encoding_damage": 1,
+    }
+
+
+@pytest.mark.parametrize(
+    "scores,expected",
+    [
+        ({"machine_translation": 0, "ocr_artifacts": 0, "grammar": 0, "encoding_damage": 0}, "green"),
+        ({"machine_translation": 1, "ocr_artifacts": 1, "grammar": 0, "encoding_damage": 0}, "green"),
+        ({"machine_translation": 2, "ocr_artifacts": 0, "grammar": 0, "encoding_damage": 0}, "yellow"),
+        ({"machine_translation": 1, "ocr_artifacts": 1, "grammar": 1, "encoding_damage": 0}, "yellow"),
+        ({"machine_translation": 3, "ocr_artifacts": 0, "grammar": 0, "encoding_damage": 0}, "red"),
+        ({"machine_translation": 2, "ocr_artifacts": 2, "grammar": 2, "encoding_damage": 0}, "red"),
+    ],
+)
+def test_derive_verdict(scores, expected):
+    assert aq._derive_verdict(scores) == expected
+
+
+def test_clean_reasons_caps_and_filters():
+    raw = ["  gut  ", 42, None, "x" * 500, "a", "b", "c", "d"]
+    reasons = aq._clean_reasons(raw)
+    assert len(reasons) == aq._MAX_REASONS
+    assert reasons[0] == "gut"
+    assert all(len(r) <= aq._MAX_REASON_CHARS for r in reasons)
+    assert aq._clean_reasons("not a list") == []
+
+
+def test_parse_verdict_json_tolerates_prose():
+    parsed = aq._parse_verdict_json('Sure! {"grammar": 2, "reasons": ["x"]} hope that helps')
+    assert parsed["grammar"] == 2
+    with pytest.raises(ValueError):
+        aq._parse_verdict_json("no json here")
+
+
+# ---- analyze_file with mocked LLM ------------------------------------------------
+
+
+def test_analyze_file_success(tmp_path, monkeypatch):
+    path = _write_srt(tmp_path / "a.de.srt", [f"Ein ganz normaler Satz {i}" for i in range(10)])
+    monkeypatch.setattr(
+        aq,
+        "_call_ollama",
+        lambda cues, language, settings: (
+            {"machine_translation": 2, "ocr_artifacts": 0, "grammar": 1, "reasons": ["klingt wörtlich"]},
+            "test-model",
+        ),
+    )
+    result = aq.analyze_file(path, "de")
+    assert result is not None
+    assert result["verdict"] == "yellow"
+    assert result["scores"]["machine_translation"] == 2
+    assert result["reasons"] == ["klingt wörtlich"]
+    assert result["model"] == "test-model"
+    assert result["sampled_cues"] == 10
+
+
+def test_analyze_file_too_few_cues_returns_none(tmp_path, monkeypatch):
+    path = _write_srt(tmp_path / "a.de.srt", ["Nur ein Satz hier"])
+    called = []
+    monkeypatch.setattr(aq, "_call_ollama", lambda *a: called.append(1))
+    assert aq.analyze_file(path, "de") is None
+    assert not called
+
+
+def test_analyze_file_llm_error_returns_none(tmp_path, monkeypatch):
+    path = _write_srt(tmp_path / "a.de.srt", [f"Ein ganz normaler Satz {i}" for i in range(10)])
+
+    def _boom(cues, language, settings):
+        raise RuntimeError("ollama down")
+
+    monkeypatch.setattr(aq, "_call_ollama", _boom)
+    assert aq.analyze_file(path, "de") is None
+
+
+def test_analyze_file_missing_file_returns_none():
+    assert aq.analyze_file("/nonexistent/x.de.srt", "de") is None
+
+
+# ---- Persistence roundtrip -------------------------------------------------------
+
+
+def test_save_get_batch_delete_roundtrip(app_ctx):
+    from db.quality import (
+        delete_ai_quality_result,
+        get_ai_quality_result,
+        get_ai_quality_results_for_paths,
+        save_ai_quality_result,
+    )
+
+    saved = save_ai_quality_result(
+        "/media/a/ep1.de.ass", "de", "yellow", '{"grammar": 2}', '["x"]', "m", 30
+    )
+    assert saved["verdict"] == "yellow"
+
+    # replace-on-save: second save for the same path leaves exactly one row
+    save_ai_quality_result("/media/a/ep1.de.ass", "de", "green", "{}", "[]", "m", 30)
+    row = get_ai_quality_result("/media/a/ep1.de.ass")
+    assert row["verdict"] == "green"
+
+    save_ai_quality_result("/media/a/ep2.de.ass", "de", "red", "{}", "[]", "m", 12)
+    batch = get_ai_quality_results_for_paths(
+        ["/media/a/ep1.de.ass", "/media/a/ep2.de.ass", "/media/a/missing.de.ass"]
+    )
+    assert set(batch.keys()) == {"/media/a/ep1.de.ass", "/media/a/ep2.de.ass"}
+
+    assert delete_ai_quality_result("/media/a/ep1.de.ass") == 1
+    assert get_ai_quality_result("/media/a/ep1.de.ass") is None
+    assert get_ai_quality_results_for_paths([]) == {}
+
+
+def test_attach_ai_quality(app_ctx):
+    from db.quality import save_ai_quality_result
+
+    save_ai_quality_result(
+        "/media/a/ep1.de.ass",
+        "de",
+        "red",
+        json.dumps({"machine_translation": 3}),
+        json.dumps(["MTL"]),
+        "m",
+        30,
+    )
+    entries = [
+        {"file_path": "/media/a/ep1.mkv", "language": "de", "format": "ass"},
+        {"file_path": "/media/a/ep2.mkv", "language": "de", "format": "srt"},
+        {"file_path": "", "language": "", "format": ""},
+    ]
+    aq.attach_ai_quality(entries)
+    assert entries[0]["ai_quality"]["verdict"] == "red"
+    assert entries[0]["ai_quality"]["scores"] == {"machine_translation": 3}
+    assert entries[0]["ai_quality"]["reasons"] == ["MTL"]
+    assert entries[1]["ai_quality"] is None
+    assert entries[2]["ai_quality"] is None
+
+
+# ---- maybe_queue_analysis guardrails ---------------------------------------------
+
+
+def test_maybe_queue_analysis_disabled_is_noop(app_ctx, monkeypatch):
+    submitted = []
+    monkeypatch.setattr("services.background_tasks.submit_background", submitted.append)
+    aq.maybe_queue_analysis("/media/a/ep1.mkv", "de", "ass")
+    assert not submitted
+
+
+def test_maybe_queue_analysis_never_raises_without_context():
+    # No app context, no settings guarantees — must still be silent.
+    aq.maybe_queue_analysis("", "", "")
+
+
+# ---- Routes ---------------------------------------------------------------------
+
+
+def test_route_get_requires_path(client):
+    resp = client.get("/api/v1/quality/ai")
+    assert resp.status_code == 400
+
+
+def test_route_get_rejects_outside_media(client):
+    resp = client.get("/api/v1/quality/ai?path=/etc/passwd")
+    assert resp.status_code == 403
+
+
+def test_route_get_returns_null_then_result(client, tmp_path):
+    target = str(tmp_path / "ep1.de.ass")
+    resp = client.get(f"/api/v1/quality/ai?path={target}")
+    assert resp.status_code == 200
+    assert resp.get_json()["result"] is None
+
+    from db.quality import save_ai_quality_result
+
+    save_ai_quality_result(target, "de", "yellow", '{"grammar": 2}', '["x"]', "m", 30)
+    resp = client.get(f"/api/v1/quality/ai?path={target}")
+    body = resp.get_json()["result"]
+    assert body["verdict"] == "yellow"
+    assert body["scores"] == {"grammar": 2}
+
+
+def test_route_analyze_disabled_returns_503(client, tmp_path):
+    resp = client.post(
+        "/api/v1/quality/ai/analyze", json={"path": str(tmp_path / "a.de.srt"), "language": "de"}
+    )
+    assert resp.status_code == 503
+
+
+def test_route_analyze_enabled_flow(client, tmp_path, monkeypatch):
+    from config import get_settings
+
+    settings = get_settings()
+    monkeypatch.setattr(settings, "ai_quality_enabled", True, raising=False)
+
+    resp = client.post("/api/v1/quality/ai/analyze", json={})
+    assert resp.status_code == 400
+
+    resp = client.post("/api/v1/quality/ai/analyze", json={"path": "/etc/passwd"})
+    assert resp.status_code == 403
+
+    missing = str(tmp_path / "missing.de.srt")
+    resp = client.post("/api/v1/quality/ai/analyze", json={"path": missing, "language": "de"})
+    assert resp.status_code == 404
+
+    real = _write_srt(tmp_path / "real.de.srt", [f"Ein Satz {i} zum Testen" for i in range(6)])
+    ran = []
+    monkeypatch.setattr(
+        "services.background_tasks.submit_background", lambda fn, *a, **kw: ran.append(fn)
+    )
+    resp = client.post("/api/v1/quality/ai/analyze", json={"path": real, "language": "de"})
+    assert resp.status_code == 202
+    assert len(ran) == 1

--- a/docs/API.md
+++ b/docs/API.md
@@ -140,6 +140,17 @@ Webhook auth: Exempt from API key check. Each handler validates HMAC signature f
 
 ---
 
+## Quality (AI, advisory)
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| GET | `/quality/ai` | Yes | Stored AI quality verdict for a subtitle sidecar. Param: `path` (absolute sidecar path). `result` is `null` when not analyzed |
+| POST | `/quality/ai/analyze` | Yes | Queue background AI quality analysis of a sidecar. Body: `path`, optional `language`. Requires `ai_quality_enabled`; 202 on queue |
+
+History rows (`GET /history`) carry the verdict inline as `ai_quality` (`verdict`, `scores`, `reasons`, `model`, `sampled_cues`, `created_at`) or `null`.
+
+---
+
 ## System / Health
 
 | Method | Path | Auth | Description |

--- a/frontend/src/components/shared/AIQualityBadge.tsx
+++ b/frontend/src/components/shared/AIQualityBadge.tsx
@@ -1,0 +1,31 @@
+import { useTranslation } from 'react-i18next'
+import { Sparkles } from 'lucide-react'
+import { Tooltip } from './Tooltip'
+import type { AIQualityInfo } from '@/types/system'
+
+const VERDICT_COLORS: Record<string, string> = {
+  green: 'var(--success)',
+  yellow: 'var(--warning)',
+  red: 'var(--error)',
+}
+
+/**
+ * AIQualityBadge — advisory LLM verdict for a downloaded subtitle.
+ * Renders nothing when no verdict is stored (feature off / not yet analyzed).
+ */
+export function AIQualityBadge({ quality }: { quality?: AIQualityInfo | null }) {
+  const { t } = useTranslation('activity')
+  if (!quality || !VERDICT_COLORS[quality.verdict]) return null
+
+  const label = t(`history.ai_quality.${quality.verdict}`)
+  const reasons = (quality.reasons ?? []).filter(Boolean).join(' · ')
+  const content = reasons ? `${label} — ${reasons}` : label
+
+  return (
+    <Tooltip content={content} maxWidth={320}>
+      <span className="inline-flex items-center" aria-label={label}>
+        <Sparkles size={12} style={{ color: VERDICT_COLORS[quality.verdict] }} />
+      </span>
+    </Tooltip>
+  )
+}

--- a/frontend/src/i18n/locales/de/activity.json
+++ b/frontend/src/i18n/locales/de/activity.json
@@ -113,7 +113,12 @@
     "blacklist_confirm_action": "Sperren",
     "blacklist_also_delete": "Datei ebenfalls löschen",
     "blacklisted_success": "Zur Sperrliste hinzugefügt",
-    "deleted_and_blacklisted": "Untertitel gelöscht und gesperrt"
+    "deleted_and_blacklisted": "Untertitel gelöscht und gesperrt",
+    "ai_quality": {
+      "green": "KI-Qualitätsprüfung: keine Auffälligkeiten",
+      "yellow": "KI-Qualitätsprüfung: kleinere Auffälligkeiten",
+      "red": "KI-Qualitätsprüfung: deutliche Mängel"
+    }
   },
   "blacklist": {
     "title": "Sperrliste",

--- a/frontend/src/i18n/locales/de/settings.json
+++ b/frontend/src/i18n/locales/de/settings.json
@@ -1307,6 +1307,17 @@
     "auto_cues_label": "Cue-Mindestzahl (Auto)",
     "auto_cues_desc": "Nur unbeaufsichtigt. Ein Track braucht beim geplanten Sweep mindestens so viele Cues, damit ein dünner Track keinen Zufallstreffer landet."
   },
+  "ai_quality_page": {
+    "title": "KI-Qualitätsprüfung",
+    "description": "Experimentell: Nach jedem Download prüft ein lokales LLM eine Stichprobe von Zeilen auf Maschinenübersetzung, OCR-Artefakte und Grammatik. Das Ergebnis erscheint als Badge im Verlauf — rein informativ, verändert nie Dateien oder Scores.",
+    "enabled_label": "KI-Qualitäts-Badge",
+    "enabled_desc": "Neue Downloads im Hintergrund über die konfigurierte Ollama-Instanz analysieren. Benötigt einen erreichbaren Ollama-Server (Einstellungen → Übersetzung).",
+    "model_label": "Modell-Override",
+    "model_desc": "Ollama-Modell für die Prüfung. Leer lassen, um das Übersetzungsmodell zu verwenden.",
+    "model_placeholder": "leer = Übersetzungsmodell",
+    "max_cues_label": "Zeilen-Stichprobe",
+    "max_cues_desc": "Wie viele Zeilen pro Datei geprüft werden (10–60). Mehr Zeilen = besseres Urteil, langsamere Prüfung."
+  },
   "subtitles_scoring_page": {
     "scoring_section": "Scoring",
     "per_language_section": "Sprach-spezifische Scores",

--- a/frontend/src/i18n/locales/en/activity.json
+++ b/frontend/src/i18n/locales/en/activity.json
@@ -113,7 +113,12 @@
     "blacklist_confirm_action": "Blacklist",
     "blacklist_also_delete": "Also delete the file",
     "blacklisted_success": "Added to blacklist",
-    "deleted_and_blacklisted": "Subtitle deleted and blacklisted"
+    "deleted_and_blacklisted": "Subtitle deleted and blacklisted",
+    "ai_quality": {
+      "green": "AI quality check: no issues found",
+      "yellow": "AI quality check: minor issues found",
+      "red": "AI quality check: serious issues found"
+    }
   },
   "blacklist": {
     "title": "Blacklist",

--- a/frontend/src/i18n/locales/en/settings.json
+++ b/frontend/src/i18n/locales/en/settings.json
@@ -1307,6 +1307,17 @@
     "auto_cues_label": "Auto cue floor",
     "auto_cues_desc": "Unattended only. A track needs at least this many cues during the scheduled sweep, so a sparse track cannot fluke a match."
   },
+  "ai_quality_page": {
+    "title": "AI Quality Check",
+    "description": "Experimental: after each download, a local LLM samples a few lines and rates machine-translation likelihood, OCR artifacts and grammar. Shown as a badge in History — advisory only, never changes files or scores.",
+    "enabled_label": "AI quality badge",
+    "enabled_desc": "Analyze new downloads in the background using the configured Ollama instance. Requires a reachable Ollama server (Settings → Translation).",
+    "model_label": "Model override",
+    "model_desc": "Ollama model used for the check. Leave empty to reuse the translation model.",
+    "model_placeholder": "empty = translation model",
+    "max_cues_label": "Sampled lines",
+    "max_cues_desc": "How many lines are sampled per file (10–60). More lines = better judgement, slower check."
+  },
   "subtitles_scoring_page": {
     "scoring_section": "Scoring",
     "per_language_section": "Per-Language Scores",

--- a/frontend/src/pages/History.tsx
+++ b/frontend/src/pages/History.tsx
@@ -10,6 +10,8 @@ import {
   CheckSquare, Square, MinusSquare, X,
 } from 'lucide-react'
 import SubtitleEditorModal from '@/components/editor/SubtitleEditorModal'
+import { AIQualityBadge } from '@/components/shared/AIQualityBadge'
+import type { AIQualityInfo } from '@/types/system'
 import { FilterBar } from '@/components/filters/FilterBar'
 import type { FilterDef, ActiveFilter } from '@/components/filters/FilterBar'
 import { BatchActionBar } from '@/components/batch/BatchActionBar'
@@ -29,6 +31,7 @@ type HistoryEntry = {
   score: number
   downloaded_at: string | null
   subtitle_id?: string
+  ai_quality?: AIQualityInfo | null
 }
 
 const HistoryTableRow = memo(function HistoryTableRow({
@@ -105,15 +108,18 @@ const HistoryTableRow = memo(function HistoryTableRow({
         </span>
       </td>
       <td className="px-3 py-2.5">
-        <span
-          className="text-[10px] px-1.5 py-0.5 rounded uppercase font-bold"
-          style={{
-            backgroundColor: entry.format === 'ass' ? 'var(--success)18' : 'var(--bg-primary)',
-            color: entry.format === 'ass' ? 'var(--success)' : 'var(--text-secondary)',
-            fontFamily: 'var(--font-mono)',
-          }}
-        >
-          {entry.format || '?'}
+        <span className="inline-flex items-center gap-1.5">
+          <span
+            className="text-[10px] px-1.5 py-0.5 rounded uppercase font-bold"
+            style={{
+              backgroundColor: entry.format === 'ass' ? 'var(--success)18' : 'var(--bg-primary)',
+              color: entry.format === 'ass' ? 'var(--success)' : 'var(--text-secondary)',
+              fontFamily: 'var(--font-mono)',
+            }}
+          >
+            {entry.format || '?'}
+          </span>
+          <AIQualityBadge quality={entry.ai_quality} />
         </span>
       </td>
       <td className="px-3 py-2.5 hidden sm:table-cell">

--- a/frontend/src/pages/Settings/AIQualitySettings.tsx
+++ b/frontend/src/pages/Settings/AIQualitySettings.tsx
@@ -1,0 +1,103 @@
+import { useTranslation } from 'react-i18next'
+import { Sparkles } from 'lucide-react'
+import { SettingRow } from '@/components/shared/SettingRow'
+import { Toggle } from '@/components/shared/Toggle'
+import { SettingsSection } from '@/components/settings/SettingsSection'
+import { useConfig, useUpdateConfig } from '@/hooks/useApi'
+
+const inputStyle = {
+  backgroundColor: 'var(--bg-primary)',
+  border: '1px solid var(--border)',
+  color: 'var(--text-primary)',
+  borderRadius: '0.375rem',
+  padding: '0.375rem 0.75rem',
+  fontSize: '0.8125rem',
+  outline: 'none',
+  width: '220px',
+}
+
+/**
+ * AIQualitySettings — advisory AI subtitle-quality badge (experimental).
+ * Maps to ai_quality_enabled, ai_quality_model, ai_quality_max_cues.
+ * The verdict is display-only: it never modifies files and never feeds
+ * into scoring or upgrades (ROADMAP "AI direction" guardrails).
+ */
+export function AIQualitySettings() {
+  const { t } = useTranslation('settings')
+  const { data: config } = useConfig()
+  const updateConfig = useUpdateConfig()
+  const cfg = config as Record<string, unknown> | undefined
+
+  const enabled = String(cfg?.ai_quality_enabled ?? 'false') === 'true'
+  const model = String(cfg?.ai_quality_model ?? '')
+  const maxCues = Number(cfg?.ai_quality_max_cues ?? 30)
+
+  return (
+    <SettingsSection
+      title={t('ai_quality_page.title', 'AI Quality Check')}
+      description={t(
+        'ai_quality_page.description',
+        'Experimental: after each download, a local LLM samples a few lines and rates machine-translation likelihood, OCR artifacts and grammar. Shown as a badge in History — advisory only, never changes files or scores.',
+      )}
+      icon={<Sparkles size={16} style={{ color: 'var(--accent)' }} />}
+    >
+      <SettingRow
+        label={t('ai_quality_page.enabled_label', 'AI quality badge')}
+        description={t(
+          'ai_quality_page.enabled_desc',
+          'Analyze new downloads in the background using the configured Ollama instance. Requires a reachable Ollama server (Settings → Translation).',
+        )}
+      >
+        <div data-testid="toggle-ai-quality">
+          <Toggle
+            checked={enabled}
+            onChange={(v) => updateConfig.mutate({ ai_quality_enabled: String(v) })}
+          />
+        </div>
+      </SettingRow>
+
+      <SettingRow
+        label={t('ai_quality_page.model_label', 'Model override')}
+        description={t(
+          'ai_quality_page.model_desc',
+          'Ollama model used for the check. Leave empty to reuse the translation model.',
+        )}
+      >
+        <input
+          type="text"
+          defaultValue={model}
+          placeholder={t('ai_quality_page.model_placeholder', 'empty = translation model')}
+          style={inputStyle}
+          onBlur={(e) => {
+            const v = e.target.value.trim()
+            if (v !== model) updateConfig.mutate({ ai_quality_model: v })
+          }}
+        />
+      </SettingRow>
+
+      <SettingRow
+        label={t('ai_quality_page.max_cues_label', 'Sampled lines')}
+        description={t(
+          'ai_quality_page.max_cues_desc',
+          'How many lines are sampled per file (10–60). More lines = better judgement, slower check.',
+        )}
+      >
+        <input
+          type="number"
+          min={10}
+          max={60}
+          defaultValue={maxCues}
+          style={{ ...inputStyle, width: '90px' }}
+          onBlur={(e) => {
+            const n = Math.round(Number(e.target.value))
+            if (!Number.isFinite(n)) return
+            const v = Math.min(60, Math.max(10, n))
+            if (v !== maxCues) updateConfig.mutate({ ai_quality_max_cues: v })
+          }}
+        />
+      </SettingRow>
+    </SettingsSection>
+  )
+}
+
+export default AIQualitySettings

--- a/frontend/src/pages/Settings/SubtitleHealthSettings.test.tsx
+++ b/frontend/src/pages/Settings/SubtitleHealthSettings.test.tsx
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { AdvancedSettingsProvider } from '@/contexts/AdvancedSettingsContext'
 import { SubtitleHealthSettings } from './SubtitleHealthSettings'
 import * as api from '@/api/subtitleHealth'
 
@@ -8,6 +10,15 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (k: string, o?: any) => (o ? `${k} ${JSON.stringify(o)}` : k) }),
 }))
 
+function renderWithQuery(ui: React.ReactElement) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={client}>
+      <AdvancedSettingsProvider>{ui}</AdvancedSettingsProvider>
+    </QueryClientProvider>,
+  )
+}
+
 describe('SubtitleHealthSettings', () => {
   it('renders the library report', async () => {
     vi.mocked(api.getHealthReport).mockResolvedValue({
@@ -15,9 +26,19 @@ describe('SubtitleHealthSettings', () => {
       by_type: { ass_escape_leak: 46, language_mislabel: 1 },
       affected_episodes: 23,
     })
-    render(<SubtitleHealthSettings />)
+    renderWithQuery(<SubtitleHealthSettings />)
     await waitFor(() =>
       expect(screen.getByText(/subtitle_health.report_total/)).toBeInTheDocument(),
     )
+  })
+
+  it('renders the AI quality section', async () => {
+    vi.mocked(api.getHealthReport).mockResolvedValue({
+      total_findings: 0,
+      by_type: {},
+      affected_episodes: 0,
+    })
+    renderWithQuery(<SubtitleHealthSettings />)
+    await waitFor(() => expect(screen.getByTestId('toggle-ai-quality')).toBeInTheDocument())
   })
 })

--- a/frontend/src/pages/Settings/SubtitleHealthSettings.tsx
+++ b/frontend/src/pages/Settings/SubtitleHealthSettings.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { getHealthReport } from '@/api/subtitleHealth'
 import type { HealthReport } from '@/lib/types'
+import { AIQualitySettings } from './AIQualitySettings'
 
 export function SubtitleHealthSettings() {
   const { t } = useTranslation('library')
@@ -42,6 +43,7 @@ export function SubtitleHealthSettings() {
           ))}
         </ul>
       )}
+      <AIQualitySettings />
     </div>
   )
 }

--- a/frontend/src/types/system.ts
+++ b/frontend/src/types/system.ts
@@ -27,6 +27,16 @@ export interface PaginatedBlacklist {
 
 // â”€â”€â”€ History â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
+/** Advisory LLM quality verdict for a downloaded subtitle (experimental). */
+export interface AIQualityInfo {
+  verdict: 'green' | 'yellow' | 'red' | string
+  scores?: Record<string, number>
+  reasons?: string[]
+  model?: string
+  sampled_cues?: number
+  created_at?: string | null
+}
+
 export interface HistoryEntry {
   id: number
   provider_name: string
@@ -36,6 +46,7 @@ export interface HistoryEntry {
   file_path: string
   score: number
   downloaded_at: string
+  ai_quality?: AIQualityInfo | null
 }
 
 export interface PaginatedHistory {


### PR DESCRIPTION
Replace the outdated v1.0.0 roadmap with the post-feature-phase direction:

- Guiding principles: reliability first, deterministic core, quality over
  quantity, AI assists but never acts
- Now: data-integrity fixes (#171, #156 repair tool, Alembic head cleanup),
  the transparency stack (#172/#173/#170), profiles & scoring rules
  (#164/#166/#168/#169) with an explicit freeze afterwards, in-app health
  dashboard (#170)
- Next: generated event reference from the event catalog, custom HTTP
  provider (#165), prove-the-plugin-registry-before-growing-it, contributor
  docs; explicit non-goals (SSE, hand-maintained SDKs)
- AI direction: explanation/suggestion layer over the deterministic
  pipeline with hard guardrails (read-only, local-first, advisory,
  no chatbot) and a prioritised candidate list

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KpTzsuFNZtYhBZ3cf55EfH